### PR TITLE
chore: update breadcrumb copy

### DIFF
--- a/src/pages/components/anchor.mdx
+++ b/src/pages/components/anchor.mdx
@@ -24,7 +24,7 @@ components:
   </Misuse>
 </Usage>
 
-## Examples
+## How to use it
 
 ### Default
 

--- a/src/pages/components/breadcrumbs.mdx
+++ b/src/pages/components/breadcrumbs.mdx
@@ -1,7 +1,7 @@
 ---
 title: Breadcrumbs
 description: >
-  Breadcrumbs mark and communicate the current location of where a user is within the product.
+  Breadcrumbs mark and communicate a user's location in the product.
 package: '@zendeskgarden/react-breadcrumbs'
 components:
   - breadcrumbs/src/elements/Breadcrumb.tsx
@@ -10,17 +10,18 @@ components:
 <Usage>
   <Use>
     <ul>
-      <li>To inform the user of where they are in a nested navigation</li>
-      <li>To quickly navigate back to a parent page</li>
+      <li>To show the user where they are in a nested navigation</li>
+      <li>To provide a quick way to navigate to ancestor pages</li>
     </ul>
   </Use>
 </Usage>
 
-## Examples
+## How to use it
 
 ### Default
 
-Breadcrumbs work in combination with the [Anchor](/components/anchor) component for linking.
+Breadcrumbs and the [Anchor](/anchor) component work together. Each element (a "crumb" if you will) is
+separated from the others with an arrow.
 
 import BreadcrumbsDefault from '../../examples/breadcrumbs/BreadcrumbsDefault.tsx';
 import BreadcrumbsDefaultCode from '!!raw-loader!../../examples/breadcrumbs/BreadcrumbsDefault.tsx';

--- a/src/pages/components/breadcrumbs.mdx
+++ b/src/pages/components/breadcrumbs.mdx
@@ -20,8 +20,8 @@ components:
 
 ### Default
 
-Breadcrumbs and the [Anchor](/anchor) component work together. Each element (a "crumb" if you will) is
-separated from the others with an arrow.
+Breadcrumbs and the [Anchor](/components/anchor) component work together. Each element (a "crumb" if
+you will) is separated from the others with an arrow.
 
 import BreadcrumbsDefault from '../../examples/breadcrumbs/BreadcrumbsDefault.tsx';
 import BreadcrumbsDefaultCode from '!!raw-loader!../../examples/breadcrumbs/BreadcrumbsDefault.tsx';

--- a/src/pages/components/button.mdx
+++ b/src/pages/components/button.mdx
@@ -9,7 +9,7 @@ components:
   - buttons/src/elements/Button.tsx
 ---
 
-## Examples
+## How to use it
 
 ### Types
 

--- a/src/pages/components/inputs.mdx
+++ b/src/pages/components/inputs.mdx
@@ -23,7 +23,7 @@ components:
   </Use>
 </Usage>
 
-## Examples
+## How to use it
 
 ### Default
 

--- a/src/pages/components/menu.mdx
+++ b/src/pages/components/menu.mdx
@@ -26,7 +26,7 @@ components:
   </Use>
 </Usage>
 
-## Examples
+## How to use it
 
 ### Select Menu
 

--- a/src/pages/components/multiselect.mdx
+++ b/src/pages/components/multiselect.mdx
@@ -22,7 +22,7 @@ components:
   </Use>
 </Usage>
 
-## Examples
+## How to use it
 
 ### Default Usage
 

--- a/src/pages/components/select.mdx
+++ b/src/pages/components/select.mdx
@@ -33,7 +33,7 @@ components:
   </Misuse>
 </Usage>
 
-## Examples
+## How to use it
 
 ### Default
 

--- a/src/pages/components/tabs.mdx
+++ b/src/pages/components/tabs.mdx
@@ -25,7 +25,7 @@ components:
   </Misuse>
 </Usage>
 
-## Examples
+## How to use it
 
 ### Default
 


### PR DESCRIPTION
This PR contains two updates: 

1. It revises the headline `Examples` to `How to use it` across all component pages so we don't accidentally miss one. 
2. Updates the copy on Breadcrumbs to new UXCS approved copy. 

## Description

<!-- a summary of the changes introduced by this PR. this description
     may populate the commit body if the PR is merged. -->

## Detail

<!-- supporting details; screen shot, code, etc. -->

<!-- closes GITHUB_ISSUE -->

## Checklist

- [ ] :ok_hand: website updates are Garden Designer approved (add the designer as a reviewer)
- [ ] :black_nib: copy updates are approved (add the content strategist as a reviewer)
- [ ] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [ ] :zap: audited via [web.dev](https://web.dev/measure/) for performance and SEO
- [ ] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
