### PR TITLE
fix: update gatsby-source-abstract filter logic

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -72,7 +72,7 @@ module.exports = {
       options: {
         apiToken: process.env.ABSTRACT_TOKEN,
         projectId: '27ff5784-e1c4-4f8c-a914-c03c380c8ea9',
-        branch: '8a6f273a-b41e-413c-924f-2f2766ccc7a5'
+        branch: 'master'
       }
     },
     `gatsby-transformer-sharp`,

--- a/plugins/gatsby-source-abstract/gatsby-node.js
+++ b/plugins/gatsby-source-abstract/gatsby-node.js
@@ -76,13 +76,6 @@ exports.sourceNodes = async (
           cache.set(FILE_CACHE_KEY, assets);
         }
 
-        /**
-         * TEMPORARY
-         *
-         * The Abstract SDK does not filter by `sha` https://github.com/goabstract/abstract-sdk/issues/230
-         */
-        assets = assets.filter(asset => asset.sha === file.sha);
-
         return Promise.all(
           assets.map(async asset => {
             const assetNode = abstractAssetNode(asset, {

--- a/src/pages/content/index.mdx
+++ b/src/pages/content/index.mdx
@@ -4,7 +4,7 @@ description: >
   At Zendesk, we have standards
 ---
 
-![Garden overview banner](abstract:home-banner-background.png)
+![Test overview banner](abstract:spacing-1-2x.png)
 
 This is a guide to write the Zendesk way in product. These standards will eventually live on Garden
 but for now, you can find them here. As with all style guides, this is a living document. Leave us


### PR DESCRIPTION
## Description

It looks like our `abstract-sdk` bug was fixed sometime recently. To properly show Abstract Assets I've removed our filtering logic.

## Checklist

- [ ] ~:ok_hand: website updates are Garden Designer approved (add the designer as a reviewer)~
- [ ] ~:black_nib: copy updates are approved (add the content strategist as a reviewer)~
- [ ] ~:wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver~
- [ ] ~:zap: audited via [web.dev](https://web.dev/measure/) for performance and SEO~
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
