### PR TITLE
feat: add initial component doc content

### DIFF
--- a/src/nav/components.yml
+++ b/src/nav/components.yml
@@ -4,6 +4,8 @@
       title: Overview
 - title: Components
   items:
+    - title: Breadcrumbs
+      id: /components/breadcrumbs
     - title: Buttons
       items:
         - id: /components/buttons/anchor

--- a/src/nav/components.yml
+++ b/src/nav/components.yml
@@ -6,5 +6,7 @@
   items:
     - title: Buttons
       items:
+        - id: /components/buttons/anchor
+          title: Anchor
         - id: /components/buttons/button
           title: Button

--- a/src/nav/components.yml
+++ b/src/nav/components.yml
@@ -4,6 +4,8 @@
       title: Overview
 - title: Components
   items:
+    - title: Avatar
+      id: /components/avatar
     - title: Breadcrumbs
       id: /components/breadcrumbs
     - title: Buttons

--- a/src/nav/components.yml
+++ b/src/nav/components.yml
@@ -6,5 +6,5 @@
   items:
     - title: Buttons
       items:
-        - id: /components/button
+        - id: /components/buttons/button
           title: Button

--- a/src/pages/components/avatar.mdx
+++ b/src/pages/components/avatar.mdx
@@ -1,0 +1,91 @@
+---
+title: Avatar description
+description: >
+  Avatars display typography, icons, or images in different sizes. They help users quickly recognize
+  an entity.
+---
+
+| When to use                                      |
+| ------------------------------------------------ |
+| To visually represent a person, brand or product |
+
+## Examples
+
+### Shape
+
+An Avatar can be a circle or rounded square. View the shape usage best practices.
+
+<!-- TODO: Hook up coded example -->
+
+<CodeExample>
+  <a href="https://share.getcloudapp.com/JrubnBkp">Example</a>
+</CodeExample>
+
+### Size
+
+Sizing can be adjusted to displayed sizes. The default size of an Avatar is `medium`.
+
+<!-- TODO: Hook up coded example -->
+
+<CodeExample>
+  <a href="https://share.getcloudapp.com/X6uObLNW">Example</a>
+</CodeExample>
+
+### Type
+
+An Avatar can contain an icon, image, or text.
+
+<!-- TODO: Hook up coded example -->
+
+<CodeExample>
+  <a href="https://share.getcloudapp.com/d5uv6kR8">Example</a>
+</CodeExample>
+
+### Status
+
+A status ring can be applied to the outside of an Avatar to communicate a user is away, available,
+or active.
+
+<!-- TODO: Hook up coded example -->
+
+<CodeExample>
+  <a href="https://share.getcloudapp.com/2NuXPebq">Example</a>
+</CodeExample>
+
+## Best practices
+
+### Selecting the right Avatar shape
+
+Circular Avatars are used to represent a person because the shape is most often associated with a
+profile picture. Rounded squares are used for system applications like objects, brands, or products.
+This helps the user quickly distinguish between a person or a system when scanning.
+
+<!-- TODO: Hook up Do this/Not this components -->
+
+![Avatar circle shape best practice](abstract:components-avatar-shape-circle.png)
+
+#### Do this
+
+Use a circular shape to represent a person
+
+![Avatar circle shape best practice](abstract:components-avatar-shape-square.png)
+
+#### Not this
+
+Use the rounded square shape to represent objects, brands, or products
+
+## Configuration
+
+<!-- TODO: Hook up Configuration section -->
+
+### API
+
+<!-- TODO: Hook up API sheet -->
+
+import { graphql } from 'gatsby';
+
+export const pageQuery = graphql`
+  query($fileAbsolutePath: String) {
+    ...SidebarPageFragment
+  }
+`;

--- a/src/pages/components/breadcrumbs.mdx
+++ b/src/pages/components/breadcrumbs.mdx
@@ -1,0 +1,38 @@
+---
+title: Breadcrumbs
+description: >
+  Breadcrumbs mark the current location of where a user is within the product. It’s helpful for giving users a sense of where they are in the experience and navigating back to parent pages.
+---
+
+| When to use                                                 | When not to use |
+| ----------------------------------------------------------- | --------------- |
+| To inform the user of where they are in a nested navigation |                 |
+| To navigate directly back to a parent page                  |                 |
+
+## Examples
+
+### Default
+
+Breadcrumbs are implemented in combination with the [Anchor](./buttons/anchor) component for navigation.
+
+<!-- TODO: Hook up coded example -->
+
+<CodeExample>
+  <a href="https://share.getcloudapp.com/5zu1NB6w">Example</a>
+</CodeExample>
+
+## Configuration
+
+<!-- TODO: Hook up Configuration section -->
+
+### API
+
+<!-- TODO: Hook up API sheet -->
+
+import { graphql } from 'gatsby';
+
+export const pageQuery = graphql`
+  query($fileAbsolutePath: String) {
+    ...SidebarPageFragment
+  }
+`;

