### PR TITLE
feat(components): add configuration section

### DIFF
--- a/plugins/gatsby-source-react-packages/gatsby-node.js
+++ b/plugins/gatsby-source-react-packages/gatsby-node.js
@@ -79,7 +79,8 @@ exports.sourceNodes = async ({ actions, reporter }) => {
       name: packageJson.name,
       description: packageJson.description,
       version: packageJson.version,
-      peerDependencies: packageJson.peerDependencies && Object.keys(packageJson.peerDependencies)
+      peerDependencies: packageJson.peerDependencies && Object.keys(packageJson.peerDependencies),
+      packageName: file
     });
 
     await createNode(node);

--- a/plugins/gatsby-source-react-packages/gatsby-node.js
+++ b/plugins/gatsby-source-react-packages/gatsby-node.js
@@ -78,7 +78,8 @@ exports.sourceNodes = async ({ actions, reporter }) => {
       id: packageJson.name,
       name: packageJson.name,
       description: packageJson.description,
-      version: packageJson.version
+      version: packageJson.version,
+      peerDependencies: packageJson.peerDependencies && Object.keys(packageJson.peerDependencies)
     });
 
     await createNode(node);

--- a/plugins/gatsby-source-react-packages/gatsby-node.js
+++ b/plugins/gatsby-source-react-packages/gatsby-node.js
@@ -79,7 +79,6 @@ exports.sourceNodes = async ({ actions, reporter }) => {
       name: packageJson.name,
       description: packageJson.description,
       version: packageJson.version,
-      peerDependencies: packageJson.peerDependencies && Object.keys(packageJson.peerDependencies),
       packageName: file
     });
 

