### PR TITLE
feat: add radio component page

### DIFF
--- a/src/examples/forms/radio/Default.tsx
+++ b/src/examples/forms/radio/Default.tsx
@@ -1,0 +1,40 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import React, { useState } from 'react';
+import { Field, Label, Radio } from '@zendeskgarden/react-forms';
+
+const Example = () => {
+  const [radioValue, setRadioValue] = useState('annual');
+
+  return (
+    <div role="group" aria-label="Choose a plant lifecycle">
+      <Field>
+        <Radio
+          name="default example"
+          value="annual"
+          checked={radioValue === 'annual'}
+          onChange={event => setRadioValue(event.target.value)}
+        >
+          <Label>Annual</Label>
+        </Radio>
+      </Field>
+      <Field>
+        <Radio
+          name="default example"
+          value="perennial"
+          checked={radioValue === 'perennial'}
+          onChange={event => setRadioValue(event.target.value)}
+        >
+          <Label>Perennial</Label>
+        </Radio>
+      </Field>
+    </div>
+  );
+};
+
+export default Example;

--- a/src/examples/forms/radio/Default.tsx
+++ b/src/examples/forms/radio/Default.tsx
@@ -7,33 +7,38 @@
 
 import React, { useState } from 'react';
 import { Field, Label, Radio } from '@zendeskgarden/react-forms';
+import { Row, Col } from '@zendeskgarden/react-grid';
 
 const Example = () => {
   const [radioValue, setRadioValue] = useState('annual');
 
   return (
-    <div role="group" aria-label="Choose a plant lifecycle">
-      <Field>
-        <Radio
-          name="default example"
-          value="annual"
-          checked={radioValue === 'annual'}
-          onChange={event => setRadioValue(event.target.value)}
-        >
-          <Label>Annual</Label>
-        </Radio>
-      </Field>
-      <Field>
-        <Radio
-          name="default example"
-          value="perennial"
-          checked={radioValue === 'perennial'}
-          onChange={event => setRadioValue(event.target.value)}
-        >
-          <Label>Perennial</Label>
-        </Radio>
-      </Field>
-    </div>
+    <Row justifyContent="center">
+      <Col size="auto">
+        <div role="group" aria-label="Choose a plant lifecycle">
+          <Field>
+            <Radio
+              name="default example"
+              value="annual"
+              checked={radioValue === 'annual'}
+              onChange={event => setRadioValue(event.target.value)}
+            >
+              <Label>Annual</Label>
+            </Radio>
+          </Field>
+          <Field>
+            <Radio
+              name="default example"
+              value="perennial"
+              checked={radioValue === 'perennial'}
+              onChange={event => setRadioValue(event.target.value)}
+            >
+              <Label>Perennial</Label>
+            </Radio>
+          </Field>
+        </div>
+      </Col>
+    </Row>
   );
 };
 

--- a/src/examples/forms/radio/Disabled.tsx
+++ b/src/examples/forms/radio/Disabled.tsx
@@ -1,0 +1,42 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import React, { useState } from 'react';
+import { Field, Label, Radio } from '@zendeskgarden/react-forms';
+
+const Example = () => {
+  const [radioValue, setRadioValue] = useState('annual');
+
+  return (
+    <div role="group" aria-label="Choose a plant lifecycle">
+      <Field>
+        <Radio
+          disabled
+          name="disabled-example"
+          value="annual"
+          checked={radioValue === 'annual'}
+          onChange={event => setRadioValue(event.target.value)}
+        >
+          <Label>Annual</Label>
+        </Radio>
+      </Field>
+      <Field>
+        <Radio
+          disabled
+          name="disabled-example"
+          value="perennial"
+          checked={radioValue === 'perennial'}
+          onChange={event => setRadioValue(event.target.value)}
+        >
+          <Label>Perennial</Label>
+        </Radio>
+      </Field>
+    </div>
+  );
+};
+
+export default Example;

--- a/src/examples/forms/radio/Disabled.tsx
+++ b/src/examples/forms/radio/Disabled.tsx
@@ -7,35 +7,40 @@
 
 import React, { useState } from 'react';
 import { Field, Label, Radio } from '@zendeskgarden/react-forms';
