### PR TITLE
chore(components): refine BestPractice component

### DIFF
--- a/src/components/MarkdownProvider/components/BestPractice.tsx
+++ b/src/components/MarkdownProvider/components/BestPractice.tsx
@@ -5,45 +5,38 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import React, { cloneElement, ReactNode, ReactElement } from 'react';
+import React, { cloneElement, ReactNode } from 'react';
 import styled from 'styled-components';
 import { ReactComponent as XStrokeIcon } from '@zendeskgarden/svg-icons/src/16/x-stroke.svg';
 import { ReactComponent as CheckLgStrokeIcon } from '@zendeskgarden/svg-icons/src/16/check-lg-stroke.svg';
 import { ReactComponent as AlertErrorStrokeIcon } from '@zendeskgarden/svg-icons/src/16/alert-error-stroke.svg';
-import { Well, Title, Paragraph } from '@zendeskgarden/react-notifications';
+import { Well, Title } from '@zendeskgarden/react-notifications';
 import { getColor } from '@zendeskgarden/react-theming';
-import { Grid, Row, Col } from '@zendeskgarden/react-grid';
+import { Row, Col } from '@zendeskgarden/react-grid';
 
-interface IStyledWellProps {
-  hue: string;
-}
+const StyledRow = styled(Row)`
+  margin-top: ${p => p.theme.space.lg};
+  margin-bottom: ${p => p.theme.space.xxl};
 
-interface ISectionProps {
-  hue: string;
-  title: string;
-  altText: string;
-  imageSource: string;
-  icon: ReactNode;
-}
+  @media (max-width: ${p => p.theme.breakpoints.sm}) {
+    margin-top: ${p => `${p.theme.space.base * 6}px`};
+    margin-bottom: ${p => p.theme.space.lg};
+  }
+`;
+
+const StyledCol = styled(Col)`
+  @media (max-width: ${p => p.theme.breakpoints.sm}) {
+    &:not(:first-child) {
+      margin-top: ${p => `${p.theme.space.base * 6}px`};
+    }
+  }
+`;
 
 const StyledFigure = styled.figure`
   display: flex;
   flex-basis: 0;
   flex-direction: column;
   flex-grow: 1;
-  margin: ${p => p.theme.space.xl} 0;
-
-  @media (min-width: ${p => p.theme.breakpoints.sm}) {
-    margin: ${p => p.theme.space.md} ${p => p.theme.space.xs};
-
-    &:first-child {
-      margin-left: 0;
-    }
-
-    &:last-child {
-      margin-right: 0;
-    }
-  }
 `;
 
 const StyledImg = styled.img`
@@ -53,14 +46,28 @@ const StyledImg = styled.img`
   border-top-right-radius: ${p => p.theme.borderRadii.md};
 `;
 
-const StyledWell = styled(props => <Well isRecessed {...props} />).attrs(p => ({
+interface IStyledCaptionProps {
+  hue: string;
+}
+
+const StyledCaption = styled(p => <Well isRecessed {...p} />).attrs(p => ({
   forwardedAs: p.tag
-}))<IStyledWellProps>`
+}))<IStyledCaptionProps>`
   border: none;
   border-top: ${p => p.theme.borders.md};
   border-radius: 0;
   border-color: ${p => getColor(p.hue, 500, p.theme)};
   padding: ${p => p.theme.space.md};
+  color: ${p => p.theme.colors.foreground};
+
+  & > p {
+    margin-top: ${p => `${p.theme.space.base * 4}px`};
+  }
+`;
+
+const StyledTitle = styled(p => <Title {...p} />).attrs(p => ({ forwardedAs: p.tag }))`
+  display: flex;
+  align-items: center;
 `;
 
 const StyledIcon = styled(({ children, ...props }) =>
@@ -70,60 +77,68 @@ const StyledIcon = styled(({ children, ...props }) =>
   color: ${p => getColor(p.hue, 500, p.theme)};
 `;
 
-const StyledTitle = styled(Title)`
-  display: flex;
-  align-items: center;
-`;
+interface ICaptionProps {
+  hue: string;
+  title: string;
+  icon: ReactNode;
+  imageSource?: string;
+}
 
-const StyledRow = styled(Row)`
-  @media (max-width: ${p => p.theme.breakpoints.sm}) {
-    flex-direction: column;
+const Caption: React.FC<ICaptionProps> = props => (
+  <StyledCaption tag={props.imageSource ? 'figcaption' : undefined} hue={props.hue}>
+    <StyledTitle tag="strong">
+      <StyledIcon hue={props.hue}>{props.icon}</StyledIcon>
+      {props.title}
+    </StyledTitle>
+    {props.children}
+  </StyledCaption>
+);
+
+interface ISectionProps extends ICaptionProps {
+  imageAlt?: string;
+}
+
+export const Section: React.FC<ISectionProps> = props => {
+  if (props.imageSource) {
+    return (
+      <StyledFigure>
+        <StyledImg alt={props.imageAlt} src={props.imageSource} />
+        <Caption {...props} />
+      </StyledFigure>
+    );
   }
-`;
 
-export const Section: React.FC<ISectionProps> = props => (
-  <StyledFigure>
-    {props.imageSource && <StyledImg alt={props.altText} src={props.imageSource} />}
-    <StyledWell tag="figcaption" hue={props.hue}>
-      <StyledTitle>
-        <StyledIcon hue={props.hue}>{props.icon}</StyledIcon>
-        {props.title}
-      </StyledTitle>
-      <Paragraph>{props.children}</Paragraph>
-    </StyledWell>
-  </StyledFigure>
-);
-
-export const Dont: React.FC<ISectionProps> = props => (
-  <Section {...props} title="Not this" altText="not this" hue="dangerHue" icon={<XStrokeIcon />} />
-);
+  return <Caption {...props} />;
+};
 
 export const Do: React.FC<ISectionProps> = props => (
   <Section
     {...props}
     title="Do this"
-    altText="do this"
+    imageAlt="do this"
     hue="successHue"
     icon={<CheckLgStrokeIcon />}
   />
+);
+
+export const Dont: React.FC<ISectionProps> = props => (
+  <Section {...props} title="Not this" imageAlt="not this" hue="dangerHue" icon={<XStrokeIcon />} />
 );
 
 export const Caution: React.FC<ISectionProps> = props => (
   <Section
     {...props}
     title="Caution"
-    altText="caution"
+    imageAlt="caution"
     hue="warningHue"
     icon={<AlertErrorStrokeIcon />}
   />
 );
 
 export const BestPractice: React.FC = props => (
-  <Grid>
-    <StyledRow>
-      {React.Children.map(props.children, child => (
-        <Col>{React.cloneElement(child as ReactElement)}</Col>
-      ))}
-    </StyledRow>
-  </Grid>
+  <StyledRow>
+    {React.Children.map(props.children, child => (
+      <StyledCol sm>{child}</StyledCol>
+    ))}
+  </StyledRow>
 );

--- a/src/components/MarkdownProvider/components/BestPractice.tsx
+++ b/src/components/MarkdownProvider/components/BestPractice.tsx
@@ -54,14 +54,24 @@ const StyledCaption = styled(p => <Well isRecessed {...p} />).attrs(p => ({
   forwardedAs: p.tag
 }))<IStyledCaptionProps>`
   border: none;
-  border-top: ${p => p.theme.borders.md};
+  border-top: ${p => `${p.theme.borders.md} ${getColor(p.hue, 500, p.theme)}`};
   border-radius: 0;
-  border-color: ${p => getColor(p.hue, 500, p.theme)};
   padding: ${p => p.theme.space.md};
   color: ${p => p.theme.colors.foreground};
 
   & > p {
     margin-top: ${p => `${p.theme.space.base * 4}px`};
+  }
+
+  & > ul {
+    list-style-type: none;
+    margin-left: 0;
+
+    & > li:not(:first-child) {
+      margin-top: ${p => p.theme.space.xs};
+      border-top: ${p => `${p.theme.borders.sm} ${getColor('neutralHue', 300, p.theme)}`};
+      padding-top: ${p => p.theme.space.xs};
+    }
   }
 `;
 

--- a/src/components/MarkdownProvider/components/Usage.tsx
+++ b/src/components/MarkdownProvider/components/Usage.tsx
@@ -6,26 +6,21 @@
  */
 
 import React from 'react';
-import styled from 'styled-components';
 import { MD } from '@zendeskgarden/react-typography';
 import { Row, Col } from '@zendeskgarden/react-grid';
 
 export const Use: React.FC = props => (
-  <Col>
+  <Col sm>
     <MD isBold>When to use</MD>
     {props.children}
   </Col>
 );
 
 export const Misuse: React.FC = props => (
-  <Col>
+  <Col sm>
     <MD isBold>When NOT to use</MD>
     {props.children}
   </Col>
 );
 
-export const StyledUsage = styled(Row)`
-  @media (max-width: ${p => p.theme.breakpoints.sm}) {
-    flex-direction: column;
-  }
-`;
+export const Usage = Row;

--- a/src/components/MarkdownProvider/index.tsx
+++ b/src/components/MarkdownProvider/index.tsx
@@ -12,7 +12,7 @@ import { Code, Paragraph } from '@zendeskgarden/react-typography';
 import { CodeExample } from './components/CodeExample';
 import { PackageDescription } from './components/PackageDescription';
 import { PropSheets } from './components/PropSheets';
-import { StyledUsage as Usage, Use, Misuse } from './components/Usage';
+import { Usage, Use, Misuse } from './components/Usage';
 import { BestPractice, Do, Dont, Caution } from './components/BestPractice';
 import {
   StyledH2,

--- a/src/layouts/Titled/index.tsx
+++ b/src/layouts/Titled/index.tsx
@@ -28,7 +28,7 @@ const TitledLayout: React.FC<{
   subTitle?: React.ReactNode;
   toc?: IHeading[];
 }> = ({ children, title, subTitle, toc }) => (
-  <Grid gutters="lg">
+  <Grid>
     <Row>
       <Col lg={12} xl={9}>
         <h1

--- a/src/pages/components/avatar.mdx
+++ b/src/pages/components/avatar.mdx
@@ -73,10 +73,10 @@ This helps the user quickly distinguish between a person or a system when scanni
 
 <BestPractice>
   <Do imageSource={props.data.avatarShapeCircle.children[0].publicURL}>
-    Use a circular shape to represent a person.
+    <p>Use a circular shape to represent a person.</p>
   </Do>
   <Do imageSource={props.data.avatarShapeSquare.children[0].publicURL}>
-    Use the rounded square shape to represent objects, brands, or products.
+    <p>Use the rounded square shape to represent objects, brands, or products.</p>
   </Do>
 </BestPractice>
 

--- a/src/pages/design/index.mdx
+++ b/src/pages/design/index.mdx
@@ -4,12 +4,74 @@ title: Overview
 
 ## Introduction
 
-TODO
+<Usage>
+  <Use>
+    <ul>
+      <li>Foo</li>
+      <li>Bar</li>
+      <li>Baz</li>
+    </ul>
+  </Use>
+  <Misuse>
+    <ul>
+      <li>Foo</li>
+      <li>Bar</li>
+      <li>Baz</li>
+    </ul>
+  </Misuse>
+</Usage>
+
+## Best Practices
+
+Veggies es bonus vobis, proinde vos postulo essum magis kohlrabi welsh onion daikon amaranth
+tatsoi tomatillo melon azuki bean garlic.
+
+<BestPractice>
+  <Do imageSource={props.data.avatarShapeCircle.children[0].publicURL}>
+    <p>
+      Veggies es bonus vobis, proinde vos postulo essum magis kohlrabi welsh onion daikon amaranth
+      tatsoi tomatillo melon azuki bean garlic.
+    </p>
+    <p>
+      Veggies es bonus vobis, proinde vos postulo essum magis kohlrabi welsh onion daikon amaranth
+      tatsoi tomatillo melon azuki bean garlic.
+    </p>
+  </Do>
+  <Dont imageSource={props.data.avatarShapeCircle.children[0].publicURL}>
+    <p>
+      Veggies es bonus vobis, proinde vos postulo essum magis kohlrabi welsh onion daikon amaranth
+      tatsoi tomatillo melon azuki bean garlic.
+    </p>
+  </Dont>
+</BestPractice>
+
+<BestPractice>
+  <Do>
+    <ul>
+      <li>Veggies es bonus vobis, proinde vos postulo</li>
+      <li>Veggies es bonus vobis, proinde vos postulo essum magis kohlrabi welsh onion.</li>
+      <li>Veggies es bonus vobis, proinde vos postulo essum magis kohlrabi welsh onion.</li>
+    </ul>
+  </Do>
+  <Caution>
+    <ul>
+      <li>Veggies es bonus vobis, proinde vos postulo essum magis kohlrabi welsh onion.</li>
+      <li>Veggies es bonus vobis, proinde vos postulo essum magis kohlrabi welsh onion.</li>
+    </ul>
+  </Caution>
+</BestPractice>
 
 import { graphql } from 'gatsby';
 
 export const pageQuery = graphql`
   query($fileAbsolutePath: String) {
     ...SidebarPageFragment
+    avatarShapeCircle: abstractAsset(layerName: { eq: "components-avatar-shape-circle" }) {
+      children {
+        ... on File {
+          publicURL
+        }
+      }
+    }
   }
 `;


### PR DESCRIPTION
## Description

Addressed a variety of layout bugs, simplified grid usage (no `flex-direction: column`), and rebuilt the `BestPractice` component.

In **draft** mode as one-off visuals can be found on the `/design` page. @rossmoody let me know if you want me to keep these for now or dispose before I open up for non-draft review. 🙏 

## Detail

### Before

<img width="727" alt="Screen Shot 2020-05-29 at 3 18 02 PM" src="https://user-images.githubusercontent.com/143773/83310016-9cd12880-a1bf-11ea-856b-7c3d7ff3e397.png">

### After

<img width="739" alt="Screen Shot 2020-05-29 at 3 19 23 PM" src="https://user-images.githubusercontent.com/143773/83310093-ce49f400-a1bf-11ea-9fed-ad39e73dc445.png">

...with added support for:

<img width="750" alt="Screen Shot 2020-05-29 at 3 20 16 PM" src="https://user-images.githubusercontent.com/143773/83310135-eb7ec280-a1bf-11ea-8d88-7aa7d3337100.png">

## Checklist

- [x] :ok_hand: website updates are Garden Designer approved (add the designer as a reviewer)
- [ ] :black_nib: ~copy updates are approved (add the content strategist as a reviewer)~
- [x] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [x] :zap: audited via [web.dev](https://web.dev/measure/) for performance and SEO
- [ ] :memo: ~tested in Chrome, Firefox, Safari, Edge, and IE11~
