### PR TITLE
fix: initial icon IA updates/styling

### DIFF
--- a/src/examples/design/icons/SvgSearch.tsx
+++ b/src/examples/design/icons/SvgSearch.tsx
@@ -12,11 +12,18 @@ import { Field, MediaInput, Label } from '@zendeskgarden/react-forms';
 import { ReactComponent as SearchStroke } from '@zendeskgarden/svg-icons/src/16/search-stroke.svg';
 import { Code, XL } from '@zendeskgarden/react-typography';
 import styled, { css } from 'styled-components';
-import { getColor } from '@zendeskgarden/react-theming';
+
+const StyledIconWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  margin: 0 0 ${p => p.theme.space.lg};
+`;
 
 const StyledSvgWrapper = styled.div<{ isAnswerBot?: boolean }>`
   display: flex;
   align-items: center;
+  margin: 0 0 ${p => p.theme.space.sm};
   fill: ${p => p.isAnswerBot && '#616788'};
   color: ${p => p.isAnswerBot && '#d0eeec'};
 `;
@@ -55,38 +62,16 @@ export const SvgSearch: React.FC<{
         return edge.node.name.trim().toLowerCase().includes(formattedSearchValue);
       })
       .map(edge => (
-        <Col key={edge.node.name} lg={4} md={4} xs={6}>
-          <div
-            css={css`
-              display: flex;
-              margin-bottom: ${p => p.theme.space.xs};
-            `}
-          >
+        <Col key={edge.node.name} lg={3} md={4} xs={6}>
+          <StyledIconWrapper>
             <StyledSvgWrapper
               isAnswerBot={edge.node.name === 'answer-bot'}
               dangerouslySetInnerHTML={{ __html: edge.node.childGardenSvg.content }}
             />
-            <div
-              css={css`
-                display: flex;
-                align-items: center;
-                margin-left: ${p => p.theme.space.xxs};
-                overflow: hidden;
-              `}
-            >
-              <Code
-                size="small"
-                css={css`
-                  overflow: hidden;
-                  text-overflow: ellipsis;
-                  white-space: nowrap;
-                `}
-                title={edge.node.name}
-              >
-                {edge.node.name}
-              </Code>
-            </div>
-          </div>
+            <Code size="small" title={edge.node.name}>
+              {edge.node.name}
+            </Code>
+          </StyledIconWrapper>
         </Col>
       ));
   }, [data, debouncedInputValue]);
@@ -99,7 +84,7 @@ export const SvgSearch: React.FC<{
             margin-bottom: ${p => p.theme.space.lg};
           `}
         >
-          <Label>Filter Icons</Label>
+          <Label>Filter icons</Label>
           <MediaInput
             start={<SearchStroke />}
             value={inputValue}
@@ -116,13 +101,7 @@ export const SvgSearch: React.FC<{
                 text-align: center;
               `}
             >
-              <XL
-                css={css`
-                  color: ${p => getColor('grey', 400, p.theme)};
-                `}
-              >
-                No icons found
-              </XL>
+              <XL>No icons found</XL>
             </Col>
           )}
         </Row>

--- a/src/layouts/Titled/components/TOC.tsx
+++ b/src/layouts/Titled/components/TOC.tsx
@@ -23,7 +23,7 @@ export const TOCBlock: React.FC<{ data: IHeading[] } & HTMLAttributes<HTMLDivEle
   ...props
 }) => (
   <div {...props}>
-    <StyledSectionHeader>Content</StyledSectionHeader>
+    <StyledSectionHeader>Table of Contents</StyledSectionHeader>
     <ul
       css={css`
         margin-bottom: ${p => p.theme.space.lg};
@@ -130,7 +130,7 @@ export const TOC: React.FC<{ data: IHeading[] }> = ({ data }) => {
           margin-left: ${p => p.theme.space.md};
         `}
       >
-        Content
+        Table of Contents
       </StyledSectionHeader>
       <ul
         css={css`

--- a/src/nav/design.yml
+++ b/src/nav/design.yml
@@ -2,12 +2,12 @@
   items:
     - id: /design
       title: Overview
-- title: SVG Icons
+- title: Foundations
   items:
-    - id: /design/icons/installation
-      title: Installation
     - title: Icons
       items:
+        - id: /design/icons/installation
+          title: Installation
         - id: /design/icons/12
           title: 12px
         - id: /design/icons/16

--- a/src/pages/design/icons/12.mdx
+++ b/src/pages/design/icons/12.mdx
@@ -1,7 +1,5 @@
 ---
 title: 12px Icons
-description: >
-  Garden SVG Icons
 ---
 
 import { SvgSearch } from '../../../examples/design/icons/SvgSearch';

--- a/src/pages/design/icons/16.mdx
+++ b/src/pages/design/icons/16.mdx
@@ -1,7 +1,5 @@
 ---
 title: 16px Icons
-description: >
-  Garden SVG Icons
 ---
 
 import { SvgSearch } from '../../../examples/design/icons/SvgSearch';

--- a/src/pages/design/icons/26.mdx
+++ b/src/pages/design/icons/26.mdx
@@ -1,7 +1,5 @@
 ---
 title: 26px Icons
-description: >
-  Garden SVG Icons
 ---
 
 import { SvgSearch } from '../../../examples/design/icons/SvgSearch';

--- a/src/pages/design/icons/installation.mdx
+++ b/src/pages/design/icons/installation.mdx
@@ -1,12 +1,8 @@
 ---
 title: Installation
-description: >
-  Garden SVG Icons
 ---
 
 import { graphql } from 'gatsby';
-
-## Installation
 
 ```bash
 npm install @zendeskgarden/svg-icons

--- a/src/pages/design/icons/wordmarks.mdx
+++ b/src/pages/design/icons/wordmarks.mdx
@@ -1,7 +1,5 @@
 ---
 title: Wordmarks
-description: >
-  Garden SVG Icons
 ---
 
 import { SvgSearch } from '../../../examples/design/icons/SvgSearch';

--- a/src/pages/design/index.mdx
+++ b/src/pages/design/index.mdx
@@ -1,7 +1,5 @@
 ---
 title: Overview
-description: >
-  A standard design overview
 ---
 
 ## Introduction


### PR DESCRIPTION
<!-- structure the Title above as the first line of a
  https://conventionalcommits.org/ message. example: "chore:
  add a new 'thing' component page". -->

## Description

Took a little time yesterday to get to the know the budding site structure a little better. This PR has some IA structure updates and then in lieu of a proper design spec for the icon pages, made a few small column and alignment adjustments for legibility. 

## Detail

<!-- supporting details; screen shot, code, etc. -->

<!-- closes GITHUB_ISSUE -->

## Checklist

- [ ] :ok_hand: website updates are Garden Designer approved (add the designer as a reviewer)
- [ ] :black_nib: copy updates are approved (add the content strategist as a reviewer)
- [ ] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [ ] :zap: audited via [web.dev](https://web.dev/measure/) for performance and SEO
- [ ] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
