### PR TITLE
feat: add new <Markdown> component

### DIFF
--- a/package.json
+++ b/package.json
@@ -100,6 +100,8 @@
     "react-dom": "16.13.1",
     "react-helmet": "6.0.0",
     "react-syntax-highlighter": "12.2.1",
+    "remark": "12.0.0",
+    "remark-react": "7.0.1",
     "slugs": "0.1.3",
     "styled-components": "4.4.1",
     "stylelint": "13.5.0",
@@ -108,7 +110,8 @@
     "stylelint-processor-styled-components": "1.10.0",
     "svgo": "1.3.2",
     "typescript": "3.9.3",
-    "unist-util-visit": "2.0.2"
+    "unist-util-visit": "2.0.2",
+    "vfile": "4.1.1"
   },
   "resolutions": {
     "@types/vfile-message": "1.0.1"

--- a/src/components/MarkdownProvider/components/Markdown.tsx
+++ b/src/components/MarkdownProvider/components/Markdown.tsx
@@ -1,0 +1,65 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import React, { ReactElement, ReactNode } from 'react';
+import remark from 'remark';
+import remark2react from 'remark-react';
+import VFile from 'vfile';
+import { Anchor } from '@zendeskgarden/react-buttons';
+import { Code } from '@zendeskgarden/react-typography';
+import { UL, OL, LI } from './Lists';
+import { Table, TR, TH, TD, TBody, THead } from './Table';
+import {
+  StyledH2,
+  StyledH3,
+  StyledH4,
+  StyledH5,
+  StyledH6,
+  StyledBlockquote,
+  StyledHr,
+  StyledParagraph,
+  StyledStrong,
+  StyledEmphasis
+} from './Typography';
+
+export const COMPONENTS = {
+  h2: StyledH2,
+  h3: StyledH3,
+  h4: StyledH4,
+  h5: StyledH5,
+  h6: StyledH6,
+  p: StyledParagraph,
+  a: Anchor,
+  blockquote: StyledBlockquote,
+  hr: StyledHr,
+  strong: StyledStrong,
+  em: StyledEmphasis,
+  code: Code,
+  ul: UL,
+  ol: OL,
+  li: LI,
+  table: Table,
+  thead: THead,
+  tbody: TBody,
+  tr: TR,
+  td: TD,
+  th: TH
+};
+
+const PROCESSOR = remark().use(remark2react, { remarkReactComponents: COMPONENTS });
+
+interface IMarkdown extends VFile.VFile {
+  result: ReactElement;
+}
+
+const toMarkdown = (node: ReactNode) => {
+  const element = (PROCESSOR.processSync(node as string) as IMarkdown).result;
+
+  return element.props.children;
+};
+
+export const Markdown: React.FC = ({ children }) => <>{toMarkdown(children)}</>;

--- a/src/components/MarkdownProvider/components/PropSheets.tsx
+++ b/src/components/MarkdownProvider/components/PropSheets.tsx
@@ -11,6 +11,7 @@ import { ComponentDoc } from 'react-docgen-typescript';
 import { getColor } from '@zendeskgarden/react-theming';
 import { Paragraph } from '@zendeskgarden/react-typography';
 import { Table, Head, Body, HeaderRow, HeaderCell, Row, Cell } from '@zendeskgarden/react-tables';
+import { Markdown } from './Markdown';
 import { StyledH3 } from './Typography';
 
 export const PropSheets: React.FC<{ propSheets: ComponentDoc[] }> = ({ propSheets }) => {
@@ -20,7 +21,9 @@ export const PropSheets: React.FC<{ propSheets: ComponentDoc[] }> = ({ propSheet
         propSheets.map((propSheet, index) => (
           <div key={`${propSheet.displayName}-${index}`}>
             <StyledH3>{propSheet.displayName}</StyledH3>
-            <Paragraph>{propSheet.description}</Paragraph>
+            <Paragraph>
+              <Markdown>{propSheet.description}</Markdown>
+            </Paragraph>
             <div
               css={`
                 overflow: auto;
@@ -68,7 +71,9 @@ export const PropSheets: React.FC<{ propSheets: ComponentDoc[] }> = ({ propSheet
                         >
                           {prop.defaultValue ? prop.defaultValue.value : '-'}
                         </Cell>
-                        <Cell>{prop.description}</Cell>
+                        <Cell>
+                          <Markdown>{prop.description}</Markdown>
+                        </Cell>
                       </Row>
                     );
                   })}

--- a/src/components/MarkdownProvider/index.tsx
+++ b/src/components/MarkdownProvider/index.tsx
@@ -14,23 +14,9 @@ import { Configuration } from './components/Configuration';
 import { PropSheets } from './components/PropSheets';
 import { Usage, Use, Misuse } from './components/Usage';
 import { BestPractice, Do, Dont, Caution } from './components/BestPractice';
-import {
-  StyledH2,
-  StyledH3,
-  StyledH4,
-  StyledH5,
-  StyledH6,
-  StyledBlockquote,
-  StyledHr,
-  StyledParagraph,
-  StyledPre,
-  StyledStrong,
-  StyledEmphasis
-} from './components/Typography';
-import { Anchor } from '@zendeskgarden/react-buttons';
+import { COMPONENTS, Markdown } from './components/Markdown';
+import { StyledPre } from './components/Typography';
 import { MDSyntaxHighlighter } from './components/Code';
-import { UL, OL, LI } from './components/Lists';
-import { Table, TR, TH, TD, TBody, THead } from './components/Table';
 
 const GlobalStyle = createGlobalStyle`
   .anchor {
@@ -76,32 +62,14 @@ export const MarkdownProvider: React.FC = ({ children }) => (
         Dont,
         Caution,
         BestPractice,
+        Markdown,
         /**
          * Markdown elements
          */
-        h2: StyledH2,
-        h3: StyledH3,
-        h4: StyledH4,
-        h5: StyledH5,
-        h6: StyledH6,
-        p: StyledParagraph,
-        a: Anchor,
-        blockquote: StyledBlockquote,
-        hr: StyledHr,
-        strong: StyledStrong,
-        em: StyledEmphasis,
+        ...COMPONENTS,
         inlineCode: Code,
         pre: StyledPre,
-        code: MDSyntaxHighlighter,
-        ul: UL,
-        ol: OL,
-        li: LI,
-        table: Table,
-        thead: THead,
-        tbody: TBody,
-        tr: TR,
-        td: TD,
-        th: TH
+        code: MDSyntaxHighlighter
       }}
     >
       {children}

--- a/src/pages/design/index.mdx
+++ b/src/pages/design/index.mdx
@@ -29,8 +29,10 @@ tatsoi tomatillo melon azuki bean garlic.
 <BestPractice>
   <Do imageSource={props.data.avatarShapeCircle.children[0].publicURL}>
     <p>
-      Veggies es bonus vobis, proinde vos postulo essum magis kohlrabi welsh onion daikon amaranth
-      tatsoi tomatillo melon azuki bean garlic.
+      <Markdown>
+        Veggies es bonus `vobis`, proinde vos postulo essum magis _kohlrabi_ welsh onion daikon
+        amaranth tatsoi tomatillo melon **azuki** bean garlic.
+      </Markdown>
     </p>
     <p>
       Veggies es bonus vobis, proinde vos postulo essum magis kohlrabi welsh onion daikon amaranth

--- a/src/pages/design/index.mdx
+++ b/src/pages/design/index.mdx
@@ -29,10 +29,8 @@ tatsoi tomatillo melon azuki bean garlic.
 <BestPractice>
   <Do imageSource={props.data.avatarShapeCircle.children[0].publicURL}>
     <p>
-      <Markdown>
-        Veggies es bonus `vobis`, proinde vos postulo essum magis _kohlrabi_ welsh onion daikon
-        amaranth tatsoi tomatillo melon **azuki** bean garlic.
-      </Markdown>
+      Veggies es bonus vobis, proinde vos postulo essum magis kohlrabi welsh onion daikon amaranth
+      tatsoi tomatillo melon azuki bean garlic.
     </p>
     <p>
       Veggies es bonus vobis, proinde vos postulo essum magis kohlrabi welsh onion daikon amaranth

--- a/utils/typings/remark-react.d.ts
+++ b/utils/typings/remark-react.d.ts
@@ -1,0 +1,8 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+declare module 'remark-react';

--- a/yarn.lock
+++ b/yarn.lock
@@ -1295,6 +1295,13 @@
     core-js "^3.4.1"
     regenerator-runtime "^0.13.3"
 
+"@mapbox/hast-util-table-cell-style@^0.1.3":
+  version "0.1.3"
+  resolved "https://registry.yarnpkg.com/@mapbox/hast-util-table-cell-style/-/hast-util-table-cell-style-0.1.3.tgz#5b7166ae01297d72216932b245e4b2f0b642dca6"
+  integrity sha512-QsEsh5YaDvHoMQ2YHdvZy2iDnU3GgKVBTcHf6cILyoWDZtPSdlG444pL/ioPYO/GpXSfODBb9sefEetfC4v9oA==
+  dependencies:
+    unist-util-visit "^1.3.0"
+
 "@mdx-js/mdx@1.6.4", "@mdx-js/mdx@^1.6.1", "@mdx-js/mdx@^1.6.4":
   version "1.6.4"
   resolved "https://registry.yarnpkg.com/@mdx-js/mdx/-/mdx-1.6.4.tgz#9c7be8430b15b18dad7bd48323eded92a01089f3"
@@ -8772,6 +8779,18 @@ hast-to-hyperscript@^7.0.0:
     unist-util-is "^3.0.0"
     web-namespaces "^1.1.2"
 
+hast-to-hyperscript@^8.0.0:
+  version "8.1.1"
+  resolved "https://registry.yarnpkg.com/hast-to-hyperscript/-/hast-to-hyperscript-8.1.1.tgz#081e5a98d961ab46277a844f97dfe8dae05a8479"
+  integrity sha512-IsVTowDrvX4n+Nt+zP0VLQmh/ddVtnFSLUv1gb/706ovL2VgFdnE5ior2fDHSp1Bc0E5GidF2ax+PMjd+TW7gA==
+  dependencies:
+    comma-separated-tokens "^1.0.0"
+    property-information "^5.3.0"
+    space-separated-tokens "^1.0.0"
+    style-to-object "^0.3.0"
+    unist-util-is "^4.0.0"
+    web-namespaces "^1.0.0"
+
 hast-util-from-parse5@^5.0.0:
   version "5.0.3"
   resolved "https://registry.yarnpkg.com/hast-util-from-parse5/-/hast-util-from-parse5-5.0.3.tgz#3089dc0ee2ccf6ec8bc416919b51a54a589e097c"
@@ -8801,6 +8820,13 @@ hast-util-raw@5.0.2:
     web-namespaces "^1.0.0"
     xtend "^4.0.0"
     zwitch "^1.0.0"
+
+hast-util-sanitize@^2.0.0:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/hast-util-sanitize/-/hast-util-sanitize-2.0.2.tgz#8a4299bccba6cc8836284466d446060d2ecb2f5c"
+  integrity sha512-ppfgtI6pVb0/dopboV/N2SZju/CKEJzLs6jm58NxoYU1c1ib+/sh14JV5bjLDOEYvyeb5hYIttFKanYm0rtnHQ==
+  dependencies:
+    xtend "^4.0.0"
 
 hast-util-to-parse5@^5.0.0:
   version "5.1.2"
@@ -11191,6 +11217,13 @@ mdast-util-definitions@^1.2.5:
   dependencies:
     unist-util-visit "^1.0.0"
 
+mdast-util-definitions@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/mdast-util-definitions/-/mdast-util-definitions-2.0.1.tgz#2c931d8665a96670639f17f98e32c3afcfee25f3"
+  integrity sha512-Co+DQ6oZlUzvUR7JCpP249PcexxygiaKk9axJh+eRzHDZJk2julbIdKB4PXHVxdBuLzvJ1Izb+YDpj2deGMOuA==
+  dependencies:
+    unist-util-visit "^2.0.0"
+
 mdast-util-definitions@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/mdast-util-definitions/-/mdast-util-definitions-3.0.1.tgz#06af6c49865fc63d6d7d30125569e2f7ae3d0a86"
@@ -11208,6 +11241,21 @@ mdast-util-to-hast@9.1.0:
     collapse-white-space "^1.0.0"
     detab "^2.0.0"
     mdast-util-definitions "^3.0.0"
+    mdurl "^1.0.0"
+    trim-lines "^1.0.0"
+    unist-builder "^2.0.0"
+    unist-util-generated "^1.0.0"
+    unist-util-position "^3.0.0"
+    unist-util-visit "^2.0.0"
+
+mdast-util-to-hast@^8.0.0:
+  version "8.2.0"
+  resolved "https://registry.yarnpkg.com/mdast-util-to-hast/-/mdast-util-to-hast-8.2.0.tgz#adf9f824defcd382e53dd7bace4282a45602ac67"
+  integrity sha512-WjH/KXtqU66XyTJQ7tg7sjvTw1OQcVV0hKdFh3BgHPwZ96fSBCQ/NitEHsN70Mmnggt+5eUUC7pCnK+2qGQnCA==
+  dependencies:
+    collapse-white-space "^1.0.0"
+    detab "^2.0.0"
+    mdast-util-definitions "^2.0.0"
     mdurl "^1.0.0"
     trim-lines "^1.0.0"
     unist-builder "^2.0.0"
@@ -14533,6 +14581,16 @@ remark-parse@^6.0.0:
     vfile-location "^2.0.0"
     xtend "^4.0.1"
 
+remark-react@7.0.1:
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/remark-react/-/remark-react-7.0.1.tgz#499c8b9384e0958834e57a49fe11e7af230936a4"
+  integrity sha512-JJ99WjMmYx2Yc/Nvg0PFH7qb4nw+POkSc8MQV0we95/cFfbUe7WLY7R+k7akAV5ZOOvv8YIkRmxuUFU+4XGPvA==
+  dependencies:
+    "@mapbox/hast-util-table-cell-style" "^0.1.3"
+    hast-to-hyperscript "^8.0.0"
+    hast-util-sanitize "^2.0.0"
+    mdast-util-to-hast "^8.0.0"
+
 remark-retext@^3.1.3:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/remark-retext/-/remark-retext-3.1.3.tgz#77173b1d9d13dab15ce5b38d996195fea522ee7f"
@@ -14587,6 +14645,15 @@ remark-stringify@^8.0.0:
     unherit "^1.0.4"
     xtend "^4.0.1"
 
+remark@12.0.0, remark@^12.0.0:
+  version "12.0.0"
+  resolved "https://registry.yarnpkg.com/remark/-/remark-12.0.0.tgz#d1c145c07341c9232f93b2f8539d56da15a2548c"
+  integrity sha512-oX4lMIS0csgk8AEbzY0h2jdR0ngiCHOpwwpxjmRa5TqAkeknY+tkhjRJGZqnCmvyuWh55/0SW5WY3R3nn3PH9A==
+  dependencies:
+    remark-parse "^8.0.0"
+    remark-stringify "^8.0.0"
+    unified "^9.0.0"
+
 remark@^10.0.1:
   version "10.0.1"
   resolved "https://registry.yarnpkg.com/remark/-/remark-10.0.1.tgz#3058076dc41781bf505d8978c291485fe47667df"
@@ -14595,15 +14662,6 @@ remark@^10.0.1:
     remark-parse "^6.0.0"
     remark-stringify "^6.0.0"
     unified "^7.0.0"
-
-remark@^12.0.0:
-  version "12.0.0"
-  resolved "https://registry.yarnpkg.com/remark/-/remark-12.0.0.tgz#d1c145c07341c9232f93b2f8539d56da15a2548c"
-  integrity sha512-oX4lMIS0csgk8AEbzY0h2jdR0ngiCHOpwwpxjmRa5TqAkeknY+tkhjRJGZqnCmvyuWh55/0SW5WY3R3nn3PH9A==
-  dependencies:
-    remark-parse "^8.0.0"
-    remark-stringify "^8.0.0"
-    unified "^9.0.0"
 
 remote-origin-url@^0.4.0:
   version "0.4.0"
@@ -17135,7 +17193,7 @@ unist-util-visit@2.0.2, unist-util-visit@^2.0.0, unist-util-visit@^2.0.2:
     unist-util-is "^4.0.0"
     unist-util-visit-parents "^3.0.0"
 
-unist-util-visit@^1.0.0, unist-util-visit@^1.1.0, unist-util-visit@^1.4.1:
+unist-util-visit@^1.0.0, unist-util-visit@^1.1.0, unist-util-visit@^1.3.0, unist-util-visit@^1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/unist-util-visit/-/unist-util-visit-1.4.1.tgz#4724aaa8486e6ee6e26d7ff3c8685960d560b1e3"
   integrity sha512-AvGNk7Bb//EmJZyhtRUnNMEpId/AZ5Ph/KUpTI09WHQuDZHKovQ1oEv3mfmKpWKtoMzyMC4GLBm1Zy5k12fjIw==
@@ -17461,6 +17519,17 @@ vfile-message@^2.0.0:
     "@types/unist" "^2.0.0"
     unist-util-stringify-position "^2.0.0"
 
+vfile@4.1.1, vfile@^4.0.0:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/vfile/-/vfile-4.1.1.tgz#282d28cebb609183ac51703001bc18b3e3f17de9"
+  integrity sha512-lRjkpyDGjVlBA7cDQhQ+gNcvB1BGaTHYuSOcY3S7OhDmBtnzX95FhtZZDecSTDm6aajFymyve6S5DN4ZHGezdQ==
+  dependencies:
+    "@types/unist" "^2.0.0"
+    is-buffer "^2.0.0"
+    replace-ext "1.0.0"
+    unist-util-stringify-position "^2.0.0"
+    vfile-message "^2.0.0"
+
 vfile@^2.0.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/vfile/-/vfile-2.3.0.tgz#e62d8e72b20e83c324bc6c67278ee272488bf84a"
@@ -17480,17 +17549,6 @@ vfile@^3.0.0:
     replace-ext "1.0.0"
     unist-util-stringify-position "^1.0.0"
     vfile-message "^1.0.0"
-
-vfile@^4.0.0:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/vfile/-/vfile-4.1.1.tgz#282d28cebb609183ac51703001bc18b3e3f17de9"
-  integrity sha512-lRjkpyDGjVlBA7cDQhQ+gNcvB1BGaTHYuSOcY3S7OhDmBtnzX95FhtZZDecSTDm6aajFymyve6S5DN4ZHGezdQ==
-  dependencies:
-    "@types/unist" "^2.0.0"
-    is-buffer "^2.0.0"
-    replace-ext "1.0.0"
-    unist-util-stringify-position "^2.0.0"
-    vfile-message "^2.0.0"
 
 vm-browserify@^1.0.1:
   version "1.1.2"


### PR DESCRIPTION
## Description

Used to apply component-internal markdown styling for text that is out-of-scope for MDX.

## Detail

PR demonstrates usage within prop sheets.

## Checklist

- [x] :ok_hand: website updates are Garden Designer approved (add the designer as a reviewer)
- [ ] :black_nib: ~copy updates are approved (add the content strategist as a reviewer)~
- [ ] :wheelchair: ~analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver~
- [ ] :zap: ~audited via [web.dev](https://web.dev/measure/) for performance and SEO~
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