+import { Row, Col } from '@zendeskgarden/react-grid';
 
 const Example = () => {
   const [radioValue, setRadioValue] = useState('annual');
 
   return (
-    <div role="group" aria-label="Choose a plant lifecycle">
-      <Field>
-        <Radio
-          disabled
-          name="disabled-example"
-          value="annual"
-          checked={radioValue === 'annual'}
-          onChange={event => setRadioValue(event.target.value)}
-        >
-          <Label>Annual</Label>
-        </Radio>
-      </Field>
-      <Field>
-        <Radio
-          disabled
-          name="disabled-example"
-          value="perennial"
-          checked={radioValue === 'perennial'}
-          onChange={event => setRadioValue(event.target.value)}
-        >
-          <Label>Perennial</Label>
-        </Radio>
-      </Field>
-    </div>
+    <Row justifyContent="center">
+      <Col size="auto">
+        <div role="group" aria-label="Choose a plant lifecycle">
+          <Field>
+            <Radio
+              disabled
+              name="disabled-example"
+              value="annual"
+              checked={radioValue === 'annual'}
+              onChange={event => setRadioValue(event.target.value)}
+            >
+              <Label>Annual</Label>
+            </Radio>
+          </Field>
+          <Field>
+            <Radio
+              disabled
+              name="disabled-example"
+              value="perennial"
+              checked={radioValue === 'perennial'}
+              onChange={event => setRadioValue(event.target.value)}
+            >
+              <Label>Perennial</Label>
+            </Radio>
+          </Field>
+        </div>
+      </Col>
+    </Row>
   );
 };
 

--- a/src/examples/forms/radio/Hidden.tsx
+++ b/src/examples/forms/radio/Hidden.tsx
@@ -1,0 +1,44 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import React, { useState } from 'react';
+import { Field, Label, Radio } from '@zendeskgarden/react-forms';
+
+const Example = () => {
+  const [radioValue, setRadioValue] = useState('annual');
+
+  return (
+    <div role="group" aria-label="Choose a plant lifecycle">
+      <Field>
+        <Radio
+          name="hidden-example"
+          value="annual"
+          checked={radioValue === 'annual'}
+          onChange={event => setRadioValue(event.target.value)}
+        >
+          <Label hidden style={{ display: 'inline-block' }}>
+            Annual
+          </Label>
+        </Radio>
+      </Field>
+      <Field>
+        <Radio
+          name="hidden-example"
+          value="perennial"
+          checked={radioValue === 'perennial'}
+          onChange={event => setRadioValue(event.target.value)}
+        >
+          <Label hidden style={{ display: 'inline-block' }}>
+            Perennial
+          </Label>
+        </Radio>
+      </Field>
+    </div>
+  );
+};
+
+export default Example;

--- a/src/examples/forms/radio/Hidden.tsx
+++ b/src/examples/forms/radio/Hidden.tsx
@@ -7,37 +7,38 @@
 
 import React, { useState } from 'react';
 import { Field, Label, Radio } from '@zendeskgarden/react-forms';
+import { Row, Col } from '@zendeskgarden/react-grid';
 
 const Example = () => {
   const [radioValue, setRadioValue] = useState('annual');
 
   return (
-    <div role="group" aria-label="Choose a plant lifecycle">
-      <Field>
-        <Radio
-          name="hidden-example"
-          value="annual"
-          checked={radioValue === 'annual'}
-          onChange={event => setRadioValue(event.target.value)}
-        >
-          <Label hidden style={{ display: 'inline-block' }}>
-            Annual
-          </Label>
-        </Radio>
-      </Field>
-      <Field>
-        <Radio
-          name="hidden-example"
-          value="perennial"
-          checked={radioValue === 'perennial'}
-          onChange={event => setRadioValue(event.target.value)}
-        >
-          <Label hidden style={{ display: 'inline-block' }}>
-            Perennial
-          </Label>
-        </Radio>
-      </Field>
-    </div>
+    <Row justifyContent="center">
+      <Col size="auto">
+        <div role="group" aria-label="Choose a plant lifecycle">
+          <Field>
+            <Radio
+              name="hidden-example"
+              value="annual"
+              checked={radioValue === 'annual'}
+              onChange={event => setRadioValue(event.target.value)}
+            >
+              <Label hidden>Annual</Label>
+            </Radio>
+          </Field>
+          <Field>
+            <Radio
+              name="hidden-example"
+              value="perennial"
+              checked={radioValue === 'perennial'}
+              onChange={event => setRadioValue(event.target.value)}
+            >
+              <Label hidden>Perennial</Label>
+            </Radio>
+          </Field>
+        </div>
+      </Col>
+    </Row>
   );
 };
 

