### PR TITLE
feat: component template css refinements

### DIFF
--- a/src/components/MarkdownProvider/components/CodeExample/index.tsx
+++ b/src/components/MarkdownProvider/components/CodeExample/index.tsx
@@ -36,7 +36,7 @@ export const CodeExample: React.FC<{ code: string }> = ({ children, code }) => {
   const [isRtl, setIsRtl] = useState(false);
   const [isCodeVisible, setIsCodeVisible] = useState(false);
   const focusVisibleRef = useRef(null);
-  const initialTooltipContent = 'Copy to clipboard';
+  const initialTooltipContent = 'Copy';
   const [tooltipContent, setTooltipContent] = useState(initialTooltipContent);
 
   const exampleTheme = useMemo<DefaultTheme>(() => {
@@ -64,7 +64,7 @@ export const CodeExample: React.FC<{ code: string }> = ({ children, code }) => {
   return (
     <div
       css={css`
-        margin: ${p => p.theme.space.md} 0;
+        margin: ${p => p.theme.space.md} 0 ${p => p.theme.space.xxl};
         border: ${p => p.theme.borders.sm} ${p => getColor('grey', 200, p.theme)};
         border-radius: ${p => p.theme.borderRadii.md};
       `}
@@ -88,8 +88,8 @@ export const CodeExample: React.FC<{ code: string }> = ({ children, code }) => {
         <form action="https://codesandbox.io/api/v1/sandboxes/define" method="POST" target="_blank">
           <input type="hidden" name="parameters" value={parameters} />
           <input type="hidden" name="query" value="module=src/Example.tsx" />
-          <Tooltip content="Fork in Codesandbox">
-            <StyledFooterButton aria-label="Fork in Codesandbox" type="submit">
+          <Tooltip content="Open Codesandbox">
+            <StyledFooterButton aria-label="Open Codesandbox" type="submit">
               <LightningBoltStroke />
             </StyledFooterButton>
           </Tooltip>
@@ -99,7 +99,7 @@ export const CodeExample: React.FC<{ code: string }> = ({ children, code }) => {
             aria-label="Copy to clipboard"
             onClick={() => {
               copyToClipboard(code);
-              setTooltipContent('Code copied to clipboard...');
+              setTooltipContent('Copied');
             }}
           >
             <CopyStroke />

--- a/src/components/MarkdownProvider/components/PropSheets.tsx
+++ b/src/components/MarkdownProvider/components/PropSheets.tsx
@@ -6,36 +6,49 @@
  */
 
 import React from 'react';
-import { css } from 'styled-components';
+import styled from 'styled-components';
 import { ComponentDoc } from 'react-docgen-typescript';
-import { getColor } from '@zendeskgarden/react-theming';
-import { MD, Paragraph } from '@zendeskgarden/react-typography';
-import { Table, Head, Body, HeaderRow, HeaderCell, Row, Cell } from '@zendeskgarden/react-tables';
+import { Paragraph, Code } from '@zendeskgarden/react-typography';
+import {
+  Table,
+  Head,
+  Body,
+  HeaderRow,
+  HeaderCell,
+  Row as GRow,
+  Cell
+} from '@zendeskgarden/react-tables';
+import { StyledH4 as Title } from './Typography';
 
-import { IPackage } from './PackageDescription';
-import { StyledH3 } from './Typography';
+const API = styled.div`
+  margin: ${p => p.theme.space.base * 6}px 0;
+`;
 
-export const PropSheets: React.FC<{ data: ComponentDoc[]; reactPackage: IPackage }> = ({
-  data,
-  reactPackage
-}) => {
+const Row = styled(GRow)`
+  font-family: ${p => p.theme.fonts.mono};
+`;
+
+const HeaderContainer = styled.div`
+  margin: 0 0 ${p => p.theme.space.base * 6}px;
+`;
+
+export const PropSheets: React.FC<{ data: ComponentDoc[] }> = ({ data }) => {
   return (
-    <>
+    <API>
       {data &&
         data.map((propSheet, index) => (
           <div key={`${propSheet.displayName}-${index}`}>
-            <StyledH3>{propSheet.displayName}</StyledH3>
-            <MD isMonospace>
-              import {`{${propSheet.displayName}}`} from &quot;{reactPackage.name}&quot;;
-            </MD>
-            <Paragraph>{propSheet.description}</Paragraph>
+            <HeaderContainer>
+              <Title>{propSheet.displayName}</Title>
+              <Paragraph>{propSheet.description}</Paragraph>
+            </HeaderContainer>
             <Table>
               <Head>
                 <HeaderRow>
-                  <HeaderCell>Prop name</HeaderCell>
+                  <HeaderCell>Property</HeaderCell>
+                  <HeaderCell>Description</HeaderCell>
                   <HeaderCell>Type</HeaderCell>
                   <HeaderCell>Default</HeaderCell>
-                  <HeaderCell>Description</HeaderCell>
                 </HeaderRow>
               </Head>
               <Body>
@@ -44,30 +57,12 @@ export const PropSheets: React.FC<{ data: ComponentDoc[]; reactPackage: IPackage
 
                   return (
                     <Row key={`${propSheet.displayName}-${propSheetKey}`}>
-                      <Cell
-                        css={css`
-                          color: ${p => getColor('kale', 400, p.theme)};
-                          font-family: ${p => p.theme.fonts.mono};
-                        `}
-                      >
-                        {prop.name}
-                      </Cell>
-                      <Cell
-                        css={css`
-                          color: ${p => getColor('red', 600, p.theme)};
-                          font-family: ${p => p.theme.fonts.mono};
-                        `}
-                      >
-                        {prop.type.name}
-                      </Cell>
-                      <Cell
-                        css={css`
-                          font-family: ${p => p.theme.fonts.mono};
-                        `}
-                      >
-                        {prop.defaultValue ? prop.defaultValue.value : '-'}
+                      <Cell>
+                        <Code>{prop.name}</Code>
                       </Cell>
                       <Cell>{prop.description}</Cell>
+                      <Cell>{prop.type.name}</Cell>
+                      <Cell>{prop.defaultValue ? prop.defaultValue.value : '-'}</Cell>
                     </Row>
                   );
                 })}
@@ -75,6 +70,6 @@ export const PropSheets: React.FC<{ data: ComponentDoc[]; reactPackage: IPackage
             </Table>
           </div>
         ))}
-    </>
+    </API>
   );
 };

--- a/src/components/MarkdownProvider/components/Typography.tsx
+++ b/src/components/MarkdownProvider/components/Typography.tsx
@@ -12,14 +12,17 @@ import { XXL, XL, LG } from '@zendeskgarden/react-typography';
 
 const headerSpacing = (p: ThemeProps<DefaultTheme>) => {
   return css`
-    margin-top: ${p.theme.space.md};
+    margin-top: ${p.theme.space.lg};
     margin-bottom: ${p.theme.space.sm};
-    padding-bottom: ${p.theme.space.xs};
+    font-weight: ${p.theme.fontWeights.semibold};
   `;
 };
 
 export const StyledH2 = styled(XXL).attrs({ tag: 'h2' })`
   ${headerSpacing}
+  margin-top: ${p => p.theme.space.xxl};
+  border-bottom: solid 1px ${getColor('grey', 300, p => p.theme)};
+  padding: 0 0 ${p => p.theme.space.base * 4}px;
 `;
 
 export const StyledH3 = styled(XL).attrs({ tag: 'h3' })`
@@ -66,7 +69,7 @@ export const StyledPre: React.FC = ({ children }) => {
 };
 
 export const StyledStrong = styled.strong`
-  font-weight: ${p => p.theme.fontWeights.bold};
+  font-weight: ${p => p.theme.fontWeights.semibold};
 `;
 
 export const StyledEmphasis = styled.em`

--- a/src/components/MarkdownProvider/components/Typography.tsx
+++ b/src/components/MarkdownProvider/components/Typography.tsx
@@ -21,7 +21,7 @@ const headerSpacing = (p: ThemeProps<DefaultTheme>) => {
 export const StyledH2 = styled(XXL).attrs({ tag: 'h2' })`
   ${headerSpacing}
   margin-top: ${p => p.theme.space.xxl};
-  border-bottom: solid 1px ${getColor('grey', 300, p => p.theme)};
+  border-bottom: solid 1px ${p => getColor('grey', 300, p.theme)};
   padding: 0 0 ${p => p.theme.space.base * 4}px;
 `;
 

--- a/src/layouts/Home/components/SectionCallout.tsx
+++ b/src/layouts/Home/components/SectionCallout.tsx
@@ -8,14 +8,13 @@
 import React, { HTMLAttributes } from 'react';
 import styled, { css } from 'styled-components';
 import { getColor } from '@zendeskgarden/react-theming';
-import { XXL, LG } from '@zendeskgarden/react-typography';
+import { XXL, LG, SM } from '@zendeskgarden/react-typography';
 
-export const StyledSectionHeader = styled.div`
+export const StyledSectionHeader = styled(SM)`
   text-transform: uppercase;
   line-height: ${p => p.theme.lineHeights.sm};
   letter-spacing: 0.5px;
   color: ${p => getColor('neutralHue', 500, p.theme)};
-  font-size: ${p => p.theme.fontSizes.xs};
   font-weight: ${p => p.theme.fontWeights.semibold};
 `;
 
@@ -27,13 +26,7 @@ export const SectionCallout: React.FC<
   } & HTMLAttributes<HTMLDivElement>
 > = ({ section, header, description, children, ...props }) => (
   <div {...props}>
-    <StyledSectionHeader
-      css={css`
-        margin-bottom: ${p => p.theme.space.xs};
-      `}
-    >
-      {section}
-    </StyledSectionHeader>
+    <StyledSectionHeader>{section}</StyledSectionHeader>
     <XXL
       tag="h2"
       css={css`

--- a/src/layouts/Sidebar/components/DesktopSidebar.tsx
+++ b/src/layouts/Sidebar/components/DesktopSidebar.tsx
@@ -93,12 +93,8 @@ export const DesktopSidebar: React.FC<{ sidebar: ISidebarSection[] }> = ({ sideb
       aria-label="Primary"
       css={css`
         background-color: ${p => p.theme.palette.tofu};
-        padding: ${p => p.theme.space.lg} ${p => p.theme.space.md} ${p => p.theme.space.lg} 0;
+        padding: ${p => p.theme.space.lg} ${p => p.theme.space.md};
         min-width: 220px;
-
-        @media (max-width: 1440px) {
-          padding: ${p => p.theme.space.lg} ${p => p.theme.space.md};
-        }
 
         @media (max-width: ${p => p.theme.breakpoints.lg}) {
           display: none;

--- a/src/layouts/Sidebar/index.tsx
+++ b/src/layouts/Sidebar/index.tsx
@@ -21,6 +21,21 @@ export interface ISidebarSection {
   items?: ISidebarSection[];
 }
 
+const ContentContainer = styled.div`
+  flex-grow: 1;
+  background-color: ${p => p.theme.colors.background};
+  padding: ${p => p.theme.space.lg} ${p => p.theme.space.md};
+
+  @media (max-width: ${p => p.theme.breakpoints.lg}) {
+    padding: ${p => p.theme.space.lg} ${p => p.theme.space.sm};
+  }
+`;
+
+const Content = styled.div`
+  margin-right: auto;
+  max-width: ${p => p.theme.breakpoints.xl};
+`;
+
 const StyledMobileNavButton = styled.button`
   display: none;
   position: fixed;
@@ -67,27 +82,9 @@ export const SidebarLayout: React.FC<{ sidebar: ISidebarSection[] }> = ({ childr
           `}
         >
           <DesktopSidebar sidebar={sidebar} />
-          <div
-            css={css`
-              flex-grow: 1;
-              background-color: ${p => p.theme.colors.background};
-              padding: ${p => p.theme.space.lg} ${p => p.theme.space.md};
-
-              @media (max-width: ${p => p.theme.breakpoints.lg}) {
-                padding: ${p => p.theme.space.lg} ${p => p.theme.space.sm};
-              }
-            `}
-          >
-            <div
-              css={css`
-                margin-right: auto;
-                margin-left: auto;
-                max-width: ${p => p.theme.breakpoints.lg};
-              `}
-            >
-              {children}
-            </div>
-          </div>
+          <ContentContainer>
+            <Content>{children}</Content>
+          </ContentContainer>
           {isMobileSidebarExpanded && <MobileSidebar sidebar={sidebar} />}
           <StyledMobileNavButton
             onClick={() => setIsMobileSidebarExpanded(!isMobileSidebarExpanded)}

--- a/src/layouts/Titled/components/TOC.tsx
+++ b/src/layouts/Titled/components/TOC.tsx
@@ -53,10 +53,11 @@ export const TOCBlock: React.FC<{ data: IHeading[] } & HTMLAttributes<HTMLDivEle
 
 const StyledAnchor = styled(Anchor)<{ isCurrent: boolean }>`
   display: block;
-  margin: ${p => p.theme.space.xxs} 0;
+  margin: ${p => p.theme.space.base * 0.5}px 0;
   margin-left: ${p => p.isCurrent && `-${p.theme.borderWidths.sm}`};
   border-left: ${p => p.isCurrent && `${p.theme.borders.sm} ${getColor('grey', 800, p.theme)}`};
   text-align: left;
+  font-size: ${p => p.theme.fontSizes.sm};
 `;
 
 export const TOC: React.FC<{ data: IHeading[] }> = ({ data }) => {
@@ -121,7 +122,7 @@ export const TOC: React.FC<{ data: IHeading[] }> = ({ data }) => {
       css={css`
         position: sticky;
         top: 32px;
-        margin-left: ${p => p.theme.space.lg};
+        margin-left: ${p => p.theme.space.sm};
       `}
     >
       <StyledSectionHeader

--- a/src/layouts/Titled/index.tsx
+++ b/src/layouts/Titled/index.tsx
@@ -6,22 +6,29 @@
  */
 
 import React from 'react';
-import { css, ThemeProps, DefaultTheme } from 'styled-components';
-import { getColor, getLineHeight } from '@zendeskgarden/react-theming';
-import { LG } from '@zendeskgarden/react-typography';
+import styled, { css } from 'styled-components';
+import { getColor } from '@zendeskgarden/react-theming';
 import { Grid, Row, Col } from '@zendeskgarden/react-grid';
+import { LG, XXXL } from '@zendeskgarden/react-typography';
 import { TOCBlock, TOC, IHeading } from './components/TOC';
 
-const headerStyles = (p: ThemeProps<DefaultTheme>) => {
-  const fontSize = `${p.theme.space.base * 12}px`;
+const TitleContainer = styled.div`
+  margin-bottom: ${p => p.theme.space.lg};
+  border-bottom: solid 1px ${p => getColor('grey', 300, p.theme)};
+  padding-bottom: ${p => p.theme.space.md};
+`;
 
-  return css`
-    margin-bottom: ${p.theme.space.md};
-    line-height: ${getLineHeight(`${p.theme.space.base * 14}px`, fontSize)};
-    font-size: ${fontSize};
-    font-weight: ${p.theme.fontWeights.bold};
-  `;
-};
+const PageTitle = styled(XXXL)`
+  margin-bottom: ${p => p.theme.space.sm};
+  line-height: 1;
+  font-size: ${p => p.theme.space.base * 12}px;
+  font-weight: ${p => p.theme.fontWeights.semibold};
+`;
+
+const SubTitle = styled(LG)`
+  max-width: 550px;
+  color: ${p => p.theme.palette.grey[600]};
+`;
 
 const TitledLayout: React.FC<{
   title: React.ReactNode;
@@ -31,30 +38,10 @@ const TitledLayout: React.FC<{
   <Grid gutters="lg">
     <Row>
       <Col lg={12} xl={9}>
-        <h1
-          css={css`
-            ${headerStyles}
-          `}
-        >
-          {title}
-        </h1>
-        {subTitle && (
-          <LG
-            tag="p"
-            css={css`
-              margin-bottom: ${p => p.theme.space.lg};
-              max-width: 450px;
-            `}
-          >
-            {subTitle}
-          </LG>
-        )}
-        <hr
-          css={css`
-            margin-bottom: ${p => p.theme.space.lg};
-            border-color: ${p => getColor('grey', 300, p.theme)};
-          `}
-        />
+        <TitleContainer>
+          <PageTitle tag="h1">{title}</PageTitle>
+          {subTitle && <SubTitle>{subTitle}</SubTitle>}
+        </TitleContainer>
         {toc && (
           <TOCBlock
             data={toc}

--- a/src/pages/components/button.mdx
+++ b/src/pages/components/button.mdx
@@ -47,7 +47,6 @@ import ButtonStretchedCode from '!!raw-loader!../../examples/button/ButtonStretc
 ### Danger
 
 Danger styling is for buttons that have a destructive intent.
-See the [Destructive actions pattern](#todo) section for guidelines.
 
 <CodeExample code={ButtonDangerCode}>
   <ButtonDanger />
@@ -58,16 +57,14 @@ See the [Destructive actions pattern](#todo) section for guidelines.
 import ButtonDanger from '../../examples/button/ButtonDanger.tsx';
 import ButtonDangerCode from '!!raw-loader!../../examples/button/ButtonDanger.tsx';
 
-Mark a button disabled with the disabled property.
-[Read more about disabled state usage](#todo)
+A disabled button prevents user interaction and is not perceived by a screen reader.
 
-## Best practices
-
-### Writing button labels
-
-## Package
+## Configuration
 
 <PackageDescription data={props.data.mdx.package} />
+
+### API
+
 <PropSheets data={props.data.mdx.propsSheets} reactPackage={props.data.mdx.package} />
 
 import { graphql } from 'gatsby';


### PR DESCRIPTION
<!-- structure the Title above as the first line of a
  https://conventionalcommits.org/ message. example: "chore:
  add a new 'thing' component page". -->

## Description

This PR aims to address some initial styling/layout simplification and continuity across component pages. I noticed as I have been going through the Avatar updates with Henry that I have been having a hard time distinguishing between content sections and generally establishing a grouped hierarchy via space. 

Some of this is new and needs @talia-eisenberg to weigh in but in general it was: 

1. Spacing updates to typography in particular. This is to help associate headers with the content and distance from other sections to create grouping. 
2. Added semi-bold font weights to heading tags across the board to help distinguish between paragraph copy and heading. This isn't currently rendering for me in Chrome. I had to reference the `font-weight` updates in Safari. [I think this is the bug. ](https://github.com/tailwindcss/tailwindcss/issues/1402)
3. The breakpoints were causing some [odd responsive behavior to happen](https://share.getcloudapp.com/eDu6e2kv) and so a few fixes for that. 
4. The content on the component pages needed more width. 740px wasn't giving us enough room for the Component examples, table, or code to show consistently without horizontal scrolling. It was opened up to `885px` (which is still 100 less than the current Garden site)
5. The `PropsTable` component had quite a bit of custom inline styling. Things were simplified down quite a bit. This could use more help than what is here (for instance the `` backticks are rendering as backticks and not turning the words into `code` elements) but thought this might be a start.  

### Static preview 

![Artboard](https://user-images.githubusercontent.com/29072694/81858823-2bd01680-9519-11ea-8cc4-b32d5f55385a.png)


** View deployment button below will hopefully create a deployment for me 🤞


## Detail

<!-- supporting details; screen shot, code, etc. -->

<!-- closes GITHUB_ISSUE -->

## Checklist

- [ ] :ok_hand: website updates are Garden Designer approved (add the designer as a reviewer)
- [ ] :black_nib: copy updates are approved (add the content strategist as a reviewer)
- [ ] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [ ] :zap: audited via [web.dev](https://web.dev/measure/) for performance and SEO
- [ ] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
