### PR TITLE
chore: overview links

### DIFF
--- a/src/components/MarkdownProvider/components/OverviewLinks.tsx
+++ b/src/components/MarkdownProvider/components/OverviewLinks.tsx
@@ -1,0 +1,60 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import React from 'react';
+import { ISidebarSection } from '../../../layouts/Sidebar';
+import { LG, UnorderedList, MD } from '@zendeskgarden/react-typography';
+import { Link } from '../../../layouts/Root/components/StyledNavigationLink';
+import styled from 'styled-components';
+
+const StyledUnorderedList = styled(UnorderedList)`
+  margin: 0 0 ${p => p.theme.space.sm} 0;
+`;
+
+const StyledListItem = styled(UnorderedList.Item)`
+  list-style: none;
+`;
+
+export const OverviewLinks: React.FC<{ nav: ISidebarSection[] }> = ({ nav }) => {
+  const content = nav.map(section => (
+    <StyledUnorderedList key={`${section.title}`}>
+      <LG isBold>{section.title}</LG>
+      {section.items && (
+        <StyledUnorderedList>
+          {section.items?.map(group => {
+            if (group.items) {
+              return (
+                <StyledListItem>
+                  <MD>{group.title}</MD>
+                  <UnorderedList>
+                    <UnorderedList.Item>
+                      {group.items.map(child => {
+                        return (
+                          <UnorderedList.Item key={`${child.title}`}>
+                            <Link to={`${child.id}`}>{child.title}</Link>
+                          </UnorderedList.Item>
+                        );
+                      })}
+                    </UnorderedList.Item>
+                  </UnorderedList>
+                </StyledListItem>
+              );
+            }
+
+            return (
+              <StyledListItem key={`${group.title}`}>
+                <Link to={`${group.id}`}>{group.title}</Link>
+              </StyledListItem>
+            );
+          })}
+        </StyledUnorderedList>
+      )}
+    </StyledUnorderedList>
+  ));
+
+  return <nav>{content}</nav>;
+};

--- a/src/components/MarkdownProvider/components/OverviewLinks.tsx
+++ b/src/components/MarkdownProvider/components/OverviewLinks.tsx
@@ -44,7 +44,7 @@ export const OverviewLinks: React.FC<{ nav: ISidebarSection[] }> = ({ nav }) => 
             }
 
             return (
-              <StyledListItem key={`${group.title}`}>
+              <StyledListItem key={group.title}>
                 <Link to={`${group.id}`}>{group.title}</Link>
               </StyledListItem>
             );

--- a/src/components/MarkdownProvider/components/OverviewLinks.tsx
+++ b/src/components/MarkdownProvider/components/OverviewLinks.tsx
@@ -6,10 +6,10 @@
  */
 
 import React from 'react';
+import styled from 'styled-components';
 import { ISidebarSection } from '../../../layouts/Sidebar';
 import { LG, UnorderedList } from '@zendeskgarden/react-typography';
 import { Link } from '../../../layouts/Root/components/StyledNavigationLink';