--- a/src/examples/forms/radio/Hint.tsx
+++ b/src/examples/forms/radio/Hint.tsx
@@ -1,0 +1,42 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import React, { useState } from 'react';
+import { Field, Label, Radio, Hint } from '@zendeskgarden/react-forms';
+
+const Example = () => {
+  const [radioValue, setRadioValue] = useState('annual');
+
+  return (
+    <div role="group" aria-label="Choose a plant lifecycle">
+      <Field>
+        <Radio
+          name="hint-example"
+          value="annual"
+          checked={radioValue === 'annual'}
+          onChange={event => setRadioValue(event.target.value)}
+        >
+          <Label>Annual</Label>
+          <Hint>Completes its life cycle with growing season</Hint>
+        </Radio>
+      </Field>
+      <Field>
+        <Radio
+          name="hint-example"
+          value="perennial"
+          checked={radioValue === 'perennial'}
+          onChange={event => setRadioValue(event.target.value)}
+        >
+          <Label>Perennial</Label>
+          <Hint>Lives more than two years</Hint>
+        </Radio>
+      </Field>
+    </div>
+  );
+};
+
+export default Example;

--- a/src/examples/forms/radio/Hint.tsx
+++ b/src/examples/forms/radio/Hint.tsx
@@ -7,35 +7,40 @@
 
 import React, { useState } from 'react';
 import { Field, Label, Radio, Hint } from '@zendeskgarden/react-forms';
+import { Row, Col } from '@zendeskgarden/react-grid';
 
 const Example = () => {
   const [radioValue, setRadioValue] = useState('annual');
 
   return (
-    <div role="group" aria-label="Choose a plant lifecycle">
-      <Field>
-        <Radio
-          name="hint-example"
-          value="annual"
-          checked={radioValue === 'annual'}
-          onChange={event => setRadioValue(event.target.value)}
-        >
-          <Label>Annual</Label>
-          <Hint>Completes its life cycle with growing season</Hint>
-        </Radio>
-      </Field>
-      <Field>
-        <Radio
-          name="hint-example"
-          value="perennial"
-          checked={radioValue === 'perennial'}
-          onChange={event => setRadioValue(event.target.value)}
-        >
-          <Label>Perennial</Label>
-          <Hint>Lives more than two years</Hint>
-        </Radio>
-      </Field>
-    </div>
+    <Row justifyContent="center">
+      <Col size="auto">
+        <div role="group" aria-label="Choose a plant lifecycle">
+          <Field>
+            <Radio
+              name="hint-example"
+              value="annual"
+              checked={radioValue === 'annual'}
+              onChange={event => setRadioValue(event.target.value)}
+            >
+              <Label>Annual</Label>
+              <Hint>Completes its life cycle with growing season</Hint>
+            </Radio>
+          </Field>
+          <Field>
+            <Radio
+              name="hint-example"
+              value="perennial"
+              checked={radioValue === 'perennial'}
+              onChange={event => setRadioValue(event.target.value)}
+            >
+              <Label>Perennial</Label>
+              <Hint>Lives more than two years</Hint>
+            </Radio>
+          </Field>
+        </div>
+      </Col>
+    </Row>
   );
 };
 

--- a/src/examples/forms/radio/Hint.tsx
+++ b/src/examples/forms/radio/Hint.tsx
@@ -6,8 +6,13 @@
  */
 
 import React, { useState } from 'react';
+import styled from 'styled-components';
 import { Field, Label, Radio, Hint } from '@zendeskgarden/react-forms';
 import { Row, Col } from '@zendeskgarden/react-grid';
