### PR TITLE
feat: add breadcrumbs component page

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "@zendeskgarden/css-bedrock": "8.0.0",
     "@zendeskgarden/eslint-config": "11.0.4",
     "@zendeskgarden/react-avatars": "8.10.0",
+    "@zendeskgarden/react-breadcrumbs": "8.10.0",
     "@zendeskgarden/react-buttons": "8.10.0",
     "@zendeskgarden/react-forms": "8.10.0",
     "@zendeskgarden/react-grid": "8.10.0",

--- a/src/components/MarkdownProvider/components/CodeExample/utils/retrieveCodesandboxParameters.ts
+++ b/src/components/MarkdownProvider/components/CodeExample/utils/retrieveCodesandboxParameters.ts
@@ -58,6 +58,7 @@ const packageJson = `
     "styled-components": "latest",
     "@zendeskgarden/css-bedrock": "^7.0.33",
     "@zendeskgarden/react-avatars": "^8.x",
+    "@zendeskgarden/react-breadcrumbs": "^8.x",
     "@zendeskgarden/react-buttons": "^8.x",
     "@zendeskgarden/react-chrome": "^8.x",
     "@zendeskgarden/react-dropdowns": "^8.x",

--- a/src/examples/breadcrumbs/BreadcrumbsDefault.tsx
+++ b/src/examples/breadcrumbs/BreadcrumbsDefault.tsx
@@ -1,0 +1,23 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import React from 'react';
+import { Anchor } from '@zendeskgarden/react-buttons';
+import { Span } from '@zendeskgarden/react-typography';
+import { Breadcrumb } from '@zendeskgarden/react-breadcrumbs';
+
+const Example = () => {
+  return (
+    <Breadcrumb>
+      <Anchor>Garden</Anchor>
+      <Anchor>Flowers</Anchor>
+      <Span>Roses</Span>
+    </Breadcrumb>
+  );
+};
+
+export default Example;

--- a/src/nav/components.yml
+++ b/src/nav/components.yml
@@ -6,6 +6,8 @@
   items:
     - title: Avatar
       id: /components/avatar
+    - title: Breadcrumbs
+      id: /components/breadcrumbs
     - title: Buttons
       items:
         - id: /components/button

--- a/src/pages/components/breadcrumbs.mdx
+++ b/src/pages/components/breadcrumbs.mdx
@@ -1,0 +1,54 @@
+---
+title: Breadcrumb
+description: >
+  Breadcrumbs mark and communicate the current location of where a user is within the product.
+package: '@zendeskgarden/react-breadcrumbs'
+---
+
+<Usage>
+  <Use>
+    <ul>
+      <li>To inform the user of where they are in a nested navigation</li>
+      <li>To quickly navigate back to a parent page</li>
+    </ul>
+  </Use>
+</Usage>
+
+## Examples
+
+### Default
+
+Breadcrumbs work in combination with the [Anchor](/components/anchor) component for linking.
+
+import BreadcrumbsDefault from '../../examples/breadcrumbs/BreadcrumbsDefault.tsx';
+import BreadcrumbsDefaultCode from '!!raw-loader!../../examples/breadcrumbs/BreadcrumbsDefault.tsx';
+
+<CodeExample code={BreadcrumbsDefaultCode}>
+  <BreadcrumbsDefault />
+</CodeExample>
+
+## Configuration
+
+<PackageDescription data={props.data.mdx.package} />
+
+import { graphql } from 'gatsby';
+
+export const pageQuery = graphql`
+  query($fileAbsolutePath: String) {
+    ...SidebarPageFragment
+    avatarShapeCircle: abstractAsset(layerName: { eq: "components-avatar-shape-circle" }) {
+      children {
+        ... on File {
+          publicURL
+        }
+      }
+    }
+    avatarShapeSquare: abstractAsset(layerName: { eq: "components-avatar-shape-square" }) {
+      children {
+        ... on File {
+          publicURL
+        }
+      }
+    }
+  }
+`;

--- a/src/pages/components/breadcrumbs.mdx
+++ b/src/pages/components/breadcrumbs.mdx
@@ -1,5 +1,5 @@
 ---
-title: Breadcrumb
+title: Breadcrumbs
 description: >
   Breadcrumbs mark and communicate the current location of where a user is within the product.
 package: '@zendeskgarden/react-breadcrumbs'

--- a/src/pages/components/breadcrumbs.mdx
+++ b/src/pages/components/breadcrumbs.mdx
@@ -36,19 +36,5 @@ import { graphql } from 'gatsby';
 export const pageQuery = graphql`
   query($fileAbsolutePath: String) {
     ...SidebarPageFragment
-    avatarShapeCircle: abstractAsset(layerName: { eq: "components-avatar-shape-circle" }) {
-      children {
-        ... on File {
-          publicURL
-        }
-      }
-    }
-    avatarShapeSquare: abstractAsset(layerName: { eq: "components-avatar-shape-square" }) {
-      children {
-        ... on File {
-          publicURL
-        }
-      }
-    }
   }
 `;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2209,6 +2209,13 @@
   resolved "https://registry.yarnpkg.com/@xtuc/long/-/long-4.2.2.tgz#d291c6a4e97989b5c61d9acf396ae4fe133a718d"
   integrity sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==
 
+"@zendeskgarden/container-breadcrumb@^0.4.1":
+  version "0.4.3"
+  resolved "https://registry.yarnpkg.com/@zendeskgarden/container-breadcrumb/-/container-breadcrumb-0.4.3.tgz#78556f2f61621e6d3e661c2c708e736cc457a18b"
+  integrity sha512-yzeGTbTWqJZEMBWDeUW6dJY4Gye+Do9dEKMzvJWTw8nli+57VVL1ysLd87dM7CDT5eirJ5aWw65ERre+e1xogg==
+  dependencies:
+    "@babel/runtime" "^7.8.4"
+
 "@zendeskgarden/container-buttongroup@^0.3.1":
   version "0.3.3"
   resolved "https://registry.yarnpkg.com/@zendeskgarden/container-buttongroup/-/container-buttongroup-0.3.3.tgz#42e86b147c6dd0a97586e255be6483545f30f3c6"
@@ -2287,6 +2294,14 @@
   resolved "https://registry.yarnpkg.com/@zendeskgarden/react-avatars/-/react-avatars-8.10.0.tgz#59862a9f0637aa88c0192c6c531d77a6a0d4f358"
   integrity sha512-K6r2NfmNx0B0gdBxKKlfOEQYybNwayfjOgyfgI+Tu5uOlB176dX1mQu+/aV5MIbe+UQvMZVTQ2osv+vy/9n2bQ==
   dependencies:
+    polished "^3.5.1"
+
+"@zendeskgarden/react-breadcrumbs@8.10.0":
+  version "8.10.0"
+  resolved "https://registry.yarnpkg.com/@zendeskgarden/react-breadcrumbs/-/react-breadcrumbs-8.10.0.tgz#9385ac2798ce018d265cc3b35f6cb73fb648f740"
+  integrity sha512-cugz0h7A+4+8UGOVCzuzMnWZECgdf9+W1c2fBlhE1OX6tJqxX5n9/+5V4fhh+RRMkMKL8otDJ0fWzHHoBrppxg==
+  dependencies:
+    "@zendeskgarden/container-breadcrumb" "^0.4.1"
     polished "^3.5.1"
 
 "@zendeskgarden/react-buttons@8.10.0":


### PR DESCRIPTION
<!-- structure the Title above as the first line of a
  https://conventionalcommits.org/ message. example: "chore:
  add a new 'thing' component page". -->

## Description

This pull request introduces the `Breadcrumb` Component Page. Use the View deployment button further down this page to view a build of this Pull Request.

## Detail

<!-- supporting details; screen shot, code, etc. -->

<!-- closes GITHUB_ISSUE -->

## Checklist

- [ ] :ok_hand: website updates are Garden Designer approved (add the designer as a reviewer)
- [ ] :black_nib: copy updates are approved (add the content strategist as a reviewer)
- [ ] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [ ] :zap: audited via [web.dev](https://web.dev/measure/) for performance and SEO
- [ ] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