--- a/src/pages/components/buttons/anchor.mdx
+++ b/src/pages/components/buttons/anchor.mdx
@@ -1,0 +1,60 @@
+---
+title: Anchor
+description: >
+  The Anchor component is a link used to navigate from one location to another.
+---
+
+| When to use                       | When not to use                                  |
+| --------------------------------- | ------------------------------------------------ |
+| To navigate from page to page     | To prompt an action or submit data, use a Button |
+| To display links inline with text |                                                  |
+| To navigate with a page           |                                                  |
+
+## Examples
+
+### Default
+
+An Anchor is used as a link to signal navigation.
+
+<!-- TODO: Hook up coded example -->
+
+<CodeExample>
+  <a href="https://share.getcloudapp.com/v1uD0b4L">Example</a>
+</CodeExample>
+
+### External Anchor
+
+An External Anchor shows an icon at the end of the link and opens it in a new window or tab.
+
+<!-- TODO: Hook up coded example -->
+
+<CodeExample>
+  <a href="https://share.getcloudapp.com/yAu2yDrZ">Example</a>
+</CodeExample>
+
+### Danger
+
+A Danger Anchor can be used to communicate that navigating away from your location
+will have destructive results.
+
+<!-- TODO: Hook up coded example -->
+
+<CodeExample>
+  <a href="https://share.getcloudapp.com/2NuXlwqe">Example</a>
+</CodeExample>
+
+## Configuration
+
+<!-- TODO: Hook up Configuration section -->
+
+### API
+
+<!-- TODO: Hook up API sheet -->
+
+import { graphql } from 'gatsby';
+
+export const pageQuery = graphql`
+  query($fileAbsolutePath: String) {
+    ...SidebarPageFragment
+  }
+`;

--- a/src/pages/components/buttons/button.mdx
+++ b/src/pages/components/buttons/button.mdx
@@ -15,8 +15,8 @@ propSheets:
 
 Buttons can be default, primary, or basic in type.
 
-import ButtonTypes from '../../examples/button/ButtonTypes.tsx';
-import ButtonTypesCode from '!!raw-loader!../../examples/button/ButtonTypes.tsx';
+import ButtonTypes from '../../../examples/button/ButtonTypes.tsx';
+import ButtonTypesCode from '!!raw-loader!../../../examples/button/ButtonTypes.tsx';
 
 <CodeExample code={ButtonTypesCode}>
   <ButtonTypes />
@@ -26,8 +26,8 @@ import ButtonTypesCode from '!!raw-loader!../../examples/button/ButtonTypes.tsx'
 
 Buttons can be small, default, or large sizes.
 
-import ButtonSizes from '../../examples/button/ButtonSizes.tsx';
-import ButtonSizesCode from '!!raw-loader!../../examples/button/ButtonSizes.tsx';
+import ButtonSizes from '../../../examples/button/ButtonSizes.tsx';
+import ButtonSizesCode from '!!raw-loader!../../../examples/button/ButtonSizes.tsx';
 
 <CodeExample code={ButtonSizesCode}>
   <ButtonSizes />
@@ -37,8 +37,8 @@ import ButtonSizesCode from '!!raw-loader!../../examples/button/ButtonSizes.tsx'
 
 The stretched property will make the button expand to fill its parents width.
 
-import ButtonStretched from '../../examples/button/ButtonStretched.tsx';
-import ButtonStretchedCode from '!!raw-loader!../../examples/button/ButtonStretched.tsx';
+import ButtonStretched from '../../../examples/button/ButtonStretched.tsx';
+import ButtonStretchedCode from '!!raw-loader!../../../examples/button/ButtonStretched.tsx';
 
 <CodeExample code={ButtonStretchedCode}>
   <ButtonStretched />
@@ -55,8 +55,8 @@ See the [Destructive actions pattern](#todo) section for guidelines.
 
 ### Disabled
 
-import ButtonDanger from '../../examples/button/ButtonDanger.tsx';
-import ButtonDangerCode from '!!raw-loader!../../examples/button/ButtonDanger.tsx';
+import ButtonDanger from '../../../examples/button/ButtonDanger.tsx';
+import ButtonDangerCode from '!!raw-loader!../../../examples/button/ButtonDanger.tsx';
 
 Mark a button disabled with the disabled property.
 [Read more about disabled state usage](#todo)


### PR DESCRIPTION
## Description

**The automated PR build is failing for me due to unauthorization: https://share.getcloudapp.com/nOu89EJW

The goal of this PR is to start populating the site with content from the Google docs in the smartest way possible to effectively tee up remaining Eng/Design work that is going to take more consideration and time to complete. The way I approached this was: 

1. Flow in the content from Avatar, Breadcrumb, and Anchor component Google docs
2. Keep the code example component shell but include a hyperlink to the static example of what is to go inside it
3. For static assets that will eventually go on the page, I am wiring them up to artboards in Abstract so when designers take more time to do polished graphics they will be imported automatically.

For sections that need more Eng attention, I am commenting with TODO. The TODO items for component pages are typically wiring up the:

- Configuration section
- API table
- Do/Don't component implementation
- Component Code examples and code
- When to use/When not to use structure

Was hoping for feedback on the approach taken here. If it's looking like a promising way to start contributing content to the site, I can continue helping in this way and soliciting help from designers for the static graphic portions. 
 
## Detail

<!-- supporting details; screen shot, code, etc. -->

<!-- closes GITHUB_ISSUE -->

## Checklist

- [ ] :ok_hand: website updates are Garden Designer approved (add the designer as a reviewer)
- [ ] :black_nib: copy updates are approved (add the content strategist as a reviewer)
- [ ] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [ ] :zap: audited via [web.dev](https://web.dev/measure/) for performance and SEO
- [ ] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