+
+const StyledField = styled(Field)`
+  margin-top: ${p => p.theme.space.xs};
+`;
 
 const Example = () => {
   const [radioValue, setRadioValue] = useState('annual');
@@ -27,7 +32,7 @@ const Example = () => {
               <Hint>Completes its life cycle with growing season</Hint>
             </Radio>
           </Field>
-          <Field>
+          <StyledField>
             <Radio
               name="hint-example"
               value="perennial"
@@ -37,7 +42,7 @@ const Example = () => {
               <Label>Perennial</Label>
               <Hint>Lives more than two years</Hint>
             </Radio>
-          </Field>
+          </StyledField>
         </div>
       </Col>
     </Row>

--- a/src/examples/forms/radio/RegularWeightLabel.tsx
+++ b/src/examples/forms/radio/RegularWeightLabel.tsx
@@ -7,33 +7,38 @@
 
 import React, { useState } from 'react';
 import { Field, Label, Radio } from '@zendeskgarden/react-forms';
+import { Row, Col } from '@zendeskgarden/react-grid';
 
 const Example = () => {
   const [radioValue, setRadioValue] = useState('annual');
 
   return (
-    <div role="group" aria-label="Choose a plant lifecycle">
-      <Field>
-        <Radio
-          name="weight-example"
-          value="annual"
-          checked={radioValue === 'annual'}
-          onChange={event => setRadioValue(event.target.value)}
-        >
-          <Label isRegular>Annual</Label>
-        </Radio>
-      </Field>
-      <Field>
-        <Radio
-          name="weight-example"
-          value="perennial"
-          checked={radioValue === 'perennial'}
-          onChange={event => setRadioValue(event.target.value)}
-        >
-          <Label isRegular>Perennial</Label>
-        </Radio>
-      </Field>
-    </div>
+    <Row justifyContent="center">
+      <Col size="auto">
+        <div role="group" aria-label="Choose a plant lifecycle">
+          <Field>
+            <Radio
+              name="weight-example"
+              value="annual"
+              checked={radioValue === 'annual'}
+              onChange={event => setRadioValue(event.target.value)}
+            >
+              <Label isRegular>Annual</Label>
+            </Radio>
+          </Field>
+          <Field>
+            <Radio
+              name="weight-example"
+              value="perennial"
+              checked={radioValue === 'perennial'}
+              onChange={event => setRadioValue(event.target.value)}
+            >
+              <Label isRegular>Perennial</Label>
+            </Radio>
+          </Field>
+        </div>
+      </Col>
+    </Row>
   );
 };
 

--- a/src/examples/forms/radio/RegularWeightLabel.tsx
+++ b/src/examples/forms/radio/RegularWeightLabel.tsx
@@ -1,0 +1,40 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import React, { useState } from 'react';
+import { Field, Label, Radio } from '@zendeskgarden/react-forms';
+
+const Example = () => {
+  const [radioValue, setRadioValue] = useState('annual');
+
+  return (
+    <div role="group" aria-label="Choose a plant lifecycle">
+      <Field>
+        <Radio
+          name="weight-example"
+          value="annual"
+          checked={radioValue === 'annual'}
+          onChange={event => setRadioValue(event.target.value)}
+        >
+          <Label isRegular>Annual</Label>
+        </Radio>
+      </Field>
+      <Field>
+        <Radio
+          name="weight-example"
+          value="perennial"
+          checked={radioValue === 'perennial'}
+          onChange={event => setRadioValue(event.target.value)}
+        >
+          <Label isRegular>Perennial</Label>
+        </Radio>
+      </Field>
+    </div>
+  );
+};
+
+export default Example;

--- a/src/examples/forms/radio/Validation.tsx
+++ b/src/examples/forms/radio/Validation.tsx
@@ -8,19 +8,20 @@
 import React, { useState } from 'react';
 import { Field, Label, Radio, Message } from '@zendeskgarden/react-forms';
 import { Row, Col } from '@zendeskgarden/react-grid';
+import { MD } from '@zendeskgarden/react-typography';
 
 const cyclce: Record<string, any> = {
   annual: {
     validation: 'success',
-    message: 'Success'
+    message: 'Growing all the time'
   },
   perennial: {
     validation: 'warning',
-    message: 'Warning'
+    message: 'Growing reguarly'
   },
   biennial: {
     validation: 'error',
-    message: 'Error'
+    message: 'Growing slowly'
   }
 };
 
@@ -29,8 +30,9 @@ const Example = () => {
 
   return (
     <Row justifyContent="center">
-      <Col size="auto">
-        <div role="group" aria-label="Choose a plant lifecycle">
+      <Col size="3">
+        <MD isBold>Choose a growth type</MD>
+        <div role="group" aria-label="Choose a growth type">
           <Field>
             <Radio
               name="validation-example"
@@ -38,7 +40,7 @@ const Example = () => {
               checked={radioValue === 'annual'}
               onChange={event => setRadioValue(event.target.value)}
             >
-              <Label>Annual</Label>
+              <Label isRegular>Annual</Label>
             </Radio>
           </Field>
           <Field>
@@ -48,7 +50,7 @@ const Example = () => {
               checked={radioValue === 'perennial'}
               onChange={event => setRadioValue(event.target.value)}
             >
-              <Label>Perennial</Label>
+              <Label isRegular>Perennial</Label>
             </Radio>
           </Field>
           <Field>
@@ -58,7 +60,7 @@ const Example = () => {
               checked={radioValue === 'biennial'}
               onChange={event => setRadioValue(event.target.value)}
             >
-              <Label>Biennial</Label>
+              <Label isRegular>Biennial</Label>
             </Radio>
             <Message validation={cyclce[radioValue].validation}>
               {cyclce[radioValue].message}

--- a/src/examples/forms/radio/Validation.tsx
+++ b/src/examples/forms/radio/Validation.tsx
@@ -7,46 +7,66 @@
 
 import React, { useState } from 'react';
 import { Field, Label, Radio, Message } from '@zendeskgarden/react-forms';
+import { Row, Col } from '@zendeskgarden/react-grid';
+
+const cyclce: Record<string, any> = {
+  annual: {
+    validation: 'success',
+    message: 'Success'
+  },
+  perennial: {
+    validation: 'warning',
+    message: 'Warning'
+  },
+  biennial: {
+    validation: 'error',
+    message: 'Error'
+  }
+};
 
 const Example = () => {
   const [radioValue, setRadioValue] = useState('annual');
 
   return (
-    <div role="group" aria-label="Choose a plant lifecycle">
-      <Field>
-        <Radio
-          name="validation-example"
-          value="annual"
-          checked={radioValue === 'annual'}
-          onChange={event => setRadioValue(event.target.value)}
-        >
-          <Label>Annual</Label>
-        </Radio>
-        <Message validation="success">Grows all the time</Message>
-      </Field>
-      <Field>
-        <Radio
-          name="validation-example"
-          value="perennial"
-          checked={radioValue === 'perennial'}
-          onChange={event => setRadioValue(event.target.value)}
-        >
-          <Label>Perennial</Label>
-        </Radio>
-        <Message validation="warning">Two years and growing</Message>
-      </Field>
-      <Field>
-        <Radio
-          name="validation-example"
-          value="biennial"
-          checked={radioValue === 'biennial'}
-          onChange={event => setRadioValue(event.target.value)}
-        >
-          <Label>Biennial</Label>
-        </Radio>
-        <Message validation="error">Five years but declining</Message>
-      </Field>
-    </div>
+    <Row justifyContent="center">
+      <Col size="auto">
+        <div role="group" aria-label="Choose a plant lifecycle">
+          <Field>
+            <Radio
+              name="validation-example"
+              value="annual"
+              checked={radioValue === 'annual'}
+              onChange={event => setRadioValue(event.target.value)}
+            >
+              <Label>Annual</Label>
+            </Radio>
+          </Field>
+          <Field>
+            <Radio
+              name="validation-example"
+              value="perennial"
+              checked={radioValue === 'perennial'}
+              onChange={event => setRadioValue(event.target.value)}
+            >
+              <Label>Perennial</Label>
+            </Radio>
+          </Field>
+          <Field>
+            <Radio
+              name="validation-example"
+              value="biennial"
+              checked={radioValue === 'biennial'}
+              onChange={event => setRadioValue(event.target.value)}
+            >
+              <Label>Biennial</Label>
+            </Radio>
+            <Message validation={cyclce[radioValue].validation}>
+              {cyclce[radioValue].message}
+            </Message>
+          </Field>
+        </div>
+      </Col>
+    </Row>
   );
 };
 

--- a/src/examples/forms/radio/Validation.tsx
+++ b/src/examples/forms/radio/Validation.tsx
@@ -1,0 +1,53 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import React, { useState } from 'react';
+import { Field, Label, Radio, Message } from '@zendeskgarden/react-forms';
+
+const Example = () => {
+  const [radioValue, setRadioValue] = useState('annual');
+
+  return (
+    <div role="group" aria-label="Choose a plant lifecycle">
+      <Field>
+        <Radio
+          name="validation-example"
+          value="annual"
+          checked={radioValue === 'annual'}
+          onChange={event => setRadioValue(event.target.value)}
+        >
+          <Label>Annual</Label>
+        </Radio>
+        <Message validation="success">Grows all the time</Message>
+      </Field>
+      <Field>
+        <Radio
+          name="validation-example"
+          value="perennial"
+          checked={radioValue === 'perennial'}
+          onChange={event => setRadioValue(event.target.value)}
+        >
+          <Label>Perennial</Label>
+        </Radio>
+        <Message validation="warning">Two years and growing</Message>
+      </Field>
+      <Field>
+        <Radio
+          name="validation-example"
+          value="biennial"
+          checked={radioValue === 'biennial'}
+          onChange={event => setRadioValue(event.target.value)}
+        >
+          <Label>Biennial</Label>
+        </Radio>
+        <Message validation="error">Five years but declining</Message>
+      </Field>
+    </div>
+  );
+};
+
+export default Example;

--- a/src/examples/forms/radio/Validation.tsx
+++ b/src/examples/forms/radio/Validation.tsx
@@ -30,7 +30,7 @@ const Example = () => {
 
   return (
     <Row justifyContent="center">
-      <Col size="3">
+      <Col size="auto">
         <MD isBold>Choose a growth type</MD>
         <div role="group" aria-label="Choose a growth type">
           <Field>

--- a/src/pages/components/radio.mdx
+++ b/src/pages/components/radio.mdx
@@ -14,14 +14,14 @@ propSheets:
 <Usage>
   <Use>
     <ul>
-      <li>For choices or options that can't occur at the same time.</li>
-      <li>To indicate that two or more options are mutually exclusive.</li>
+      <li>For choices or options that can't occur at the same time</li>
+      <li>To indicate that two or more options are mutually exclusive</li>
     </ul>
   </Use>
   <Misuse>
     <ul>
-      <li>If the user can choose more than one option at once, use a Checkbox instead.</li>
-      <li>To select from a long list of options, use a Select.</li>
+      <li>If the user can choose more than one option at once, use a Checkbox instead</li>
+      <li>To select from a long list of options, use Select instead</li>
     </ul>
   </Misuse>
 </Usage>
@@ -41,7 +41,7 @@ import DefaultCode from '!!raw-loader!../../examples/forms/radio/Default.tsx';
 
 ### Regular weight label
 
-Radio labels are bold by default but can be regular weight.
+Radio labels are bold by default, but can be regular weight too.
 
 import RegularWeightLabel from '../../examples/forms/radio/RegularWeightLabel.tsx';
 import RegularWeightLabelCode from '!!raw-loader!../../examples/forms/radio/RegularWeightLabel.tsx';
@@ -63,7 +63,7 @@ import HintCode from '!!raw-loader!../../examples/forms/radio/Hint.tsx';
 
 ### Validation
 
-Success, warning, or danger validation messages are shown using the Message component.
+Success, warning, and danger validation messages are shown using the Message component.
 
 import Validation from '../../examples/forms/radio/Validation.tsx';
 import ValidationCode from '!!raw-loader!../../examples/forms/radio/Validation.tsx';
@@ -72,9 +72,9 @@ import ValidationCode from '!!raw-loader!../../examples/forms/radio/Validation.t
   <Validation />
 </CodeExample>
 
-### Hidden
+### Hidden label
 
-Radio labels can be removed.
+Radio labels can be hidden.
 
 import Hidden from '../../examples/forms/radio/Hidden.tsx';
 import HiddenCode from '!!raw-loader!../../examples/forms/radio/Hidden.tsx';

--- a/src/pages/components/radio.mdx
+++ b/src/pages/components/radio.mdx
@@ -3,7 +3,7 @@ title: Radio
 description: >
   Radio buttons let users choose a single option among two or more mutually exclusive options.
 package: '@zendeskgarden/react-forms'
-propSheets:
+components:
   - forms/src/elements/Radio.tsx
   - forms/src/elements/common/Field.tsx
   - forms/src/elements/common/Hint.tsx
@@ -96,11 +96,29 @@ import DisabledCode from '!!raw-loader!../../examples/forms/radio/Disabled.tsx';
 
 ## Configuration
 
-<Configuration reactPackage={props.data.mdx.package} propSheets={props.data.mdx.propsSheets} />
+<Configuration reactPackage={props.data.mdx.package} components={props.data.mdx.components} />
 
 ## API
 
-<PropSheets propSheets={props.data.mdx.propsSheets} />
+### Radio
+
+<PropSheet components={props.data.mdx.components} componentName="radio" />
+
+### Field
+
+<PropSheet components={props.data.mdx.components} componentName="field" />
+
+### Hint
+
+<PropSheet components={props.data.mdx.components} componentName="hint" />
+
+### Label
+
+<PropSheet components={props.data.mdx.components} componentName="label" />
+
+### Message
+
+<PropSheet components={props.data.mdx.components} componentName="message" />
 
 import { graphql } from 'gatsby';
 

--- a/src/pages/components/radio.mdx
+++ b/src/pages/components/radio.mdx
@@ -1,10 +1,106 @@
 ---
 title: Radio
 description: >
-  Description will be here
+  Radio buttons let users choose a single option among two or more mutually exclusive options.
+package: '@zendeskgarden/react-forms'
+propSheets:
+  - forms/src/elements/Radio.tsx
+  - forms/src/elements/common/Field.tsx
+  - forms/src/elements/common/Hint.tsx
+  - forms/src/elements/common/Label.tsx
+  - forms/src/elements/common/Message.tsx
 ---
 
-Content here
+<Usage>
+  <Use>
+    <ul>
+      <li>For choices or options that can't occur at the same time.</li>
+      <li>To indicate that two or more options are mutually exclusive.</li>
+    </ul>
+  </Use>
+  <Misuse>
+    <ul>
+      <li>If the user can choose more than one option at once, use a Checkbox instead.</li>
+      <li>To select from a long list of options, use a Select.</li>
+    </ul>
+  </Misuse>
+</Usage>
+
+## How to use it
+
+### Default
+
+A Radio’s label is part of its touch target.
+
+import Default from '../../examples/forms/radio/Default.tsx';
+import DefaultCode from '!!raw-loader!../../examples/forms/radio/Default.tsx';
+
+<CodeExample code={DefaultCode}>
+  <Default />
+</CodeExample>
+
+### Regular weight label
+
+Radio labels are bold by default but can be regular weight.
+
+import RegularWeightLabel from '../../examples/forms/radio/RegularWeightLabel.tsx';
+import RegularWeightLabelCode from '!!raw-loader!../../examples/forms/radio/RegularWeightLabel.tsx';
+
+<CodeExample code={RegularWeightLabelCode}>
+  <RegularWeightLabel />
+</CodeExample>
+
+### Hint text
+
+Hint text adds additional context to a Radio label.
+
+import Hint from '../../examples/forms/radio/Hint.tsx';
+import HintCode from '!!raw-loader!../../examples/forms/radio/Hint.tsx';
+
+<CodeExample code={HintCode}>
+  <Hint />
+</CodeExample>
+
+### Validation
+
+Success, warning, or danger validation messages are shown using the Message component.
+
+import Validation from '../../examples/forms/radio/Validation.tsx';
+import ValidationCode from '!!raw-loader!../../examples/forms/radio/Validation.tsx';
+
+<CodeExample code={ValidationCode}>
+  <Validation />
+</CodeExample>
+
+### Hidden
+
+Radio labels can be removed.
+
+import Hidden from '../../examples/forms/radio/Hidden.tsx';
+import HiddenCode from '!!raw-loader!../../examples/forms/radio/Hidden.tsx';
+
+<CodeExample code={HiddenCode}>
+  <Hidden />
+</CodeExample>
+
+### Disabled
+
+Disabled Radios are not interactive, and not perceived by a screen reader.
+
+import Disabled from '../../examples/forms/radio/Disabled.tsx';
+import DisabledCode from '!!raw-loader!../../examples/forms/radio/Disabled.tsx';
+
+<CodeExample code={DisabledCode}>
+  <Disabled />
+</CodeExample>
+
+## Configuration
+
+<Configuration reactPackage={props.data.mdx.package} propSheets={props.data.mdx.propsSheets} />
+
+## API
+
+<PropSheets propSheets={props.data.mdx.propsSheets} />
 
 import { graphql } from 'gatsby';
 


### PR DESCRIPTION
## Description

This PR introduces the Radio component page.

## Checklist

- [x] :ok_hand: website updates are Garden Designer approved (add the designer as a reviewer)
- [ ] :black_nib: copy updates are approved (add the content strategist as a reviewer)
- [x] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [x] :zap: audited via [web.dev](https://web.dev/measure/) for performance and SEO
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