-import styled from 'styled-components';
 
 const StyledUnorderedList = styled(UnorderedList)`
   margin: 0 0 ${p => p.theme.space.sm} 0;
@@ -28,18 +28,16 @@ export const OverviewLinks: React.FC<{ nav: ISidebarSection[] }> = ({ nav }) => 
           {section.items?.map(group => {
             if (group.items) {
               return (
-                <StyledListItem>
+                <StyledListItem key={`${group.title}`}>
                   {group.title}
-                  <UnorderedList>
-                    <UnorderedList.Item>
-                      {group.items.map(child => {
-                        return (
-                          <UnorderedList.Item key={`${child.title}`}>
-                            <Link to={`${child.id}`}>{child.title}</Link>
-                          </UnorderedList.Item>
-                        );
-                      })}
-                    </UnorderedList.Item>
+                  <UnorderedList type="disc">
+                    {group.items.map(child => {
+                      return (
+                        <UnorderedList.Item key={`${child.title}`}>
+                          <Link to={`${child.id}`}>{child.title}</Link>
+                        </UnorderedList.Item>
+                      );
+                    })}
                   </UnorderedList>
                 </StyledListItem>
               );

--- a/src/components/MarkdownProvider/components/OverviewLinks.tsx
+++ b/src/components/MarkdownProvider/components/OverviewLinks.tsx
@@ -21,19 +21,19 @@ const StyledListItem = styled(UnorderedList.Item)`
 
 export const OverviewLinks: React.FC<{ nav: ISidebarSection[] }> = ({ nav }) => {
   const content = nav.map(section => (
-    <StyledUnorderedList key={`${section.title}`}>
+    <StyledUnorderedList key={section.title}>
       <LG isBold>{section.title}</LG>
       {section.items && (
         <StyledUnorderedList>
           {section.items?.map(group => {
             if (group.items) {
               return (
-                <StyledListItem key={`${group.title}`}>
+                <StyledListItem key={group.title}>
                   {group.title}
                   <UnorderedList type="disc">
                     {group.items.map(child => {
                       return (
-                        <UnorderedList.Item key={`${child.title}`}>
+                        <UnorderedList.Item key={child.title}>
                           <Link to={`${child.id}`}>{child.title}</Link>
                         </UnorderedList.Item>
                       );

--- a/src/components/MarkdownProvider/components/OverviewLinks.tsx
+++ b/src/components/MarkdownProvider/components/OverviewLinks.tsx
@@ -7,7 +7,7 @@
 
 import React from 'react';
 import { ISidebarSection } from '../../../layouts/Sidebar';
-import { LG, UnorderedList, MD } from '@zendeskgarden/react-typography';
+import { LG, UnorderedList } from '@zendeskgarden/react-typography';
 import { Link } from '../../../layouts/Root/components/StyledNavigationLink';
 import styled from 'styled-components';
 
@@ -29,7 +29,7 @@ export const OverviewLinks: React.FC<{ nav: ISidebarSection[] }> = ({ nav }) => 
             if (group.items) {
               return (
                 <StyledListItem>
-                  <MD>{group.title}</MD>
+                  {group.title}
                   <UnorderedList>
                     <UnorderedList.Item>
                       {group.items.map(child => {

--- a/src/components/MarkdownProvider/index.tsx
+++ b/src/components/MarkdownProvider/index.tsx
@@ -17,6 +17,7 @@ import { BestPractice, Do, Dont, Caution } from './components/BestPractice';
 import { COMPONENTS, Markdown } from './components/Markdown';
 import { StyledPre } from './components/Typography';
 import { MDSyntaxHighlighter } from './components/Code';
+import { OverviewLinks } from './components/OverviewLinks';
 
 const GlobalStyle = createGlobalStyle`
   .anchor {
@@ -63,6 +64,7 @@ export const MarkdownProvider: React.FC = ({ children }) => (
         Caution,
         BestPractice,
         Markdown,
+        OverviewLinks,
         /**
          * Markdown elements
          */

--- a/src/pages/components/index.mdx
+++ b/src/pages/components/index.mdx
@@ -1,12 +1,13 @@
 ---
 title: Overview
 description: >
-  A standard overview
+  Development instructions for building effective user interfaces.
 ---
 
-## Introduction
+import { OverviewLinks } from '../../components/MarkdownProvider';
+import links from '../../nav/components.yml';
 
-TODO
+<OverviewLinks nav={links} />
 
 import { graphql } from 'gatsby';
 

--- a/src/pages/components/index.mdx
+++ b/src/pages/components/index.mdx
@@ -4,7 +4,6 @@ description: >
   Development instructions for building effective user interfaces.
 ---
 
-import { OverviewLinks } from '../../components/MarkdownProvider';
 import links from '../../nav/components.yml';
 
 <OverviewLinks nav={links} />

--- a/src/pages/content/index.mdx
+++ b/src/pages/content/index.mdx
@@ -1,32 +1,13 @@
 ---
 title: Overview
 description: >
-  At Zendesk, we have standards
+  The principles of language for writing products.
 ---
 
-![Test overview banner](abstract:spacing-1-2x.png)
+import { OverviewLinks } from '../../components/MarkdownProvider';
+import links from '../../nav/content.yml';
 
-This is a guide to write the Zendesk way in product. These standards will eventually live on Garden
-but for now, you can find them here. As with all style guides, this is a living document. Leave us
-questions and comments below.
-
-## Who should use this
-
-This is for anyone who builds digital experiences for humans. That's a lot of people.
-You might be a product manager (PM) looking to reduce confusion about terminology as a product grows.
-You might be an interaction designer thinking about the semantic side of a multi-step flow.
-Or you could be a writer looking for clear standards and guidelines on the craft of UX Content Strategy.
-
-## Why we wrote this
-
-Visual design and language shape the user experience. The words in your product are like the holds
-on a rock climbing wall. Language that's easier to “grasp” makes a product easier to use.
-
-> Language is a way to connect with the people who use your product. When users have a choice (and
-> they often do), they choose experiences that make them feel good. In a way that pixels can't,
-> language can show empathy, invoke delight, or reassure users when things aren't going well.
->
-> Abraham Lincoln
+<OverviewLinks nav={links} />
 
 import { graphql } from 'gatsby';
 

--- a/src/pages/content/index.mdx
+++ b/src/pages/content/index.mdx
@@ -4,7 +4,6 @@ description: >
   The principles of language for writing products.
 ---
 
-import { OverviewLinks } from '../../components/MarkdownProvider';
 import links from '../../nav/content.yml';
 
 <OverviewLinks nav={links} />

--- a/src/pages/design/index.mdx
+++ b/src/pages/design/index.mdx
@@ -4,7 +4,6 @@ description: >
   Foundations for creating purposeful UI.
 ---
 
-import { OverviewLinks } from '../../components/MarkdownProvider';
 import links from '../../nav/design.yml';
 
 <OverviewLinks nav={links} />
@@ -14,12 +13,5 @@ import { graphql } from 'gatsby';
 export const pageQuery = graphql`
   query($fileAbsolutePath: String) {
     ...SidebarPageFragment
-    avatarShapeCircle: abstractAsset(layerName: { eq: "components-avatar-shape-circle" }) {
-      children {
-        ... on File {
-          publicURL
-        }
-      }
-    }
   }
 `;

--- a/src/pages/design/index.mdx
+++ b/src/pages/design/index.mdx
@@ -1,65 +1,13 @@
 ---
 title: Overview
+description: >
+  Foundations for creating purposeful UI.
 ---
 
-## Introduction
+import { OverviewLinks } from '../../components/MarkdownProvider';
+import links from '../../nav/design.yml';
 
-<Usage>
-  <Use>
-    <ul>
-      <li>Foo</li>
-      <li>Bar</li>
-      <li>Baz</li>
-    </ul>
-  </Use>
-  <Misuse>
-    <ul>
-      <li>Foo</li>
-      <li>Bar</li>
-      <li>Baz</li>
-    </ul>
-  </Misuse>
-</Usage>
-
-## Best Practices
-
-Veggies es bonus vobis, proinde vos postulo essum magis kohlrabi welsh onion daikon amaranth
-tatsoi tomatillo melon azuki bean garlic.
-
-<BestPractice>
-  <Do imageSource={props.data.avatarShapeCircle.children[0].publicURL}>
-    <p>
-      Veggies es bonus vobis, proinde vos postulo essum magis kohlrabi welsh onion daikon amaranth
-      tatsoi tomatillo melon azuki bean garlic.
-    </p>
-    <p>
-      Veggies es bonus vobis, proinde vos postulo essum magis kohlrabi welsh onion daikon amaranth
-      tatsoi tomatillo melon azuki bean garlic.
-    </p>
-  </Do>
-  <Dont imageSource={props.data.avatarShapeCircle.children[0].publicURL}>
-    <p>
-      Veggies es bonus vobis, proinde vos postulo essum magis kohlrabi welsh onion daikon amaranth
-      tatsoi tomatillo melon azuki bean garlic.
-    </p>
-  </Dont>
-</BestPractice>
-
-<BestPractice>
-  <Do>
-    <ul>
-      <li>Veggies es bonus vobis, proinde vos postulo</li>
-      <li>Veggies es bonus vobis, proinde vos postulo essum magis kohlrabi welsh onion.</li>
-      <li>Veggies es bonus vobis, proinde vos postulo essum magis kohlrabi welsh onion.</li>
-    </ul>
-  </Do>
-  <Caution>
-    <ul>
-      <li>Veggies es bonus vobis, proinde vos postulo essum magis kohlrabi welsh onion.</li>
-      <li>Veggies es bonus vobis, proinde vos postulo essum magis kohlrabi welsh onion.</li>
-    </ul>
-  </Caution>
-</BestPractice>
+<OverviewLinks nav={links} />
 
 import { graphql } from 'gatsby';
 


### PR DESCRIPTION
## Description

This is an approach for the temporary overview page links to address navigating when the sidebar disappears. I was thinking that borrowing a similar approach from the sidebar navigation for the overview pages might be nice for programmatically showing the correct links in each section. This way we don't have to manually keep track of IA changes on each overview page. 

## Detail

<!-- supporting details; screen shot, code, etc. -->

<!-- closes GITHUB_ISSUE -->

## Checklist

- [ ] :ok_hand: website updates are Garden Designer approved (add the designer as a reviewer)
- [ ] :black_nib: copy updates are approved (add the content strategist as a reviewer)
- [ ] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [ ] :zap: audited via [web.dev](https://web.dev/measure/) for performance and SEO
- [ ] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
