### PR TITLE
chore: information architecture links

### DIFF
--- a/content/news/news.yml
+++ b/content/news/news.yml
@@ -17,3 +17,8 @@
   author: Ross Moody
   author_url: https://medium.com/@moodyrooster
   url: https://medium.com/zendesk-creative-blog/6-tips-for-writing-effective-design-system-documentation-11c35b44169
+
+- title: Designing for inclusivity
+  author: Allison Shaw
+  author_url: https://www.invisionapp.com/inside-design/author/allison-shaw/
+  url: https://www.invisionapp.com/inside-design/designing-for-inclusivity/

--- a/src/layouts/Home/components/News.tsx
+++ b/src/layouts/Home/components/News.tsx
@@ -8,7 +8,7 @@
 import React from 'react';
 import { useStaticQuery, graphql } from 'gatsby';
 import styled, { css } from 'styled-components';
-import { getColor, PALETTE } from '@zendeskgarden/react-theming';
+import { getColor } from '@zendeskgarden/react-theming';
 import { Grid, Row, Col } from '@zendeskgarden/react-grid';
 import { XXL } from '@zendeskgarden/react-typography';
 import { Anchor } from '@zendeskgarden/react-buttons';

--- a/src/layouts/Home/components/News.tsx
+++ b/src/layouts/Home/components/News.tsx
@@ -49,7 +49,7 @@ export const News: React.FC = () => {
           right: 50%;
           bottom: 0;
           left: 0;
-          background-color: ${PALETTE.green[200]};
+          background-color: ${p => getColor('grey', 200, p.theme)};
 
           @media (max-width: ${p => p.theme.breakpoints.lg}) {
             display: none;

--- a/src/layouts/Home/components/News.tsx
+++ b/src/layouts/Home/components/News.tsx
@@ -74,9 +74,6 @@ export const News: React.FC = () => {
         <Grid gutters="lg">
           <Row>
             <Col
-              sm={12}
-              md={12}
-              lg={8}
               css={css`
                 background-color: ${p => getColor('grey', 200, p.theme)};
                 padding: ${p => p.theme.space.xxl};
@@ -88,7 +85,7 @@ export const News: React.FC = () => {
                   return (
                     <Col
                       key={`${edge.node.url}-${index}`}
-                      sm={6}
+                      sm={4}
                       css={css`
                         margin-bottom: ${p => p.theme.space.lg};
                       `}

--- a/src/layouts/Home/components/News.tsx
+++ b/src/layouts/Home/components/News.tsx
@@ -75,29 +75,10 @@ export const News: React.FC = () => {
           <Row>
             <Col
               sm={12}
-              md={6}
-              lg={4}
-              css={css`
-                background-color: ${PALETTE.green[200]};
-                padding-top: ${p => p.theme.space.xxl};
-                padding-right: ${p => p.theme.space.xxl};
-                padding-bottom: ${p => p.theme.space.xxl};
-
-                @media (max-width: ${p => p.theme.breakpoints.md}) {
-                  padding: ${p => p.theme.space.xxl};
-                }
-              `}
-            >
-              <StyledSectionHeader>Site Updates</StyledSectionHeader>
-              <p>TODO</p>
-            </Col>
-            <Col
-              sm={12}
-              md={6}
+              md={12}
               lg={8}
               css={css`
                 background-color: ${p => getColor('grey', 200, p.theme)};
-
                 padding: ${p => p.theme.space.xxl};
               `}
             >

--- a/src/layouts/Home/components/Search.tsx
+++ b/src/layouts/Home/components/Search.tsx
@@ -100,7 +100,7 @@ export const Search: React.FC = () => {
                     ${headerStyling}
                   `}
                 >
-                  Search the Garden
+                  Welcome to Garden
                 </h1>
                 <LG
                   tag="p"
@@ -112,7 +112,7 @@ export const Search: React.FC = () => {
                   The source of truth for tools, standards, and best practices when building
                   products at Zendesk.
                 </LG>
-                <div
+                {/* <div
                   css={css`
                     width: 340px;
 
@@ -126,7 +126,7 @@ export const Search: React.FC = () => {
                     aria-label="Garden search"
                     start={<SearchStroke />}
                   />
-                </div>
+                </div> */}
               </div>
             </Col>
           </Row>

--- a/src/layouts/Home/components/Search.tsx
+++ b/src/layouts/Home/components/Search.tsx
@@ -9,9 +9,9 @@ import React from 'react';
 import Img from 'gatsby-image';
 import { css, ThemeProps, DefaultTheme } from 'styled-components';
 import { Grid, Row, Col } from '@zendeskgarden/react-grid';
-import { MediaInput } from '@zendeskgarden/react-forms';
+// import { MediaInput } from '@zendeskgarden/react-forms';
 import { LG } from '@zendeskgarden/react-typography';
-import { ReactComponent as SearchStroke } from '@zendeskgarden/svg-icons/src/16/search-stroke.svg';
+// import { ReactComponent as SearchStroke } from '@zendeskgarden/svg-icons/src/16/search-stroke.svg';
 
 import MaxWidthLayout from 'layouts/MaxWidth';
 import { useStaticQuery, graphql } from 'gatsby';

--- a/src/layouts/Home/index.tsx
+++ b/src/layouts/Home/index.tsx
@@ -8,7 +8,7 @@
 import React from 'react';
 import { Search } from './components/Search';
 import { Foundation } from './components/Foundation';
-import { Patterns } from './components/Patterns';
+// import { Patterns } from './components/Patterns';
 import { News } from './components/News';
 
 const HomeLayout: React.FC = () => {
@@ -16,7 +16,7 @@ const HomeLayout: React.FC = () => {
     <>
       <Search />
       <Foundation />
-      <Patterns />
+      {/* <Patterns /> */}
       <News />
     </>
   );

--- a/src/layouts/Root/components/Footer.tsx
+++ b/src/layouts/Root/components/Footer.tsx
@@ -6,15 +6,11 @@
  */
 
 import React from 'react';
-import styled, { css } from 'styled-components';
+import { css } from 'styled-components';
 import { math } from 'polished';
 import { getColor } from '@zendeskgarden/react-theming';
 import { ReactComponent as GardenIcon } from '@zendeskgarden/svg-icons/src/26/garden.svg';
 import MaxWidthLayout from 'layouts/MaxWidth';
-
-const StyledFooterItem = styled.div`
-  margin-right: ${p => p.theme.space.lg};
-`;
 
 const Footer: React.FC = () => (
   <footer
@@ -27,25 +23,6 @@ const Footer: React.FC = () => (
     `}
   >
     <MaxWidthLayout>
-      <div
-        css={css`
-          display: flex;
-          padding-bottom: ${p => p.theme.space.md};
-
-          @media (max-width: ${p => p.theme.breakpoints.md}) {
-            flex-direction: column;
-            padding-left: ${p => math(`${p.theme.iconSizes.md} + ${p.theme.space.md}`)};
-            text-align: center;
-          }
-        `}
-      >
-        <StyledFooterItem>Site Updates</StyledFooterItem>
-        <StyledFooterItem>License</StyledFooterItem>
-        <StyledFooterItem>Contribute</StyledFooterItem>
-        <StyledFooterItem>Blog</StyledFooterItem>
-        <StyledFooterItem>Github</StyledFooterItem>
-        <StyledFooterItem>v8.x.x</StyledFooterItem>
-      </div>
       <div
         css={css`
           display: flex;

--- a/src/layouts/Root/components/Footer.tsx
+++ b/src/layouts/Root/components/Footer.tsx
@@ -6,11 +6,18 @@
  */
 
 import React from 'react';
-import { css } from 'styled-components';
+import styled, { css } from 'styled-components';
 import { math } from 'polished';
 import { getColor } from '@zendeskgarden/react-theming';
 import { ReactComponent as GardenIcon } from '@zendeskgarden/svg-icons/src/26/garden.svg';
+import { Link } from './StyledNavigationLink'
 import MaxWidthLayout from 'layouts/MaxWidth';
+
+const StyledFooterItem = styled(Link)`
+  margin-right: ${ p => p.theme.space.lg};
+  color: ${ p => p.theme.colors.background};
+  cursor: pointer;
+`;
 
 const Footer: React.FC = () => (
   <footer
@@ -26,11 +33,25 @@ const Footer: React.FC = () => (
       <div
         css={css`
           display: flex;
+          padding-bottom: ${p => p.theme.space.md};
+          @media (max-width: ${p => p.theme.breakpoints.md}) {
+            flex-direction: column;
+            padding-left: ${p => math(`${p.theme.iconSizes.md} + ${p.theme.space.md}`)};
+            text-align: center;
+          }
+        `}
+      >
+        <StyledFooterItem to='https://design.zendesk.com'>Blog</StyledFooterItem>
+        <StyledFooterItem to='https://www.github.com/zendeskgarden/react-components'>GitHub</StyledFooterItem>
+        <StyledFooterItem to='/components/versions'>Versions</StyledFooterItem>
+      </div>
+      <div
+        css={css`
+          display: flex;
           flex-wrap: wrap;
           align-items: center;
           border-top: ${p => p.theme.borders.sm} ${p => getColor('kale', 500, p.theme)};
           padding-top: ${p => p.theme.space.md};
-
           @media (max-width: ${p => p.theme.breakpoints.md}) {
             flex-direction: column;
             align-items: center;
@@ -42,7 +63,6 @@ const Footer: React.FC = () => (
           css={css`
             display: flex;
             align-items: center;
-
             @media (max-width: ${p => p.theme.breakpoints.md}) {
               margin-bottom: ${p => p.theme.space.md};
             }
@@ -79,7 +99,7 @@ const Footer: React.FC = () => (
         </div>
       </div>
     </MaxWidthLayout>
-  </footer>
+  </footer >
 );
 
 export default Footer;

--- a/src/layouts/Root/components/Footer.tsx
+++ b/src/layouts/Root/components/Footer.tsx
@@ -15,7 +15,6 @@ import MaxWidthLayout from 'layouts/MaxWidth';
 
 const StyledFooterItem = styled(Link)`
   margin-right: ${p => p.theme.space.lg};
-  cursor: pointer;
   color: ${p => p.theme.palette.white};
 `;
 

--- a/src/layouts/Root/components/Footer.tsx
+++ b/src/layouts/Root/components/Footer.tsx
@@ -16,7 +16,7 @@ import MaxWidthLayout from 'layouts/MaxWidth';
 const StyledFooterItem = styled(Link)`
   margin-right: ${p => p.theme.space.lg};
   cursor: pointer;
-  color: ${p => p.theme.colors.background};
+  color: ${p => p.theme.palette.white};
 `;
 
 const Footer: React.FC = () => (

--- a/src/layouts/Root/components/Footer.tsx
+++ b/src/layouts/Root/components/Footer.tsx
@@ -10,13 +10,13 @@ import styled, { css } from 'styled-components';
 import { math } from 'polished';
 import { getColor } from '@zendeskgarden/react-theming';
 import { ReactComponent as GardenIcon } from '@zendeskgarden/svg-icons/src/26/garden.svg';
-import { Link } from './StyledNavigationLink'
+import { Link } from './StyledNavigationLink';
 import MaxWidthLayout from 'layouts/MaxWidth';
 
 const StyledFooterItem = styled(Link)`
-  margin-right: ${ p => p.theme.space.lg};
-  color: ${ p => p.theme.colors.background};
+  margin-right: ${p => p.theme.space.lg};
   cursor: pointer;
+  color: ${p => p.theme.colors.background};
 `;
 
 const Footer: React.FC = () => (
@@ -41,9 +41,11 @@ const Footer: React.FC = () => (
           }
         `}
       >
-        <StyledFooterItem to='https://design.zendesk.com'>Blog</StyledFooterItem>
-        <StyledFooterItem to='https://www.github.com/zendeskgarden/react-components'>GitHub</StyledFooterItem>
-        <StyledFooterItem to='/components/versions'>Versions</StyledFooterItem>
+        <StyledFooterItem to="https://design.zendesk.com">Blog</StyledFooterItem>
+        <StyledFooterItem to="https://www.github.com/zendeskgarden/react-components">
+          GitHub
+        </StyledFooterItem>
+        <StyledFooterItem to="/components/versions">Versions</StyledFooterItem>
       </div>
       <div
         css={css`
@@ -99,7 +101,7 @@ const Footer: React.FC = () => (
         </div>
       </div>
     </MaxWidthLayout>
-  </footer >
+  </footer>
 );
 
 export default Footer;

--- a/src/layouts/Root/components/Header.tsx
+++ b/src/layouts/Root/components/Header.tsx
@@ -151,6 +151,16 @@ const MobileNavButton: React.FC<
   );
 };
 
+/* Temporary empty placeholder div with explicit button dimensions for search functionality on mobile */
+const TemporaryBox = styled.div`
+  width: 60px;
+  height: 60px;
+
+  @media (min-width: ${p => p.theme.breakpoints.md}) {
+    display: none;
+  }
+`;
+
 const StyledMobileNavLink = styled(StyledNavigationLink).attrs({ partiallyActive: true })`
   display: block;
   margin-top: ${p => p.theme.space.base * 2}px;
@@ -239,7 +249,7 @@ const Header: React.FC = () => {
             min-height: 100%;
           `}
         >
-          <MobileNavButton
+          {/* <MobileNavButton
             icon={<SearchStroke />}
             label="Search"
             isExpanded={isSearchVisible}
@@ -250,7 +260,8 @@ const Header: React.FC = () => {
                 setIsNavigationVisible(false);
               }
             }}
-          />
+          /> */}
+          <TemporaryBox />
           {!isSearchVisible && <Logo />}
           {isSearchVisible && <MobileSearch ref={inputRef} />}
           <MobileNavButton

--- a/src/layouts/Root/components/Header.tsx
+++ b/src/layouts/Root/components/Header.tsx
@@ -181,7 +181,7 @@ const MobileNav: React.FC = () => {
       <StyledMobileNavLink to="/content">Content</StyledMobileNavLink>
       <StyledMobileNavLink to="/design">Design</StyledMobileNavLink>
       <StyledMobileNavLink to="/components">Components</StyledMobileNavLink>
-      <StyledMobileNavLink to="/patterns">Patterns</StyledMobileNavLink>
+      {/* <StyledMobileNavLink to="/patterns">Patterns</StyledMobileNavLink> */}
     </div>
   );
 };
@@ -209,12 +209,12 @@ const DesktopNav: React.FC = () => (
     <StyledDesktopNavItem>
       <StyledDesktopNavLink to="/components">Components</StyledDesktopNavLink>
     </StyledDesktopNavItem>
-    <StyledDesktopNavItem>
+    {/* <StyledDesktopNavItem>
       <StyledDesktopNavLink to="/patterns">Patterns</StyledDesktopNavLink>
-    </StyledDesktopNavItem>
+    </StyledDesktopNavItem> 
     <StyledDesktopNavItem>
       <SearchInput />
-    </StyledDesktopNavItem>
+    </StyledDesktopNavItem> */}
   </nav>
 );
 

--- a/src/layouts/Root/components/StyledNavigationLink.tsx
+++ b/src/layouts/Root/components/StyledNavigationLink.tsx
@@ -13,10 +13,10 @@ import { getColor } from '@zendeskgarden/react-theming';
 interface ILink {
   children: string;
   to: string;
-  activeClassName: string;
+  activeClassName?: string;
 }
 
-const Link = ({ children, to, ...props }: ILink) => {
+export const Link = ({ children, to, ...props }: ILink) => {
   const internal = /^\/(?!\/)/u.test(to);
 
   if (internal) {

--- a/src/layouts/Root/components/StyledNavigationLink.tsx
+++ b/src/layouts/Root/components/StyledNavigationLink.tsx
@@ -5,9 +5,34 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
+import React from 'react';
 import styled from 'styled-components';
-import { Link } from 'gatsby';
+import { Link as GatsbyLink } from 'gatsby';
 import { getColor } from '@zendeskgarden/react-theming';
+
+interface ILink {
+  children: string;
+  to: string;
+  activeClassName: string;
+}
+
+const Link = ({ children, to, ...props }: ILink) => {
+  const internal = /^\/(?!\/)/u.test(to);
+
+  if (internal) {
+    return (
+      <GatsbyLink to={to} {...props}>
+        {children}
+      </GatsbyLink>
+    );
+  }
+
+  return (
+    <a href={to} {...props}>
+      {children}
+    </a>
+  );
+};
 
 export const StyledNavigationLink = styled(Link).attrs(p => ({
   activeClassName: p.activeClassName || 'is-current'

--- a/src/layouts/Sidebar/components/MobileSidebar.tsx
+++ b/src/layouts/Sidebar/components/MobileSidebar.tsx
@@ -100,6 +100,7 @@ export const MobileSidebar: React.FC<{ sidebar: ISidebarSection[] }> = ({ sideba
         left: 0;
         background-color: ${p => p.theme.palette.tofu};
         padding: ${p => p.theme.space.lg} ${p => p.theme.space.xxl};
+        overflow: scroll;
 
         @media (max-width: ${p => p.theme.breakpoints.md}) {
           top: ${p => p.theme.space.base * 15}px;

--- a/src/nav/components.yml
+++ b/src/nav/components.yml
@@ -2,8 +2,18 @@
   items:
     - id: /components
       title: Overview
+- title: Foundations
+  items:
+    - id: /components/versions
+      title: Versions
+    - id: https://zendeskgarden.github.io/react-containers
+      title: Containers
+    - id: https://zendeskgarden.github.io/react-components/theming
+      title: Theme
 - title: Components
   items:
+    - title: Accordion
+      id: https://zendeskgarden.github.io/react-components/accordions
     - title: Avatar
       id: /components/avatar
     - title: Breadcrumbs
@@ -14,11 +24,75 @@
           title: Anchor
         - id: /components/button
           title: Button
+        - id: /components/button-group
+          title: Button Group
+        - id: /components/split-button
+          title: Split Button
+        - id: /components/icon-button
+          title: Icon Button
+    - title: Chrome
+      id: https://zendeskgarden.github.io/react-components/chrome
+    - title: Datepicker
+      id: https://zendeskgarden.github.io/react-components/datepickers
     - title: Dropdowns
       items:
-        - id: /components/select
-          title: Select
+        - id: /components/autocomplete
+          title: Autocomplete
+        - id: /components/menu
+          title: Menu
         - id: /components/multiselect
           title: Multiselect
+        - id: /components/select
+          title: Select
+    - title: Grid
+      id: https://zendeskgarden.github.io/react-components/grid
+    - title: Forms
+      items:
+        - id: /components/checkbox
+          title: Checkbox
+        - id: /components/radio
+          title: Radio
+        - id: /components/range
+          title: Range
+        - id: /components/text-input
+          title: Text input
+        - id: /components/toggle
+          title: Toggle
+    - title: Loaders
+      items:
+        - id: https://zendeskgarden.github.io/react-components/grid
+          title: Dots
+        - id: https://zendeskgarden.github.io/react-components/grid
+          title: Progress
+        - id: https://zendeskgarden.github.io/react-components/grid
+          title: Skeleton
+        - id: https://zendeskgarden.github.io/react-components/grid
+          title: Spinner
+        - id: https://zendeskgarden.github.io/react-components/grid
+          title: Inline
+    - title: Modal
+      id: https://zendeskgarden.github.io/react-components/modals
+    - title: Notification
+      items:
+        - id: https://zendeskgarden.github.io/react-components/notifications
+          title: Alert
+        - id: https://zendeskgarden.github.io/react-components/notifications
+          title: Notification
+    - title: Pagination
+      id: https://zendeskgarden.github.io/react-components/pagination
+    - title: Stepper
+      id: https://zendeskgarden.github.io/react-components/accordions/#stepper
+    - title: Table
+      id: https://zendeskgarden.github.io/react-components/tables
     - title: Tabs
       id: /components/tabs
+    - title: Tags
+      id: https://zendeskgarden.github.io/react-components/tags
+    - title: Tiles
+      id: https://zendeskgarden.github.io/react-components/forms/#tiles
+    - title: Tooltip
+      id: https://zendeskgarden.github.io/react-components/tooltips
+    - title: Typography
+      id: /components/typography
+    - title: Well
+      id: https://zendeskgarden.github.io/react-components/notifications

--- a/src/nav/components.yml
+++ b/src/nav/components.yml
@@ -60,15 +60,15 @@
           title: Toggle
     - title: Loaders
       items:
-        - id: https://zendeskgarden.github.io/react-components/grid
+        - id: https://zendeskgarden.github.io/react-components/loaders
           title: Dots
-        - id: https://zendeskgarden.github.io/react-components/grid
+        - id: https://zendeskgarden.github.io/react-components/loaders
           title: Progress
-        - id: https://zendeskgarden.github.io/react-components/grid
+        - id: https://zendeskgarden.github.io/react-components/loaders
           title: Skeleton
-        - id: https://zendeskgarden.github.io/react-components/grid
+        - id: https://zendeskgarden.github.io/react-components/loaders
           title: Spinner
-        - id: https://zendeskgarden.github.io/react-components/grid
+        - id: https://zendeskgarden.github.io/react-components/loaders
           title: Inline
     - title: Modal
       id: https://zendeskgarden.github.io/react-components/modals

--- a/src/nav/design.yml
+++ b/src/nav/design.yml
@@ -17,4 +17,4 @@
         - id: /design/icons/wordmarks
           title: Wordmarks
     - title: Color
-      id: https://garden.zendesk.com/css-components/utilities/color/
+      id: https://zendeskgarden.github.io/react-components/theming/#!/PALETTE

--- a/src/nav/design.yml
+++ b/src/nav/design.yml
@@ -16,3 +16,5 @@
           title: 26px
         - id: /design/icons/wordmarks
           title: Wordmarks
+    - title: Color
+      id: https://garden.zendesk.com/css-components/utilities/color/

--- a/src/pages/components/autocomplete.mdx
+++ b/src/pages/components/autocomplete.mdx
@@ -1,0 +1,15 @@
+---
+title: Autocomplete
+description: >
+  Description will be here
+---
+
+Content here
+
+import { graphql } from 'gatsby';
+
+export const pageQuery = graphql`
+  query($fileAbsolutePath: String) {
+    ...SidebarPageFragment
+  }
+`;

--- a/src/pages/components/button-group.mdx
+++ b/src/pages/components/button-group.mdx
@@ -1,0 +1,15 @@
+---
+title: Button Group
+description: >
+  Description will be here
+---
+
+Content here
+
+import { graphql } from 'gatsby';
+
+export const pageQuery = graphql`
+  query($fileAbsolutePath: String) {
+    ...SidebarPageFragment
+  }
+`;

--- a/src/pages/components/checkbox.mdx
+++ b/src/pages/components/checkbox.mdx
@@ -1,0 +1,15 @@
+---
+title: Checkbox
+description: >
+  Description will be here
+---
+
+Content here
+
+import { graphql } from 'gatsby';
+
+export const pageQuery = graphql`
+  query($fileAbsolutePath: String) {
+    ...SidebarPageFragment
+  }
+`;

--- a/src/pages/components/icon-button.mdx
+++ b/src/pages/components/icon-button.mdx
@@ -1,0 +1,15 @@
+---
+title: Icon Button
+description: >
+  Description will be here
+---
+
+Content here
+
+import { graphql } from 'gatsby';
+
+export const pageQuery = graphql`
+  query($fileAbsolutePath: String) {
+    ...SidebarPageFragment
+  }
+`;

--- a/src/pages/components/menu.mdx
+++ b/src/pages/components/menu.mdx
@@ -1,0 +1,15 @@
+---
+title: Menu
+description: >
+  Description will be here
+---
+
+Content here
+
+import { graphql } from 'gatsby';
+
+export const pageQuery = graphql`
+  query($fileAbsolutePath: String) {
+    ...SidebarPageFragment
+  }
+`;

--- a/src/pages/components/radio.mdx
+++ b/src/pages/components/radio.mdx
@@ -1,0 +1,15 @@
+---
+title: Radio
+description: >
+  Description will be here
+---
+
+Content here
+
+import { graphql } from 'gatsby';
+
+export const pageQuery = graphql`
+  query($fileAbsolutePath: String) {
+    ...SidebarPageFragment
+  }
+`;

--- a/src/pages/components/range.mdx
+++ b/src/pages/components/range.mdx
@@ -1,0 +1,15 @@
+---
+title: Range
+description: >
+  Description will be here
+---
+
+Content here
+
+import { graphql } from 'gatsby';
+
+export const pageQuery = graphql`
+  query($fileAbsolutePath: String) {
+    ...SidebarPageFragment
+  }
+`;

--- a/src/pages/components/split-button.mdx
+++ b/src/pages/components/split-button.mdx
@@ -1,0 +1,15 @@
+---
+title: Split Button
+description: >
+  Description will be here
+---
+
+Content here
+
+import { graphql } from 'gatsby';
+
+export const pageQuery = graphql`
+  query($fileAbsolutePath: String) {
+    ...SidebarPageFragment
+  }
+`;

--- a/src/pages/components/text-input.mdx
+++ b/src/pages/components/text-input.mdx
@@ -1,0 +1,15 @@
+---
+title: Text input
+description: >
+  Description will be here
+---
+
+Content here
+
+import { graphql } from 'gatsby';
+
+export const pageQuery = graphql`
+  query($fileAbsolutePath: String) {
+    ...SidebarPageFragment
+  }
+`;

--- a/src/pages/components/toggle.mdx
+++ b/src/pages/components/toggle.mdx
@@ -1,0 +1,15 @@
+---
+title: Toggle
+description: >
+  Description will be here
+---
+
+Content here
+
+import { graphql } from 'gatsby';
+
+export const pageQuery = graphql`
+  query($fileAbsolutePath: String) {
+    ...SidebarPageFragment
+  }
+`;

--- a/src/pages/components/typography.mdx
+++ b/src/pages/components/typography.mdx
@@ -1,0 +1,16 @@
+---
+title: Typography
+
+description: >
+  Description will be here
+---
+
+Content here
+
+import { graphql } from 'gatsby';
+
+export const pageQuery = graphql`
+  query($fileAbsolutePath: String) {
+    ...SidebarPageFragment
+  }
+`;

--- a/src/pages/components/versions.mdx
+++ b/src/pages/components/versions.mdx
@@ -1,0 +1,18 @@
+---
+title: Versions
+description: >
+  Description will be here
+---
+
+Garden website release documentation
+
+- [Versions 7](https://garden-v7.netlify.app/)
+- [Versions 6](https://garden-v6.netlify.app/)
+
+import { graphql } from 'gatsby';
+
+export const pageQuery = graphql`
+  query($fileAbsolutePath: String) {
+    ...SidebarPageFragment
+  }
+`;


### PR DESCRIPTION
## Description
This PR aims to have every link on the site that is to be in the MVP represented and with a legitimate endpoint (whether on this site or the old). 

<!-- a summary of the changes introduced by this PR. this description
     may populate the commit body if the PR is merged. -->

## Detail

1. I had to write a little logic to get the sidebar links to style and function correctly depending on whether they are an `<a>` or a Gatsby Link. Gatsby `<Link>` components only allow for internal linking. Very open to feedback on that implementation as it was a smidge outside my comfort zone (especially the types). 
2. On the homepage I omitted the "Site news" section as that won't be represented.
4. Pages that are for on the MVP site but aren't ready yet I created blank placeholder pages. 
5. I think the Content section is still set to be revised a little depending on @vsri1137 direction, but it's pretty close.
6. I created a Versions page to link to v6 and v7 versions of the old site in the Components section. This will need written but depending on how it's received here I will add that task to 1280. 

<!-- supporting details; screen shot, code, etc. -->

<!-- closes GITHUB_ISSUE -->

## Checklist

- [ ] :ok_hand: website updates are Garden Designer approved (add the designer as a reviewer)
- [ ] :black_nib: copy updates are approved (add the content strategist as a reviewer)
- [ ] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [ ] :zap: audited via [web.dev](https://web.dev/measure/) for performance and SEO
- [ ] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
