### PR TITLE
fix: move token validation and dotenv to the top of gastby config

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -5,8 +5,12 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
+const envalid = require('envalid');
 const path = require('path');
 const { PALETTE } = require('@zendeskgarden/react-theming');
+
+require('dotenv').config();
+envalid.cleanEnv(process.env, { ABSTRACT_TOKEN: envalid.str() });
 
 module.exports = {
   siteMetadata: {

--- a/plugins/gatsby-source-abstract/gatsby-node.js
+++ b/plugins/gatsby-source-abstract/gatsby-node.js
@@ -6,13 +6,9 @@
  */
 
 const createNodeHelpers = require('gatsby-node-helpers').default;
-const envalid = require('envalid');
 const AbstractSdk = require('abstract-sdk');
 const Bottleneck = require('bottleneck');
 const { createRemoteFileNode } = require('gatsby-source-filesystem');
-
-require('dotenv').config();
-envalid.cleanEnv(process.env, { ABSTRACT_TOKEN: envalid.str() });
 
 /** Limit Abstract requests to avoid rate limiting */
 const rateLimiter = new Bottleneck({


### PR DESCRIPTION
## Description

The previous code timing prevents `.env` token from being passed to Abstract.