--- a/src/components/MarkdownProvider/components/Configuration.tsx
+++ b/src/components/MarkdownProvider/components/Configuration.tsx
@@ -21,17 +21,17 @@ export interface IPackage {
 
 const StyledUnorderedList = styled(UnorderedList)`
   margin: 0 0 ${p => p.theme.space.xxl};
-  border-bottom: solid 1px ${p => getColor('grey', 300, p.theme)};
+  border-bottom: ${p => `${p.theme.borders.sm} ${getColor('grey', 300, p.theme)}`};
 `;
 
 const StyledListItem = styled(UnorderedList.Item)`
   list-style: none;
 
-  & > :first-child {
+  & > div {
     display: flex;
-    margin: ${p => p.theme.space.base * 3}px 0;
-    border-top: solid 1px ${p => getColor('grey', 300, p.theme)};
-    padding: ${p => p.theme.space.base * 3}px 0 0;
+    margin: ${p => p.theme.space.sm} 0;
+    border-top: ${p => `${p.theme.borders.sm} ${getColor('grey', 300, p.theme)}`};
+    padding: ${p => p.theme.space.sm} 0 0;
     font-family: ${p => p.theme.fonts.mono};
   }
 `;
@@ -43,7 +43,7 @@ const StyledListItemLabel = styled.label`
 `;
 
 const StyledSpan = styled(Span)`
-  margin-right: ${p => p.theme.space.base * 3}px;
+  margin-right: ${p => p.theme.space.sm};
 `;
 
 export const Configuration: React.FC<{ reactPackage: IPackage; propSheets: ComponentDoc[] }> = ({
@@ -54,7 +54,6 @@ export const Configuration: React.FC<{ reactPackage: IPackage; propSheets: Compo
     <StyledUnorderedList>
       <StyledListItem>
         <StyledListItemLabel>Name</StyledListItemLabel>
-        {/* This is showing the version on this page and not the latest available. Need to fix */}
         <StyledSpan>{reactPackage.version}</StyledSpan>
         <StyledSpan>•</StyledSpan>
         <StyledSpan>

--- a/src/components/MarkdownProvider/components/Configuration.tsx
+++ b/src/components/MarkdownProvider/components/Configuration.tsx
@@ -34,10 +34,8 @@ const StyledListItem = styled(UnorderedList.Item)`
   }
 `;
 
-const StyledListItemLabel = styled.label`
+const StyledListItemLabel = styled(MD)`
   min-width: ${p => p.theme.space.base * 20}px;
-  font-family: ${p => p.theme.fonts.system};
-  font-weight: ${p => p.theme.fontWeights.semibold};
 `;
 
 const StyledDot = styled(Span)`
@@ -56,7 +54,7 @@ export const Configuration: React.FC<{ reactPackage: IPackage; propSheets: Compo
   return (
     <StyledUnorderedList>
       <StyledListItem>
-        <StyledListItemLabel>Name</StyledListItemLabel>
+        <StyledListItemLabel isBold>Name</StyledListItemLabel>
         {reactPackage.version}
         <StyledDot>•</StyledDot>
         <Anchor
@@ -72,17 +70,17 @@ export const Configuration: React.FC<{ reactPackage: IPackage; propSheets: Compo
         </Anchor>
       </StyledListItem>
       <StyledListItem>
-        <StyledListItemLabel>Install</StyledListItemLabel>
+        <StyledListItemLabel isBold>Install</StyledListItemLabel>
         <StyledMD isMonospace>npm install {reactPackage.name}</StyledMD>
       </StyledListItem>
       <StyledListItem>
-        <StyledListItemLabel>Deps</StyledListItemLabel>
+        <StyledListItemLabel isBold>Deps</StyledListItemLabel>
         <StyledMD isMonospace>
           npm install react react-dom prop-types styled-components @zendeskgarden/react-theming
         </StyledMD>
       </StyledListItem>
       <StyledListItem>
-        <StyledListItemLabel>Import</StyledListItemLabel>
+        <StyledListItemLabel isBold>Import</StyledListItemLabel>
         <StyledMD isMonospace>
           import{' '}
           {`{ ${propSheets && propSheets.map(propSheet => propSheet.displayName).join(', ')} }`}{' '}

--- a/src/components/MarkdownProvider/components/Configuration.tsx
+++ b/src/components/MarkdownProvider/components/Configuration.tsx
@@ -21,11 +21,10 @@ interface IPackage {
 const StyledUnorderedList = styled(UnorderedList)`
   margin: 0 0 ${p => p.theme.space.xxl};
   border-bottom: ${p => `${p.theme.borders.sm} ${getColor('grey', 200, p.theme)}`};
+  list-style: none;
 `;
 
 const StyledListItem = styled(UnorderedList.Item)`
-  list-style: none;
-
   & > div {
     display: flex;
     margin: ${p => p.theme.space.base * 2.5}px 0;
@@ -43,7 +42,9 @@ const StyledDot = styled(Span)`
   color: ${p => getColor('grey', 600, p.theme)};
 `;
 
-const StyledMD = styled(MD)`
+const StyledMono = styled(MD)`
+  /* 1px nudge to align mono type with 14px label baseline */
+  line-height: 21px;
   color: ${p => getColor('grey', 700, p.theme)};
 `;
 
@@ -66,28 +67,28 @@ export const Configuration: React.FC<{ reactPackage: IPackage; propSheets: Compo
         <Anchor
           href={`https://www.npmjs.com/package/@zendeskgarden/react-${reactPackage.packageName}`}
         >
-          View on NPM
+          View on npm
         </Anchor>
       </StyledListItem>
       <StyledListItem>
         <StyledListItemLabel isBold>Install</StyledListItemLabel>
-        <StyledMD isMonospace>npm install {reactPackage.name}</StyledMD>
+        <StyledMono isMonospace>npm install {reactPackage.name}</StyledMono>
       </StyledListItem>
       <StyledListItem>
         <StyledListItemLabel isBold>Deps</StyledListItemLabel>
-        <StyledMD isMonospace>
+        <StyledMono isMonospace>
           npm install react react-dom prop-types styled-components @zendeskgarden/react-theming
-        </StyledMD>
+        </StyledMono>
       </StyledListItem>
       <StyledListItem>
         <StyledListItemLabel isBold>Import</StyledListItemLabel>
-        <StyledMD isMonospace>
+        <StyledMono isMonospace>
           import{' '}
           {`{ ${propSheets && propSheets.map(propSheet => propSheet.displayName).join(', ')} }`}{' '}
           from &apos;
           {reactPackage.name}
           &apos;
-        </StyledMD>
+        </StyledMono>
       </StyledListItem>
     </StyledUnorderedList>
   );

--- a/src/components/MarkdownProvider/components/Configuration.tsx
+++ b/src/components/MarkdownProvider/components/Configuration.tsx
@@ -7,7 +7,7 @@
 
 import React from 'react';
 import styled from 'styled-components';
-import { UnorderedList, Span } from '@zendeskgarden/react-typography';
+import { UnorderedList, Span, MD } from '@zendeskgarden/react-typography';
 import { Anchor } from '@zendeskgarden/react-buttons';
 import { getColor } from '@zendeskgarden/react-theming';
 import { ComponentDoc } from 'react-docgen-typescript';
@@ -31,7 +31,6 @@ const StyledListItem = styled(UnorderedList.Item)`
     margin: ${p => p.theme.space.base * 2.5}px 0;
     border-top: ${p => `${p.theme.borders.sm} ${getColor('grey', 200, p.theme)}`};
     padding: ${p => p.theme.space.base * 2.5}px 0 0;
-    font-family: ${p => p.theme.fonts.mono};
   }
 `;
 
@@ -42,7 +41,12 @@ const StyledListItemLabel = styled.label`
 `;
 
 const StyledDot = styled(Span)`
-  margin: 0 ${p => p.theme.space.sm};
+  margin: 0 ${p => p.theme.space.xs};
+  color: ${p => getColor('grey', 600, p.theme)};
+`;
+
+const StyledMD = styled(MD)`
+  color: ${p => getColor('grey', 700, p.theme)};
 `;
 
 export const Configuration: React.FC<{ reactPackage: IPackage; propSheets: ComponentDoc[] }> = ({
@@ -57,33 +61,35 @@ export const Configuration: React.FC<{ reactPackage: IPackage; propSheets: Compo
         <StyledDot>•</StyledDot>
         <Anchor
           href={`https://github.com/zendeskgarden/react-components/tree/master/packages/${reactPackage.packageName}`}
-          target="_blank"
         >
           View source
         </Anchor>
         <StyledDot>•</StyledDot>
         <Anchor
           href={`https://www.npmjs.com/package/@zendeskgarden/react-${reactPackage.packageName}`}
-          target="_blank"
         >
           View on NPM
         </Anchor>
       </StyledListItem>
       <StyledListItem>
         <StyledListItemLabel>Install</StyledListItemLabel>
-        npm install {reactPackage.name}
+        <StyledMD isMonospace>npm install {reactPackage.name}</StyledMD>
       </StyledListItem>
       <StyledListItem>
         <StyledListItemLabel>Deps</StyledListItemLabel>
-        npm install react react-dom prop-types styled-components @zendeskgarden/react-theming
+        <StyledMD isMonospace>
+          npm install react react-dom prop-types styled-components @zendeskgarden/react-theming
+        </StyledMD>
       </StyledListItem>
       <StyledListItem>
         <StyledListItemLabel>Import</StyledListItemLabel>
-        import{' '}
-        {`{ ${propSheets && propSheets.map(propSheet => propSheet.displayName).join(', ')} }`} from
-        &apos;
-        {reactPackage.name}
-        &apos;
+        <StyledMD isMonospace>
+          import{' '}
+          {`{ ${propSheets && propSheets.map(propSheet => propSheet.displayName).join(', ')} }`}{' '}
+          from &apos;
+          {reactPackage.name}
+          &apos;
+        </StyledMD>
       </StyledListItem>
     </StyledUnorderedList>
   );

--- a/src/components/MarkdownProvider/components/Configuration.tsx
+++ b/src/components/MarkdownProvider/components/Configuration.tsx
@@ -20,7 +20,7 @@ export interface IPackage {
 }
 
 const StyledUnorderedList = styled(UnorderedList)`
-  margin: 0 0 ${p => p.theme.space.base * 12}px;
+  margin: 0 0 ${p => p.theme.space.xxl};
   border-bottom: solid 1px ${p => getColor('grey', 300, p.theme)};
 `;
 
@@ -46,20 +46,20 @@ const StyledSpan = styled(Span)`
   margin-right: ${p => p.theme.space.base * 3}px;
 `;
 
-export const PackageDescription: React.FC<{ data: IPackage; components: ComponentDoc[] }> = ({
-  data,
-  components
+export const Configuration: React.FC<{ reactPackage: IPackage; propSheets: ComponentDoc[] }> = ({
+  reactPackage,
+  propSheets
 }) => {
   return (
     <StyledUnorderedList>
       <StyledListItem>
         <StyledListItemLabel>Name</StyledListItemLabel>
         {/* This is showing the version on this page and not the latest available. Need to fix */}
-        <StyledSpan>{data.version}</StyledSpan>
+        <StyledSpan>{reactPackage.version}</StyledSpan>
         <StyledSpan>•</StyledSpan>
         <StyledSpan>
           <Anchor
-            href={`https://github.com/zendeskgarden/react-components/tree/master/packages/${data.packageName}`}
+            href={`https://github.com/zendeskgarden/react-components/tree/master/packages/${reactPackage.packageName}`}
             target="_blank"
           >
             View source
@@ -68,7 +68,7 @@ export const PackageDescription: React.FC<{ data: IPackage; components: Componen
         <StyledSpan>•</StyledSpan>
         <StyledSpan>
           <Anchor
-            href={`https://www.npmjs.com/package/@zendeskgarden/react-${data.packageName}`}
+            href={`https://www.npmjs.com/package/@zendeskgarden/react-${reactPackage.packageName}`}
             target="_blank"
           >
             View on NPM
@@ -77,16 +77,18 @@ export const PackageDescription: React.FC<{ data: IPackage; components: Componen
       </StyledListItem>
       <StyledListItem>
         <StyledListItemLabel>Install</StyledListItemLabel>
-        npm install {data.name}
+        npm install {reactPackage.name}
       </StyledListItem>
       <StyledListItem>
         <StyledListItemLabel>Deps</StyledListItemLabel>
-        npm install {data.peerDependencies.join(' ')}
+        npm install {reactPackage.peerDependencies.join(' ')}
       </StyledListItem>
       <StyledListItem>
         <StyledListItemLabel>Import</StyledListItemLabel>
-        import {`{ ${components && components.map(e => e.displayName).join(', ')} }`} from &apos;
-        {data.name}
+        import{' '}
+        {`{ ${propSheets && propSheets.map(propSheet => propSheet.displayName).join(', ')} }`} from
+        &apos;
+        {reactPackage.name}
         &apos;
       </StyledListItem>
     </StyledUnorderedList>

--- a/src/components/MarkdownProvider/components/Configuration.tsx
+++ b/src/components/MarkdownProvider/components/Configuration.tsx
@@ -12,16 +12,15 @@ import { Anchor } from '@zendeskgarden/react-buttons';
 import { getColor } from '@zendeskgarden/react-theming';
 import { ComponentDoc } from 'react-docgen-typescript';
 
-export interface IPackage {
+interface IPackage {
   version: string;
   name: string;
-  peerDependencies: string[];
   packageName: string;
 }
 
 const StyledUnorderedList = styled(UnorderedList)`
   margin: 0 0 ${p => p.theme.space.xxl};
-  border-bottom: ${p => `${p.theme.borders.sm} ${getColor('grey', 300, p.theme)}`};
+  border-bottom: ${p => `${p.theme.borders.sm} ${getColor('grey', 200, p.theme)}`};
 `;
 
 const StyledListItem = styled(UnorderedList.Item)`
@@ -29,9 +28,9 @@ const StyledListItem = styled(UnorderedList.Item)`
 
   & > div {
     display: flex;
-    margin: ${p => p.theme.space.sm} 0;
-    border-top: ${p => `${p.theme.borders.sm} ${getColor('grey', 300, p.theme)}`};
-    padding: ${p => p.theme.space.sm} 0 0;
+    margin: ${p => p.theme.space.base * 2.5}px 0;
+    border-top: ${p => `${p.theme.borders.sm} ${getColor('grey', 200, p.theme)}`};
+    padding: ${p => p.theme.space.base * 2.5}px 0 0;
     font-family: ${p => p.theme.fonts.mono};
   }
 `;
@@ -42,8 +41,8 @@ const StyledListItemLabel = styled.label`
   font-weight: ${p => p.theme.fontWeights.semibold};
 `;
 
-const StyledSpan = styled(Span)`
-  margin-right: ${p => p.theme.space.sm};
+const StyledDot = styled(Span)`
+  margin: 0 ${p => p.theme.space.sm};
 `;
 
 export const Configuration: React.FC<{ reactPackage: IPackage; propSheets: ComponentDoc[] }> = ({
@@ -54,25 +53,21 @@ export const Configuration: React.FC<{ reactPackage: IPackage; propSheets: Compo
     <StyledUnorderedList>
       <StyledListItem>
         <StyledListItemLabel>Name</StyledListItemLabel>
-        <StyledSpan>{reactPackage.version}</StyledSpan>
-        <StyledSpan>•</StyledSpan>
-        <StyledSpan>
-          <Anchor
-            href={`https://github.com/zendeskgarden/react-components/tree/master/packages/${reactPackage.packageName}`}
-            target="_blank"
-          >
-            View source
-          </Anchor>
-        </StyledSpan>
-        <StyledSpan>•</StyledSpan>
-        <StyledSpan>
-          <Anchor
-            href={`https://www.npmjs.com/package/@zendeskgarden/react-${reactPackage.packageName}`}
-            target="_blank"
-          >
-            View on NPM
-          </Anchor>
-        </StyledSpan>
+        {reactPackage.version}
+        <StyledDot>•</StyledDot>
+        <Anchor
+          href={`https://github.com/zendeskgarden/react-components/tree/master/packages/${reactPackage.packageName}`}
+          target="_blank"
+        >
+          View source
+        </Anchor>
+        <StyledDot>•</StyledDot>
+        <Anchor
+          href={`https://www.npmjs.com/package/@zendeskgarden/react-${reactPackage.packageName}`}
+          target="_blank"
+        >
+          View on NPM
+        </Anchor>
       </StyledListItem>
       <StyledListItem>
         <StyledListItemLabel>Install</StyledListItemLabel>
@@ -80,7 +75,7 @@ export const Configuration: React.FC<{ reactPackage: IPackage; propSheets: Compo
       </StyledListItem>
       <StyledListItem>
         <StyledListItemLabel>Deps</StyledListItemLabel>
-        npm install {reactPackage.peerDependencies.join(' ')}
+        npm install react react-dom prop-types styled-components @zendeskgarden/react-theming
       </StyledListItem>
       <StyledListItem>
         <StyledListItemLabel>Import</StyledListItemLabel>

--- a/src/components/MarkdownProvider/components/PackageDescription.tsx
+++ b/src/components/MarkdownProvider/components/PackageDescription.tsx
@@ -43,7 +43,7 @@ const StyledListItemLabel = styled.label`
 `;
 
 const StyledSpan = styled(Span)`
-  margin-right: 12px;
+  margin-right: ${p => p.theme.space.base * 3}px;
 `;
 
 export const PackageDescription: React.FC<{ data: IPackage; components: ComponentDoc[] }> = ({

--- a/src/components/MarkdownProvider/components/PackageDescription.tsx
+++ b/src/components/MarkdownProvider/components/PackageDescription.tsx
@@ -6,20 +6,69 @@
  */
 
 import React from 'react';
+import styled from 'styled-components';
 import { UnorderedList } from '@zendeskgarden/react-typography';
+import { getColor } from '@zendeskgarden/react-theming';
 
 export interface IPackage {
   version: string;
   name: string;
-  description: string;
 }
 
-export const PackageDescription: React.FC<{ data: IPackage }> = ({ data }) => {
+const StyledUnorderedList = styled(UnorderedList)`
+  margin: 0 0 ${p => p.theme.space.base * 12}px;
+`;
+
+const StyledListItem = styled(UnorderedList.Item)`
+  list-style: none;
+`;
+
+const StyledListItemRow = styled.div`
+  display: flex;
+  margin: 0 0 ${p => p.theme.space.base * 2}px;
+  border-bottom: solid 1px ${p => getColor('grey', 300, p.theme)};
+  padding: 0 0 ${p => p.theme.space.base * 2}px;
+  font-family: ${p => p.theme.fonts.mono};
+`;
+
+const StyledListItemLabel = styled.label`
+  min-width: ${p => p.theme.space.base * 20}px;
+  font-family: ${p => p.theme.fonts.system};
+  font-weight: ${p => p.theme.fontWeights.semibold};
+`;
+
+// The List.Item automatically creates a child div that is kind of annoying
+
+export const PackageDescription: React.FC<{ data: IPackage }> = ({ data }, props) => {
   return (
-    <UnorderedList>
-      <UnorderedList.Item>Name: {data.name}</UnorderedList.Item>
-      <UnorderedList.Item>Version: {data.version}</UnorderedList.Item>
-      <UnorderedList.Item>Description: {data.description}</UnorderedList.Item>
-    </UnorderedList>
+    <StyledUnorderedList>
+      <StyledListItem>
+        <StyledListItemRow>
+          <StyledListItemLabel>Name</StyledListItemLabel>
+          <p>
+            {data.version} • <a href="https://www.google.com">View source</a> •{' '}
+            <a href="https://www.google.com">View on NPM</a>
+          </p>
+        </StyledListItemRow>
+      </StyledListItem>
+      <StyledListItem>
+        <StyledListItemRow>
+          <StyledListItemLabel>Install</StyledListItemLabel>
+          npm install {data.name}
+        </StyledListItemRow>
+      </StyledListItem>
+      <StyledListItem>
+        <StyledListItemRow>
+          <StyledListItemLabel>Deps</StyledListItemLabel>
+          npm install <span>{props.deps}</span>
+        </StyledListItemRow>
+      </StyledListItem>
+      <StyledListItem>
+        <StyledListItemRow>
+          <StyledListItemLabel>Import</StyledListItemLabel>
+          import {data.name} from {data.name}
+        </StyledListItemRow>
+      </StyledListItem>
+    </StyledUnorderedList>
   );
 };

--- a/src/components/MarkdownProvider/components/PackageDescription.tsx
+++ b/src/components/MarkdownProvider/components/PackageDescription.tsx
@@ -7,31 +7,33 @@
 
 import React from 'react';
 import styled from 'styled-components';
-import { UnorderedList } from '@zendeskgarden/react-typography';
+import { UnorderedList, Span } from '@zendeskgarden/react-typography';
+import { Anchor } from '@zendeskgarden/react-buttons';
 import { getColor } from '@zendeskgarden/react-theming';
+import { ComponentDoc } from 'react-docgen-typescript';
 
 export interface IPackage {
   version: string;
   name: string;
   peerDependencies: string[];
+  packageName: string;
 }
 
 const StyledUnorderedList = styled(UnorderedList)`
   margin: 0 0 ${p => p.theme.space.base * 12}px;
+  border-bottom: solid 1px ${p => getColor('grey', 300, p.theme)};
 `;
 
 const StyledListItem = styled(UnorderedList.Item)`
   list-style: none;
-`;
 
-// Try to get rid of this extra div. Automatically creates a div in UL
-
-const StyledListItemRow = styled.div`
-  display: flex;
-  margin: 0 0 ${p => p.theme.space.base * 2}px;
-  border-bottom: solid 1px ${p => getColor('grey', 300, p.theme)};
-  padding: 0 0 ${p => p.theme.space.base * 2}px;
-  font-family: ${p => p.theme.fonts.mono};
+  & > :first-child {
+    display: flex;
+    margin: ${p => p.theme.space.base * 3}px 0;
+    border-top: solid 1px ${p => getColor('grey', 300, p.theme)};
+    padding: ${p => p.theme.space.base * 3}px 0 0;
+    font-family: ${p => p.theme.fonts.mono};
+  }
 `;
 
 const StyledListItemLabel = styled.label`
@@ -40,38 +42,52 @@ const StyledListItemLabel = styled.label`
   font-weight: ${p => p.theme.fontWeights.semibold};
 `;
 
-export const PackageDescription: React.FC<{ data: IPackage }> = ({ data }) => {
+const StyledSpan = styled(Span)`
+  margin-right: 12px;
+`;
+
+export const PackageDescription: React.FC<{ data: IPackage; components: ComponentDoc[] }> = ({
+  data,
+  components
+}) => {
   return (
     <StyledUnorderedList>
       <StyledListItem>
-        <StyledListItemRow>
-          <StyledListItemLabel>Name</StyledListItemLabel>
-          <span>
-            {data.version} •{' '}
-            <a href="https://github.com/zendeskgarden/react-components/tree/master/packages/avatars">
-              View source
-            </a>{' '}
-            • <a href="https://www.npmjs.com/package/@zendeskgarden/react-avatars">View on NPM</a>
-          </span>
-        </StyledListItemRow>
+        <StyledListItemLabel>Name</StyledListItemLabel>
+        {/* This is showing the version on this page and not the latest available. Need to fix */}
+        <StyledSpan>{data.version}</StyledSpan>
+        <StyledSpan>•</StyledSpan>
+        <StyledSpan>
+          <Anchor
+            href={`https://github.com/zendeskgarden/react-components/tree/master/packages/${data.packageName}`}
+            target="_blank"
+          >
+            View source
+          </Anchor>
+        </StyledSpan>
+        <StyledSpan>•</StyledSpan>
+        <StyledSpan>
+          <Anchor
+            href={`https://www.npmjs.com/package/@zendeskgarden/react-${data.packageName}`}
+            target="_blank"
+          >
+            View on NPM
+          </Anchor>
+        </StyledSpan>
       </StyledListItem>
       <StyledListItem>
-        <StyledListItemRow>
-          <StyledListItemLabel>Install</StyledListItemLabel>
-          npm install {data.name}
-        </StyledListItemRow>
+        <StyledListItemLabel>Install</StyledListItemLabel>
+        npm install {data.name}
       </StyledListItem>
       <StyledListItem>
-        <StyledListItemRow>
-          <StyledListItemLabel>Deps</StyledListItemLabel>
-          npm install {data.peerDependencies.join(' ')}
-        </StyledListItemRow>
+        <StyledListItemLabel>Deps</StyledListItemLabel>
+        npm install {data.peerDependencies.join(' ')}
       </StyledListItem>
       <StyledListItem>
-        <StyledListItemRow>
-          <StyledListItemLabel>Import</StyledListItemLabel>
-          import
-        </StyledListItemRow>
+        <StyledListItemLabel>Import</StyledListItemLabel>
+        import {`{ ${components && components.map(e => e.displayName).join(', ')} }`} from &apos;
+        {data.name}
+        &apos;
       </StyledListItem>
     </StyledUnorderedList>
   );

--- a/src/components/MarkdownProvider/components/PackageDescription.tsx
+++ b/src/components/MarkdownProvider/components/PackageDescription.tsx
@@ -13,6 +13,7 @@ import { getColor } from '@zendeskgarden/react-theming';
 export interface IPackage {
   version: string;
   name: string;
+  peerDependencies: string[];
 }
 
 const StyledUnorderedList = styled(UnorderedList)`
@@ -22,6 +23,8 @@ const StyledUnorderedList = styled(UnorderedList)`
 const StyledListItem = styled(UnorderedList.Item)`
   list-style: none;
 `;
+
+// Try to get rid of this extra div. Automatically creates a div in UL
 
 const StyledListItemRow = styled.div`
   display: flex;
@@ -37,18 +40,19 @@ const StyledListItemLabel = styled.label`
   font-weight: ${p => p.theme.fontWeights.semibold};
 `;
 
-// The List.Item automatically creates a child div that is kind of annoying
-
-export const PackageDescription: React.FC<{ data: IPackage }> = ({ data }, props) => {
+export const PackageDescription: React.FC<{ data: IPackage }> = ({ data }) => {
   return (
     <StyledUnorderedList>
       <StyledListItem>
         <StyledListItemRow>
           <StyledListItemLabel>Name</StyledListItemLabel>
-          <p>
-            {data.version} • <a href="https://www.google.com">View source</a> •{' '}
-            <a href="https://www.google.com">View on NPM</a>
-          </p>
+          <span>
+            {data.version} •{' '}
+            <a href="https://github.com/zendeskgarden/react-components/tree/master/packages/avatars">
+              View source
+            </a>{' '}
+            • <a href="https://www.npmjs.com/package/@zendeskgarden/react-avatars">View on NPM</a>
+          </span>
         </StyledListItemRow>
       </StyledListItem>
       <StyledListItem>
@@ -60,13 +64,13 @@ export const PackageDescription: React.FC<{ data: IPackage }> = ({ data }, props
       <StyledListItem>
         <StyledListItemRow>
           <StyledListItemLabel>Deps</StyledListItemLabel>
-          npm install <span>{props.deps}</span>
+          npm install {data.peerDependencies.join(' ')}
         </StyledListItemRow>
       </StyledListItem>
       <StyledListItem>
         <StyledListItemRow>
           <StyledListItemLabel>Import</StyledListItemLabel>
-          import {data.name} from {data.name}
+          import
         </StyledListItemRow>
       </StyledListItem>
     </StyledUnorderedList>

--- a/src/components/MarkdownProvider/components/PropSheets.tsx
+++ b/src/components/MarkdownProvider/components/PropSheets.tsx
@@ -13,11 +13,11 @@ import { Paragraph } from '@zendeskgarden/react-typography';
 import { Table, Head, Body, HeaderRow, HeaderCell, Row, Cell } from '@zendeskgarden/react-tables';
 import { StyledH3 } from './Typography';
 
-export const PropSheets: React.FC<{ data: ComponentDoc[] }> = ({ data }) => {
+export const PropSheets: React.FC<{ propSheets: ComponentDoc[] }> = ({ propSheets }) => {
   return (
     <>
-      {data &&
-        data.map((propSheet, index) => (
+      {propSheets &&
+        propSheets.map((propSheet, index) => (
           <div key={`${propSheet.displayName}-${index}`}>
             <StyledH3>{propSheet.displayName}</StyledH3>
             <Paragraph>{propSheet.description}</Paragraph>

--- a/src/components/MarkdownProvider/components/PropSheets.tsx
+++ b/src/components/MarkdownProvider/components/PropSheets.tsx
@@ -9,25 +9,17 @@ import React from 'react';
 import { css } from 'styled-components';
 import { ComponentDoc } from 'react-docgen-typescript';
 import { getColor } from '@zendeskgarden/react-theming';
-import { MD, Paragraph } from '@zendeskgarden/react-typography';
+import { Paragraph } from '@zendeskgarden/react-typography';
 import { Table, Head, Body, HeaderRow, HeaderCell, Row, Cell } from '@zendeskgarden/react-tables';
-
-import { IPackage } from './PackageDescription';
 import { StyledH3 } from './Typography';
 
-export const PropSheets: React.FC<{ data: ComponentDoc[]; reactPackage: IPackage }> = ({
-  data,
-  reactPackage
-}) => {
+export const PropSheets: React.FC<{ data: ComponentDoc[] }> = ({ data }) => {
   return (
     <>
       {data &&
         data.map((propSheet, index) => (
           <div key={`${propSheet.displayName}-${index}`}>
             <StyledH3>{propSheet.displayName}</StyledH3>
-            <MD isMonospace>
-              import {`{${propSheet.displayName}}`} from &quot;{reactPackage.name}&quot;;
-            </MD>
             <Paragraph>{propSheet.description}</Paragraph>
             <Table>
               <Head>

--- a/src/components/MarkdownProvider/index.tsx
+++ b/src/components/MarkdownProvider/index.tsx
@@ -10,7 +10,7 @@ import { createGlobalStyle } from 'styled-components';
 import { MDXProvider } from '@mdx-js/react';
 import { Code, Paragraph } from '@zendeskgarden/react-typography';
 import { CodeExample } from './components/CodeExample';
-import { PackageDescription } from './components/PackageDescription';
+import { Configuration } from './components/Configuration';
 import { PropSheets } from './components/PropSheets';
 import { Usage, Use, Misuse } from './components/Usage';
 import { BestPractice, Do, Dont, Caution } from './components/BestPractice';
@@ -66,7 +66,7 @@ export const MarkdownProvider: React.FC = ({ children }) => (
          * Helper components
          */
         CodeExample,
-        PackageDescription,
+        Configuration,
         PropSheets,
         Usage,
         Use,

--- a/src/pages/components/anchor.mdx
+++ b/src/pages/components/anchor.mdx
@@ -63,7 +63,7 @@ import AnchorDangerCode from '!!raw-loader!../../examples/anchor/AnchorDanger.ts
 
 ## Configuration
 
-<PackageDescription data={props.data.mdx.package} />
+<Configuration reactPackage={props.data.mdx.package} propSheets={props.data.mdx.propsSheets} />
 
 ## API
 

--- a/src/pages/components/anchor.mdx
+++ b/src/pages/components/anchor.mdx
@@ -67,7 +67,7 @@ import AnchorDangerCode from '!!raw-loader!../../examples/anchor/AnchorDanger.ts
 
 ## API
 
-<PropSheets data={props.data.mdx.propsSheets} reactPackage={props.data.mdx.package} />
+<PropSheets propSheets={props.data.mdx.propsSheets} />
 
 import { graphql } from 'gatsby';
 

--- a/src/pages/components/avatar.mdx
+++ b/src/pages/components/avatar.mdx
@@ -82,11 +82,11 @@ This helps the user quickly distinguish between a person or a system when scanni
 
 ## Configuration
 
-<PackageDescription data={props.data.mdx.package} />
+<PackageDescription data={props.data.mdx.package} components={props.data.mdx.propsSheets} />
 
 ## API
 
-<PropSheets data={props.data.mdx.propsSheets} reactPackage={props.data.mdx.package} />
+<PropSheets data={props.data.mdx.propsSheets} />
 
 import { graphql } from 'gatsby';
 

--- a/src/pages/components/avatar.mdx
+++ b/src/pages/components/avatar.mdx
@@ -82,11 +82,11 @@ This helps the user quickly distinguish between a person or a system when scanni
 
 ## Configuration
 
-<PackageDescription data={props.data.mdx.package} components={props.data.mdx.propsSheets} />
+<Configuration reactPackage={props.data.mdx.package} propSheets={props.data.mdx.propsSheets} />
 
 ## API
 
-<PropSheets data={props.data.mdx.propsSheets} />
+<PropSheets propSheets={props.data.mdx.propsSheets} />
 
 import { graphql } from 'gatsby';
 

--- a/src/pages/components/breadcrumbs.mdx
+++ b/src/pages/components/breadcrumbs.mdx
@@ -29,7 +29,7 @@ import BreadcrumbsDefaultCode from '!!raw-loader!../../examples/breadcrumbs/Brea
 
 ## Configuration
 
-<PackageDescription data={props.data.mdx.package} />
+<Configuration reactPackage={props.data.mdx.package} propSheets={props.data.mdx.propsSheets} />
 
 import { graphql } from 'gatsby';
 

--- a/src/pages/components/button.mdx
+++ b/src/pages/components/button.mdx
@@ -63,11 +63,11 @@ Mark a button disabled with the disabled property.
 
 ## Configuration
 
-<PackageDescription data={props.data.mdx.package} components={props.data.mdx.propsSheets} />
+<Configuration reactPackage={props.data.mdx.package} propSheets={props.data.mdx.propsSheets} />
 
 ## API
 
-<PropSheets data={props.data.mdx.propsSheets} />
+<PropSheets propSheets={props.data.mdx.propsSheets} />
 
 import { graphql } from 'gatsby';
 

--- a/src/pages/components/button.mdx
+++ b/src/pages/components/button.mdx
@@ -63,11 +63,11 @@ Mark a button disabled with the disabled property.
 
 ## Configuration
 
-<PackageDescription data={props.data.mdx.package} />
+<PackageDescription data={props.data.mdx.package} components={props.data.mdx.propsSheets} />
 
 ## API
 
-<PropSheets data={props.data.mdx.propsSheets} reactPackage={props.data.mdx.package} />
+<PropSheets data={props.data.mdx.propsSheets} />
 
 import { graphql } from 'gatsby';
 

--- a/src/pages/components/button.mdx
+++ b/src/pages/components/button.mdx
@@ -61,13 +61,12 @@ import ButtonDangerCode from '!!raw-loader!../../examples/button/ButtonDanger.ts
 Mark a button disabled with the disabled property.
 [Read more about disabled state usage](#todo)
 
-## Best practices
-
-### Writing button labels
-
-## Package
+## Configuration
 
 <PackageDescription data={props.data.mdx.package} />
+
+## API
+
 <PropSheets data={props.data.mdx.propsSheets} reactPackage={props.data.mdx.package} />
 
 import { graphql } from 'gatsby';

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -36,6 +36,7 @@ export const SidebarPageFragment = graphql`
         version
         name
         description
+        peerDependencies
       }
       propsSheets: reactPropSheets {
         displayName

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -37,6 +37,7 @@ export const SidebarPageFragment = graphql`
         name
         description
         peerDependencies
+        packageName
       }
       propsSheets: reactPropSheets {
         displayName

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -36,7 +36,6 @@ export const SidebarPageFragment = graphql`
         version
         name
         description
-        peerDependencies
         packageName
       }
       propsSheets: reactPropSheets {


### PR DESCRIPTION
<!-- structure the Title above as the first line of a
  https://conventionalcommits.org/ message. example: "chore:
  add a new 'thing' component page". -->

## Description

This PR introduces the configuration section styling and logic into the component pages. 

## Detail

1. The `UnorderedList.Item` component renders a wrapping child div. Instead of creating an additional wrapping element for Flex styling, we styled the child div with Flex styles using `& > div` CSS selector
1. The Configuration and API section props and component names were getting a little confusing. The names were revised a bit to [more accurately reflect what they are for.](https://github.com/zendeskgarden/website/compare/rmoody/configuration?expand=1#diff-0b9a85d38fa919055fd1752418521e3aR85)

<!-- supporting details; screen shot, code, etc. -->

<!-- closes GITHUB_ISSUE -->

## Checklist

- [ ] :ok_hand: website updates are Garden Designer approved (add the designer as a reviewer)
- [ ] :black_nib: copy updates are approved (add the content strategist as a reviewer)
- [x] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [x] :zap: audited via [web.dev](http://localhost:8000/components/button//) for performance and SEO
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
