### PR TITLE
fix: sort icons by name in ascending order

### DIFF
--- a/src/pages/design/icons/12.mdx
+++ b/src/pages/design/icons/12.mdx
@@ -13,6 +13,7 @@ export const pageQuery = graphql`
     ...SidebarPageFragment
     svgIcons: allFile(
       filter: { sourceInstanceName: { eq: "svg-icons" }, relativeDirectory: { eq: "12" } }
+      sort: { fields: name, order: ASC }
     ) {
       edges {
         node {

--- a/src/pages/design/icons/16.mdx
+++ b/src/pages/design/icons/16.mdx
@@ -13,6 +13,7 @@ export const pageQuery = graphql`
     ...SidebarPageFragment
     svgIcons: allFile(
       filter: { sourceInstanceName: { eq: "svg-icons" }, relativeDirectory: { eq: "16" } }
+      sort: { fields: name, order: ASC }
     ) {
       edges {
         node {

--- a/src/pages/design/icons/26.mdx
+++ b/src/pages/design/icons/26.mdx
@@ -17,6 +17,7 @@ export const pageQuery = graphql`
         relativeDirectory: { eq: "26" }
         name: { glob: "!wordmark-*" }
       }
+      sort: { fields: name, order: ASC }
     ) {
       totalCount
       edges {


### PR DESCRIPTION
## Description

This pull request sorts the SVG icons by name in ascending order by passing a sort option into the GraphQL query.

## Checklist

- [ ] ~:ok_hand: website updates are Garden Designer approved (add the designer as a reviewer)~
- [ ] ~:black_nib: copy updates are approved (add the content strategist as a reviewer)~
- [ ] ~:wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver~
- [ ] ~:zap: audited via [web.dev](https://web.dev/measure/) for performance and SEO~
- [ ] ~:memo: tested in Chrome, Firefox, Safari, Edge, and IE11~
