### PR TITLE
fix(examples): update with consistent formatting

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -50,9 +50,10 @@
   },
   "overrides": [
     {
-      "files": ["src/examples/dropdowns/**/*.{ts,tsx}"],
+      "files": ["src/examples/**/*.{ts,tsx}"],
       "rules": {
-        "no-alert": "off"
+        "no-alert": "off",
+        "jsx-a11y/img-redundant-alt": "off"
       }
     }
   ]

--- a/src/components/MarkdownProvider/components/CodeExample/index.tsx
+++ b/src/components/MarkdownProvider/components/CodeExample/index.tsx
@@ -6,7 +6,7 @@
  */
 
 import React, { useRef, useState, useMemo, useEffect } from 'react';
-import styled, { css, DefaultTheme } from 'styled-components';
+import { css, DefaultTheme } from 'styled-components';
 import { ThemeProvider, DEFAULT_THEME, getColor } from '@zendeskgarden/react-theming';
 import { Tooltip } from '@zendeskgarden/react-tooltips';
 import { IconButton, ToggleIconButton } from '@zendeskgarden/react-buttons';
@@ -17,14 +17,7 @@ import { ReactComponent as DirectionRtlStroke } from '@zendeskgarden/svg-icons/s
 import { SyntaxHighlighter } from './components/SyntaxHighlighter';
 import { retrieveCodesandboxParameters } from './utils/retrieveCodesandboxParameters';
 import { copyToClipboard } from './utils/copyToClipboard';
-
-const StyledExampleWrapper = styled.div`
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  padding: ${p => p.theme.space.md};
-  direction: ${p => p.theme.rtl && 'rtl'};
-`;
+import { Row, Col } from '@zendeskgarden/react-grid';
 
 export const CodeExample: React.FC<{ code: string }> = ({ children, code }) => {
   const [isRtl, setIsRtl] = useState(false);
@@ -65,7 +58,19 @@ export const CodeExample: React.FC<{ code: string }> = ({ children, code }) => {
       `}
     >
       <ThemeProvider theme={exampleTheme} focusVisibleRef={focusVisibleRef}>
-        <StyledExampleWrapper>{children}</StyledExampleWrapper>
+        <Row
+          css={css`
+            padding: ${p => p.theme.space.md};
+          `}
+        >
+          <Col
+            css={css`
+              direction: ${p => p.theme.rtl && 'rtl'};
+            `}
+          >
+            {children}
+          </Col>
+        </Row>
       </ThemeProvider>
       <div
         css={css`

--- a/src/components/MarkdownProvider/components/CodeExample/index.tsx
+++ b/src/components/MarkdownProvider/components/CodeExample/index.tsx
@@ -17,7 +17,6 @@ import { ReactComponent as DirectionRtlStroke } from '@zendeskgarden/svg-icons/s
 import { SyntaxHighlighter } from './components/SyntaxHighlighter';
 import { retrieveCodesandboxParameters } from './utils/retrieveCodesandboxParameters';
 import { copyToClipboard } from './utils/copyToClipboard';
-import { Row, Col } from '@zendeskgarden/react-grid';
 
 export const CodeExample: React.FC<{ code: string }> = ({ children, code }) => {
   const [isRtl, setIsRtl] = useState(false);
@@ -58,19 +57,13 @@ export const CodeExample: React.FC<{ code: string }> = ({ children, code }) => {
       `}
     >
       <ThemeProvider theme={exampleTheme} focusVisibleRef={focusVisibleRef}>
-        <Row
+        <div
           css={css`
             padding: ${p => p.theme.space.md};
           `}
         >
-          <Col
-            css={css`
-              direction: ${p => p.theme.rtl && 'rtl'};
-            `}
-          >
-            {children}
-          </Col>
-        </Row>
+          {children}
+        </div>
       </ThemeProvider>
       <div
         css={css`

--- a/src/examples/anchor/AnchorDanger.tsx
+++ b/src/examples/anchor/AnchorDanger.tsx
@@ -7,13 +7,16 @@
 
 import React from 'react';
 import { Anchor } from '@zendeskgarden/react-buttons';
+import { Row, Col } from '@zendeskgarden/react-grid';
 
-const Example = () => {
-  return (
-    <Anchor isDanger href="#danger">
-      Leave the Garden
-    </Anchor>
-  );
-};
+const Example = () => (
+  <Row>
+    <Col textAlign="center">
+      <Anchor isDanger href="#danger">
+        Leave the Garden
+      </Anchor>
+    </Col>
+  </Row>
+);
 
 export default Example;

--- a/src/examples/anchor/AnchorDefault.tsx
+++ b/src/examples/anchor/AnchorDefault.tsx
@@ -7,9 +7,14 @@
 
 import React from 'react';
 import { Anchor } from '@zendeskgarden/react-buttons';
+import { Row, Col } from '@zendeskgarden/react-grid';
 
-const Example = () => {
-  return <Anchor href="#default">Go to the Garden</Anchor>;
-};
+const Example = () => (
+  <Row>
+    <Col textAlign="center">
+      <Anchor href="#default">Go to the Garden</Anchor>
+    </Col>
+  </Row>
+);
 
 export default Example;

--- a/src/examples/anchor/AnchorExternal.tsx
+++ b/src/examples/anchor/AnchorExternal.tsx
@@ -7,13 +7,16 @@
 
 import React from 'react';
 import { Anchor } from '@zendeskgarden/react-buttons';
+import { Row, Col } from '@zendeskgarden/react-grid';
 
-const Example = () => {
-  return (
-    <Anchor isExternal href="https://garden.zendesk.com/" target="_blank">
-      Open a new Garden
-    </Anchor>
-  );
-};
+const Example = () => (
+  <Row>
+    <Col textAlign="center">
+      <Anchor isExternal href="https://garden.zendesk.com/" target="_blank">
+        Open a new Garden
+      </Anchor>
+    </Col>
+  </Row>
+);
 
 export default Example;

--- a/src/examples/avatar/AvatarShape.tsx
+++ b/src/examples/avatar/AvatarShape.tsx
@@ -8,27 +8,23 @@
 import React from 'react';
 import { PALETTE } from '@zendeskgarden/react-theming';
 import { Avatar } from '@zendeskgarden/react-avatars';
-import { Grid, Row, Col } from '@zendeskgarden/react-grid';
+import { Row, Col } from '@zendeskgarden/react-grid';
 import { ReactComponent as ZendeskIcon } from '@zendeskgarden/svg-icons/src/26/zendesk.svg';
 import { ReactComponent as UserStrokeIcon } from '@zendeskgarden/svg-icons/src/16/user-solo-stroke.svg';
 
-const Example = () => {
-  return (
-    <Grid>
-      <Row alignItems="center">
-        <Col textAlign="center">
-          <Avatar backgroundColor={PALETTE.grey[600]} size="medium">
-            <UserStrokeIcon role="img" aria-label="User" />
-          </Avatar>
-        </Col>
-        <Col textAlign="center">
-          <Avatar backgroundColor={PALETTE.kale[700]} size="medium" isSystem>
-            <ZendeskIcon role="img" aria-label="Zendesk" />
-          </Avatar>
-        </Col>
-      </Row>
-    </Grid>
-  );
-};
+const Example = () => (
+  <Row>
+    <Col textAlign="center">
+      <Avatar backgroundColor={PALETTE.grey[600]} size="medium">
+        <UserStrokeIcon role="img" aria-label="User" />
+      </Avatar>
+    </Col>
+    <Col textAlign="center">
+      <Avatar backgroundColor={PALETTE.kale[700]} size="medium" isSystem>
+        <ZendeskIcon role="img" aria-label="Zendesk" />
+      </Avatar>
+    </Col>
+  </Row>
+);
 
 export default Example;

--- a/src/examples/avatar/AvatarSize.tsx
+++ b/src/examples/avatar/AvatarSize.tsx
@@ -8,43 +8,37 @@
 import React from 'react';
 import { PALETTE } from '@zendeskgarden/react-theming';
 import { Avatar } from '@zendeskgarden/react-avatars';
-import { Grid, Row, Col } from '@zendeskgarden/react-grid';
+import { Row, Col } from '@zendeskgarden/react-grid';
 import { ReactComponent as UserStrokeIcon } from '@zendeskgarden/svg-icons/src/16/user-solo-stroke.svg';
 
-const Example = () => {
-  const iconColor = PALETTE.grey[600];
-
-  return (
-    <Grid>
-      <Row alignItems="center">
-        <Col textAlign="center">
-          <Avatar backgroundColor={iconColor} size="extraextrasmall">
-            <UserStrokeIcon role="img" aria-label="extra extra small user avatar" />
-          </Avatar>
-        </Col>
-        <Col textAlign="center">
-          <Avatar backgroundColor={iconColor} size="extrasmall">
-            <UserStrokeIcon role="img" aria-label="extra small user avatar" />
-          </Avatar>
-        </Col>
-        <Col textAlign="center">
-          <Avatar backgroundColor={iconColor} size="small">
-            <UserStrokeIcon role="img" aria-label="small user avatar" />
-          </Avatar>
-        </Col>
-        <Col textAlign="center">
-          <Avatar backgroundColor={iconColor} size="medium">
-            <UserStrokeIcon role="img" aria-label="medium user avatar" />
-          </Avatar>
-        </Col>
-        <Col textAlign="center">
-          <Avatar backgroundColor={iconColor} size="large">
-            <UserStrokeIcon role="img" aria-label="large user avatar" />
-          </Avatar>
-        </Col>
-      </Row>
-    </Grid>
-  );
-};
+const Example = () => (
+  <Row alignItems="center">
+    <Col textAlign="center">
+      <Avatar backgroundColor={PALETTE.grey[600]} size="extraextrasmall">
+        <UserStrokeIcon role="img" aria-label="extra extra small user avatar" />
+      </Avatar>
+    </Col>
+    <Col textAlign="center">
+      <Avatar backgroundColor={PALETTE.grey[600]} size="extrasmall">
+        <UserStrokeIcon role="img" aria-label="extra small user avatar" />
+      </Avatar>
+    </Col>
+    <Col textAlign="center">
+      <Avatar backgroundColor={PALETTE.grey[600]} size="small">
+        <UserStrokeIcon role="img" aria-label="small user avatar" />
+      </Avatar>
+    </Col>
+    <Col textAlign="center">
+      <Avatar backgroundColor={PALETTE.grey[600]} size="medium">
+        <UserStrokeIcon role="img" aria-label="medium user avatar" />
+      </Avatar>
+    </Col>
+    <Col textAlign="center">
+      <Avatar backgroundColor={PALETTE.grey[600]} size="large">
+        <UserStrokeIcon role="img" aria-label="large user avatar" />
+      </Avatar>
+    </Col>
+  </Row>
+);
 
 export default Example;

--- a/src/examples/avatar/AvatarStatus.tsx
+++ b/src/examples/avatar/AvatarStatus.tsx
@@ -8,41 +8,35 @@
 import React from 'react';
 import { PALETTE } from '@zendeskgarden/react-theming';
 import { Avatar } from '@zendeskgarden/react-avatars';
-import { Grid, Row, Col } from '@zendeskgarden/react-grid';
+import { Row, Col } from '@zendeskgarden/react-grid';
 
-const Example = () => {
-  const iconColor = PALETTE.grey[600];
-
-  return (
-    <Grid>
-      <Row alignItems="center">
-        <Col textAlign="center">
-          <Avatar backgroundColor={iconColor} status="away">
-            <img
-              alt="away avatar"
-              src="https://garden.zendesk.com/react-components/avatars/images/avatar-3.png"
-            />
-          </Avatar>
-        </Col>
-        <Col textAlign="center">
-          <Avatar backgroundColor={iconColor} status="available">
-            <img
-              alt="available avatar"
-              src="https://garden.zendesk.com/react-components/avatars/images/avatar-3.png"
-            />
-          </Avatar>
-        </Col>
-        <Col textAlign="center">
-          <Avatar backgroundColor={iconColor} badge={8}>
-            <img
-              alt="active avatar"
-              src="https://garden.zendesk.com/react-components/avatars/images/avatar-3.png"
-            />
-          </Avatar>
-        </Col>
-      </Row>
-    </Grid>
-  );
-};
+const Example = () => (
+  <Row>
+    <Col textAlign="center">
+      <Avatar backgroundColor={PALETTE.grey[600]} status="away">
+        <img
+          alt="away avatar"
+          src="https://garden.zendesk.com/react-components/avatars/images/avatar-3.png"
+        />
+      </Avatar>
+    </Col>
+    <Col textAlign="center">
+      <Avatar backgroundColor={PALETTE.grey[600]} status="available">
+        <img
+          alt="available avatar"
+          src="https://garden.zendesk.com/react-components/avatars/images/avatar-3.png"
+        />
+      </Avatar>
+    </Col>
+    <Col textAlign="center">
+      <Avatar backgroundColor={PALETTE.grey[600]} badge={8}>
+        <img
+          alt="active avatar"
+          src="https://garden.zendesk.com/react-components/avatars/images/avatar-3.png"
+        />
+      </Avatar>
+    </Col>
+  </Row>
+);
 
 export default Example;

--- a/src/examples/avatar/AvatarType.tsx
+++ b/src/examples/avatar/AvatarType.tsx
@@ -8,38 +8,30 @@
 import React from 'react';
 import { PALETTE } from '@zendeskgarden/react-theming';
 import { Avatar } from '@zendeskgarden/react-avatars';
-import { Grid, Row, Col } from '@zendeskgarden/react-grid';
+import { Row, Col } from '@zendeskgarden/react-grid';
 import { ReactComponent as UserStrokeIcon } from '@zendeskgarden/svg-icons/src/16/user-solo-stroke.svg';
 
-const Example = () => {
-  const iconColor = PALETTE.grey[600];
-
-  return (
-    <Grid>
-      <Row alignItems="center">
-        <Col textAlign="center">
-          <Avatar backgroundColor={iconColor}>
-            <UserStrokeIcon role="img" aria-label="icon avatar" />
-          </Avatar>
-        </Col>
-        <Col textAlign="center">
-          <Avatar backgroundColor={iconColor}>
-            {/* eslint-disable jsx-a11y/img-redundant-alt */}
-            <img
-              alt="image avatar"
-              src="https://garden.zendesk.com/react-components/avatars/images/avatar-3.png"
-            />
-            {/* eslint-enable jsx-a11y/img-redundant-alt */}
-          </Avatar>
-        </Col>
-        <Col textAlign="center">
-          <Avatar backgroundColor={iconColor}>
-            <Avatar.Text>ZD</Avatar.Text>
-          </Avatar>
-        </Col>
-      </Row>
-    </Grid>
-  );
-};
+const Example = () => (
+  <Row>
+    <Col textAlign="center">
+      <Avatar backgroundColor={PALETTE.grey[600]}>
+        <UserStrokeIcon role="img" aria-label="icon avatar" />
+      </Avatar>
+    </Col>
+    <Col textAlign="center">
+      <Avatar backgroundColor={PALETTE.grey[600]}>
+        <img
+          alt="image avatar"
+          src="https://garden.zendesk.com/react-components/avatars/images/avatar-3.png"
+        />
+      </Avatar>
+    </Col>
+    <Col textAlign="center">
+      <Avatar backgroundColor={PALETTE.grey[600]}>
+        <Avatar.Text>ZD</Avatar.Text>
+      </Avatar>
+    </Col>
+  </Row>
+);
 
 export default Example;

--- a/src/examples/breadcrumbs/BreadcrumbsDefault.tsx
+++ b/src/examples/breadcrumbs/BreadcrumbsDefault.tsx
@@ -9,15 +9,18 @@ import React from 'react';
 import { Anchor } from '@zendeskgarden/react-buttons';
 import { Span } from '@zendeskgarden/react-typography';
 import { Breadcrumb } from '@zendeskgarden/react-breadcrumbs';
+import { Row, Col } from '@zendeskgarden/react-grid';
 
-const Example = () => {
-  return (
-    <Breadcrumb>
-      <Anchor>Garden</Anchor>
-      <Anchor>Flowers</Anchor>
-      <Span>Roses</Span>
-    </Breadcrumb>
-  );
-};
+const Example = () => (
+  <Row justifyContent="center">
+    <Col size="auto">
+      <Breadcrumb>
+        <Anchor>Garden</Anchor>
+        <Anchor>Flowers</Anchor>
+        <Span>Roses</Span>
+      </Breadcrumb>
+    </Col>
+  </Row>
+);
 
 export default Example;

--- a/src/examples/button/ButtonDanger.tsx
+++ b/src/examples/button/ButtonDanger.tsx
@@ -6,29 +6,25 @@
  */
 
 import React from 'react';
-import { Grid, Row, Col } from '@zendeskgarden/react-grid';
+import { Row, Col } from '@zendeskgarden/react-grid';
 import { Button } from '@zendeskgarden/react-buttons';
 
-const Example = () => {
-  return (
-    <Grid>
-      <Row alignItems="center">
-        <Col textAlign="center">
-          <Button isDanger>Default</Button>
-        </Col>
-        <Col textAlign="center">
-          <Button isPrimary isDanger>
-            Primary
-          </Button>
-        </Col>
-        <Col textAlign="center">
-          <Button isBasic isDanger>
-            Basic
-          </Button>
-        </Col>
-      </Row>
-    </Grid>
-  );
-};
+const Example = () => (
+  <Row>
+    <Col textAlign="center">
+      <Button isDanger>Default</Button>
+    </Col>
+    <Col textAlign="center">
+      <Button isPrimary isDanger>
+        Primary
+      </Button>
+    </Col>
+    <Col textAlign="center">
+      <Button isBasic isDanger>
+        Basic
+      </Button>
+    </Col>
+  </Row>
+);
 
 export default Example;

--- a/src/examples/button/ButtonSizes.tsx
+++ b/src/examples/button/ButtonSizes.tsx
@@ -6,25 +6,21 @@
  */
 
 import React from 'react';
-import { Grid, Row, Col } from '@zendeskgarden/react-grid';
+import { Row, Col } from '@zendeskgarden/react-grid';
 import { Button } from '@zendeskgarden/react-buttons';
 
-const Example = () => {
-  return (
-    <Grid>
-      <Row alignItems="center">
-        <Col textAlign="center">
-          <Button size="small">Small</Button>
-        </Col>
-        <Col textAlign="center">
-          <Button size="medium">Default</Button>
-        </Col>
-        <Col textAlign="center">
-          <Button size="large">Large</Button>
-        </Col>
-      </Row>
-    </Grid>
-  );
-};
+const Example = () => (
+  <Row alignItems="center">
+    <Col textAlign="center">
+      <Button size="small">Small</Button>
+    </Col>
+    <Col textAlign="center">
+      <Button size="medium">Default</Button>
+    </Col>
+    <Col textAlign="center">
+      <Button size="large">Large</Button>
+    </Col>
+  </Row>
+);
 
 export default Example;

--- a/src/examples/button/ButtonStretched.tsx
+++ b/src/examples/button/ButtonStretched.tsx
@@ -7,30 +7,28 @@
 
 import React from 'react';
 import styled from 'styled-components';
-import { Grid, Row, Col } from '@zendeskgarden/react-grid';
+import { Row, Col } from '@zendeskgarden/react-grid';
 import { Button } from '@zendeskgarden/react-buttons';
 
 const StyledRow = styled(Row)`
   margin-top: ${p => p.theme.space.md};
 `;
 
-const Example = () => {
-  return (
-    <Grid>
-      <Row>
-        <Col textAlign="center">
-          <Button isStretched>Stretched</Button>
-        </Col>
-      </Row>
-      <StyledRow>
-        <Col textAlign="center">
-          <Button isPrimary isStretched>
-            Stretched
-          </Button>
-        </Col>
-      </StyledRow>
-    </Grid>
-  );
-};
+const Example = () => (
+  <>
+    <Row>
+      <Col textAlign="center">
+        <Button isStretched>Stretched</Button>
+      </Col>
+    </Row>
+    <StyledRow>
+      <Col textAlign="center">
+        <Button isPrimary isStretched>
+          Stretched
+        </Button>
+      </Col>
+    </StyledRow>
+  </>
+);
 
 export default Example;

--- a/src/examples/button/ButtonTypes.tsx
+++ b/src/examples/button/ButtonTypes.tsx
@@ -6,25 +6,21 @@
  */
 
 import React from 'react';
-import { Grid, Row, Col } from '@zendeskgarden/react-grid';
+import { Row, Col } from '@zendeskgarden/react-grid';
 import { Button } from '@zendeskgarden/react-buttons';
 
-const Example = () => {
-  return (
-    <Grid>
-      <Row>
-        <Col textAlign="center">
-          <Button>Default</Button>
-        </Col>
-        <Col textAlign="center">
-          <Button isPrimary>Primary</Button>
-        </Col>
-        <Col textAlign="center">
-          <Button isBasic>Basic</Button>
-        </Col>
-      </Row>
-    </Grid>
-  );
-};
+const Example = () => (
+  <Row>
+    <Col textAlign="center">
+      <Button>Default</Button>
+    </Col>
+    <Col textAlign="center">
+      <Button isPrimary>Primary</Button>
+    </Col>
+    <Col textAlign="center">
+      <Button isBasic>Basic</Button>
+    </Col>
+  </Row>
+);
 
 export default Example;

--- a/src/examples/dropdowns/MenuArrow.tsx
+++ b/src/examples/dropdowns/MenuArrow.tsx
@@ -8,18 +8,23 @@
 import React from 'react';
 import { Dropdown, Menu, Item, Trigger } from '@zendeskgarden/react-dropdowns';
 import { Button } from '@zendeskgarden/react-buttons';
+import { Row, Col } from '@zendeskgarden/react-grid';
 
 const Example = () => (
-  <Dropdown onSelect={item => alert(`You planted a ${item}`)}>
-    <Trigger>
-      <Button>Menu</Button>
-    </Trigger>
-    <Menu hasArrow>
-      <Item value="cactus">Cactus</Item>
-      <Item value="flower">Flower</Item>
-      <Item value="succulent">Succulent</Item>
-    </Menu>
-  </Dropdown>
+  <Row>
+    <Col textAlign="center">
+      <Dropdown onSelect={item => alert(`You planted a ${item}`)}>
+        <Trigger>
+          <Button>Menu</Button>
+        </Trigger>
+        <Menu hasArrow>
+          <Item value="cactus">Cactus</Item>
+          <Item value="flower">Flower</Item>
+          <Item value="succulent">Succulent</Item>
+        </Menu>
+      </Dropdown>
+    </Col>
+  </Row>
 );
 
 export default Example;

--- a/src/examples/dropdowns/MenuButton.tsx
+++ b/src/examples/dropdowns/MenuButton.tsx
@@ -8,18 +8,23 @@
 import React from 'react';
 import { Dropdown, Menu, Item, Trigger } from '@zendeskgarden/react-dropdowns';
 import { Button } from '@zendeskgarden/react-buttons';
+import { Row, Col } from '@zendeskgarden/react-grid';
 
 const Example = () => (
-  <Dropdown onSelect={item => alert(`You planted a ${item}`)}>
-    <Trigger>
-      <Button>Menu</Button>
-    </Trigger>
-    <Menu>
-      <Item value="cactus">Cactus</Item>
-      <Item value="flower">Flower</Item>
-      <Item value="succulent">Succulent</Item>
-    </Menu>
-  </Dropdown>
+  <Row>
+    <Col textAlign="center">
+      <Dropdown onSelect={item => alert(`You planted a ${item}`)}>
+        <Trigger>
+          <Button>Menu</Button>
+        </Trigger>
+        <Menu>
+          <Item value="cactus">Cactus</Item>
+          <Item value="flower">Flower</Item>
+          <Item value="succulent">Succulent</Item>
+        </Menu>
+      </Dropdown>
+    </Col>
+  </Row>
 );
 
 export default Example;

--- a/src/examples/dropdowns/MenuDisabled.tsx
+++ b/src/examples/dropdowns/MenuDisabled.tsx
@@ -8,20 +8,25 @@
 import React from 'react';
 import { Dropdown, Menu, Item, Trigger } from '@zendeskgarden/react-dropdowns';
 import { Button } from '@zendeskgarden/react-buttons';
+import { Row, Col } from '@zendeskgarden/react-grid';
 
 const Example = () => (
-  <Dropdown onSelect={item => alert(`You planted a ${item}`)}>
-    <Trigger>
-      <Button>Menu</Button>
-    </Trigger>
-    <Menu>
-      <Item value="cactus">Cactus</Item>
-      <Item value="flower" disabled>
-        Flower
-      </Item>
-      <Item value="succulent">Succulent</Item>
-    </Menu>
-  </Dropdown>
+  <Row>
+    <Col textAlign="center">
+      <Dropdown onSelect={item => alert(`You planted a ${item}`)}>
+        <Trigger>
+          <Button>Menu</Button>
+        </Trigger>
+        <Menu>
+          <Item value="cactus">Cactus</Item>
+          <Item value="flower" disabled>
+            Flower
+          </Item>
+          <Item value="succulent">Succulent</Item>
+        </Menu>
+      </Dropdown>
+    </Col>
+  </Row>
 );
 
 export default Example;

--- a/src/examples/dropdowns/MenuMedia.tsx
+++ b/src/examples/dropdowns/MenuMedia.tsx
@@ -21,47 +21,53 @@ import {
   MediaBody,
   MediaFigure
 } from '@zendeskgarden/react-dropdowns';
+import { Row, Col } from '@zendeskgarden/react-grid';
 import { ReactComponent as LeafIcon } from '@zendeskgarden/svg-icons/src/16/leaf-stroke.svg';
 
 const Example = () => (
-  <Dropdown
-    onSelect={item => {
-      const message = item === 'add-plant' ? 'A plant can be added soon' : `You planted a ${item}`;
+  <Row>
+    <Col textAlign="center">
+      <Dropdown
+        onSelect={item => {
+          const message =
+            item === 'add-plant' ? 'A plant can be added soon' : `You planted a ${item}`;
 
-      alert(message);
-    }}
-  >
-    <Trigger>
-      <Button>Menu</Button>
-    </Trigger>
-    <Menu>
-      <HeaderItem hasIcon>
-        <HeaderIcon>
-          <LeafIcon />
-        </HeaderIcon>
-        Plants
-      </HeaderItem>
-      <Separator />
-      <MediaItem value="cactus">
-        <MediaFigure>
-          <LeafIcon />
-        </MediaFigure>
-        <MediaBody>
-          Cactus
-          <ItemMeta>15 available</ItemMeta>
-        </MediaBody>
-      </MediaItem>
-      <Item value="flower">
-        <MediaFigure>
-          <LeafIcon />
-        </MediaFigure>
-        <MediaBody>Flower</MediaBody>
-      </Item>
-      <Item value="succulent">Succulent</Item>
-      <Separator />
-      <AddItem value="add-plant">Add plant</AddItem>
-    </Menu>
-  </Dropdown>
+          alert(message);
+        }}
+      >
+        <Trigger>
+          <Button>Menu</Button>
+        </Trigger>
+        <Menu>
+          <HeaderItem hasIcon>
+            <HeaderIcon>
+              <LeafIcon />
+            </HeaderIcon>
+            Plants
+          </HeaderItem>
+          <Separator />
+          <MediaItem value="cactus">
+            <MediaFigure>
+              <LeafIcon />
+            </MediaFigure>
+            <MediaBody>
+              Cactus
+              <ItemMeta>15 available</ItemMeta>
+            </MediaBody>
+          </MediaItem>
+          <Item value="flower">
+            <MediaFigure>
+              <LeafIcon />
+            </MediaFigure>
+            <MediaBody>Flower</MediaBody>
+          </Item>
+          <Item value="succulent">Succulent</Item>
+          <Separator />
+          <AddItem value="add-plant">Add plant</AddItem>
+        </Menu>
+      </Dropdown>
+    </Col>
+  </Row>
 );
 
 export default Example;

--- a/src/examples/dropdowns/MenuMeta.tsx
+++ b/src/examples/dropdowns/MenuMeta.tsx
@@ -8,27 +8,32 @@
 import React from 'react';
 import { Dropdown, Menu, Item, ItemMeta, Trigger } from '@zendeskgarden/react-dropdowns';
 import { Button } from '@zendeskgarden/react-buttons';
+import { Row, Col } from '@zendeskgarden/react-grid';
 
 const Example = () => (
-  <Dropdown onSelect={item => alert(`You planted a ${item}`)}>
-    <Trigger>
-      <Button>Menu</Button>
-    </Trigger>
-    <Menu>
-      <Item value="cactus">
-        Cactus
-        <ItemMeta>10 available</ItemMeta>
-      </Item>
-      <Item value="flower">
-        Flower
-        <ItemMeta>20 available</ItemMeta>
-      </Item>
-      <Item value="succulent">
-        Succulent
-        <ItemMeta>30 available</ItemMeta>
-      </Item>
-    </Menu>
-  </Dropdown>
+  <Row>
+    <Col textAlign="center">
+      <Dropdown onSelect={item => alert(`You planted a ${item}`)}>
+        <Trigger>
+          <Button>Menu</Button>
+        </Trigger>
+        <Menu>
+          <Item value="cactus">
+            Cactus
+            <ItemMeta>10 available</ItemMeta>
+          </Item>
+          <Item value="flower">
+            Flower
+            <ItemMeta>20 available</ItemMeta>
+          </Item>
+          <Item value="succulent">
+            Succulent
+            <ItemMeta>30 available</ItemMeta>
+          </Item>
+        </Menu>
+      </Dropdown>
+    </Col>
+  </Row>
 );
 
 export default Example;

--- a/src/examples/dropdowns/MenuNested.tsx
+++ b/src/examples/dropdowns/MenuNested.tsx
@@ -16,6 +16,7 @@ import {
   PreviousItem
 } from '@zendeskgarden/react-dropdowns';
 import { Button } from '@zendeskgarden/react-buttons';
+import { Row, Col } from '@zendeskgarden/react-grid';
 
 const Example = () => {
   const [state, setState] = useState({
@@ -24,59 +25,63 @@ const Example = () => {
   });
 
   return (
-    <Dropdown
-      isOpen={state.isOpen}
-      onSelect={item => {
-        if (item !== 'plants' && item !== 'flowers') {
-          alert(`You planted a ${item}`);
-        }
-      }}
-      onStateChange={(changes, stateAndHelpers) => {
-        const updatedState: any = {};
+    <Row>
+      <Col textAlign="center">
+        <Dropdown
+          isOpen={state.isOpen}
+          onSelect={item => {
+            if (item !== 'plants' && item !== 'flowers') {
+              alert(`You planted a ${item}`);
+            }
+          }}
+          onStateChange={(changes, stateAndHelpers) => {
+            const updatedState: any = {};
 
-        if (Object.prototype.hasOwnProperty.call(changes, 'isOpen')) {
-          updatedState.isOpen =
-            changes.selectedItem === 'flowers' ||
-            changes.selectedItem === 'plants' ||
-            changes.isOpen;
-        }
+            if (Object.prototype.hasOwnProperty.call(changes, 'isOpen')) {
+              updatedState.isOpen =
+                changes.selectedItem === 'flowers' ||
+                changes.selectedItem === 'plants' ||
+                changes.isOpen;
+            }
 
-        if (Object.prototype.hasOwnProperty.call(changes, 'selectedItem')) {
-          updatedState.tempSelectedItem = changes.selectedItem;
+            if (Object.prototype.hasOwnProperty.call(changes, 'selectedItem')) {
+              updatedState.tempSelectedItem = changes.selectedItem;
 
-          if (updatedState.tempSelectedItem === 'flowers') {
-            stateAndHelpers.setHighlightedIndex(1);
-          } else if (updatedState.tempSelectedItem === 'plants') {
-            stateAndHelpers.setHighlightedIndex(3);
-          }
-        }
+              if (updatedState.tempSelectedItem === 'flowers') {
+                stateAndHelpers.setHighlightedIndex(1);
+              } else if (updatedState.tempSelectedItem === 'plants') {
+                stateAndHelpers.setHighlightedIndex(3);
+              }
+            }
 
-        if (Object.keys(updatedState).length > 0) {
-          setState(updatedState);
-        }
-      }}
-    >
-      <Trigger>
-        <Button>Menu</Button>
-      </Trigger>
-      <Menu placement="end">
-        {state.tempSelectedItem === 'flowers' ? (
-          <>
-            <PreviousItem value="plants">Plants</PreviousItem>
-            <Separator />
-            <Item value="daisy">Daisy</Item>
-            <Item value="tulip">Tulip</Item>
-            <Item value="rose">Rose</Item>
-          </>
-        ) : (
-          <>
-            <Item value="cactus">Cactus</Item>
-            <NextItem value="flowers">Flowers</NextItem>
-            <Item value="shrub">Shrub</Item>
-          </>
-        )}
-      </Menu>
-    </Dropdown>
+            if (Object.keys(updatedState).length > 0) {
+              setState(updatedState);
+            }
+          }}
+        >
+          <Trigger>
+            <Button>Menu</Button>
+          </Trigger>
+          <Menu placement="end">
+            {state.tempSelectedItem === 'flowers' ? (
+              <>
+                <PreviousItem value="plants">Plants</PreviousItem>
+                <Separator />
+                <Item value="daisy">Daisy</Item>
+                <Item value="tulip">Tulip</Item>
+                <Item value="rose">Rose</Item>
+              </>
+            ) : (
+              <>
+                <Item value="cactus">Cactus</Item>
+                <NextItem value="flowers">Flowers</NextItem>
+                <Item value="shrub">Shrub</Item>
+              </>
+            )}
+          </Menu>
+        </Dropdown>
+      </Col>
+    </Row>
   );
 };
 

--- a/src/examples/dropdowns/MenuPlacement.tsx
+++ b/src/examples/dropdowns/MenuPlacement.tsx
@@ -8,7 +8,7 @@
 import React from 'react';
 import { Dropdown, Menu, Item, Trigger, GARDEN_PLACEMENT } from '@zendeskgarden/react-dropdowns';
 import { Button } from '@zendeskgarden/react-buttons';
-import styled from 'styled-components';
+import { Row, Col } from '@zendeskgarden/react-grid';
 
 const PLACEMENTS: Record<string, GARDEN_PLACEMENT> = {
   auto: 'auto',
@@ -26,25 +26,21 @@ const PLACEMENTS: Record<string, GARDEN_PLACEMENT> = {
   startBottom: 'start-bottom'
 };
 
-const Center = styled.div`
-  display: flex;
-  justify-content: center;
-  padding: 150px 0;
-`;
-
 const Example = () => (
-  <Center>
-    <Dropdown onSelect={item => alert(`You planted a ${item}`)}>
-      <Trigger>
-        <Button>Menu</Button>
-      </Trigger>
-      <Menu placement={PLACEMENTS.topStart}>
-        <Item value="cactus">Cactus</Item>
-        <Item value="flower">Flower</Item>
-        <Item value="succulent">Succulent</Item>
-      </Menu>
-    </Dropdown>
-  </Center>
+  <Row style={{ margin: 140 }}>
+    <Col textAlign="center">
+      <Dropdown onSelect={item => alert(`You planted a ${item}`)}>
+        <Trigger>
+          <Button>Menu</Button>
+        </Trigger>
+        <Menu placement={PLACEMENTS.topStart}>
+          <Item value="cactus">Cactus</Item>
+          <Item value="flower">Flower</Item>
+          <Item value="succulent">Succulent</Item>
+        </Menu>
+      </Dropdown>
+    </Col>
+  </Row>
 );
 
 export default Example;

--- a/src/examples/dropdowns/MenuSelect.tsx
+++ b/src/examples/dropdowns/MenuSelect.tsx
@@ -7,6 +7,7 @@
 
 import React, { useState } from 'react';
 import { Dropdown, Field, Menu, Item, Select, Label } from '@zendeskgarden/react-dropdowns';
+import { Row, Col } from '@zendeskgarden/react-grid';
 
 interface IItem {
   label: string;
@@ -23,23 +24,27 @@ const Example = () => {
   const [selectedItem, setSelectedItem] = useState(items[0]);
 
   return (
-    <Dropdown
-      selectedItem={selectedItem}
-      onSelect={setSelectedItem}
-      downshiftProps={{ itemToString: (item: IItem) => item && item.label }}
-    >
-      <Field>
-        <Label>Plant</Label>
-        <Select>{selectedItem.label}</Select>
-      </Field>
-      <Menu>
-        {items.map(option => (
-          <Item key={option.value} value={option}>
-            {option.label}
-          </Item>
-        ))}
-      </Menu>
-    </Dropdown>
+    <Row justifyContent="center">
+      <Col sm={5}>
+        <Dropdown
+          selectedItem={selectedItem}
+          onSelect={setSelectedItem}
+          downshiftProps={{ itemToString: (item: IItem) => item && item.label }}
+        >
+          <Field>
+            <Label>Plant</Label>
+            <Select>{selectedItem.label}</Select>
+          </Field>
+          <Menu>
+            {items.map(option => (
+              <Item key={option.value} value={option}>
+                {option.label}
+              </Item>
+            ))}
+          </Menu>
+        </Dropdown>
+      </Col>
+    </Row>
   );
 };
 

--- a/src/examples/dropdowns/MenuSize.tsx
+++ b/src/examples/dropdowns/MenuSize.tsx
@@ -8,37 +8,35 @@
 import React from 'react';
 import { Dropdown, Menu, Item, Trigger } from '@zendeskgarden/react-dropdowns';
 import { Button } from '@zendeskgarden/react-buttons';
-import { Grid, Row, Col } from '@zendeskgarden/react-grid';
+import { Row, Col } from '@zendeskgarden/react-grid';
 
 const Example = () => (
-  <Grid>
-    <Row>
-      <Col textAlign="center">
-        <Dropdown onSelect={item => alert(`You planted a ${item}`)}>
-          <Trigger>
-            <Button>Default</Button>
-          </Trigger>
-          <Menu>
-            <Item value="cactus">Cactus</Item>
-            <Item value="flower">Flower</Item>
-            <Item value="succulent">Succulent</Item>
-          </Menu>
-        </Dropdown>
-      </Col>
-      <Col textAlign="center">
-        <Dropdown onSelect={item => alert(`You planted a ${item}`)}>
-          <Trigger>
-            <Button size="small">Compact</Button>
-          </Trigger>
-          <Menu isCompact>
-            <Item value="cactus">Cactus</Item>
-            <Item value="flower">Flower</Item>
-            <Item value="succulent">Succulent</Item>
-          </Menu>
-        </Dropdown>
-      </Col>
-    </Row>
-  </Grid>
+  <Row alignItems="center">
+    <Col textAlign="center">
+      <Dropdown onSelect={item => alert(`You planted a ${item}`)}>
+        <Trigger>
+          <Button>Default</Button>
+        </Trigger>
+        <Menu>
+          <Item value="cactus">Cactus</Item>
+          <Item value="flower">Flower</Item>
+          <Item value="succulent">Succulent</Item>
+        </Menu>
+      </Dropdown>
+    </Col>
+    <Col textAlign="center">
+      <Dropdown onSelect={item => alert(`You planted a ${item}`)}>
+        <Trigger>
+          <Button size="small">Compact</Button>
+        </Trigger>
+        <Menu isCompact>
+          <Item value="cactus">Cactus</Item>
+          <Item value="flower">Flower</Item>
+          <Item value="succulent">Succulent</Item>
+        </Menu>
+      </Dropdown>
+    </Col>
+  </Row>
 );
 
 export default Example;

--- a/src/examples/dropdowns/MultiselectDefault.tsx
+++ b/src/examples/dropdowns/MultiselectDefault.tsx
@@ -9,7 +9,6 @@ import React, { useState, useEffect, useRef } from 'react';
 import debounce from 'lodash.debounce';
 import { Dropdown, Multiselect, Field, Menu, Item, Label } from '@zendeskgarden/react-dropdowns';
 import { Tag } from '@zendeskgarden/react-tags';
-import { Grid, Row, Col } from '@zendeskgarden/react-grid';
 
 const options = [
   'Asparagus',
@@ -73,36 +72,30 @@ const Example = () => {
   };
 
   return (
-    <Grid>
-      <Row>
-        <Col>
-          <Dropdown
-            inputValue={inputValue}
-            selectedItems={selectedItems}
-            onSelect={items => setSelectedItems(items)}
-            downshiftProps={{ defaultHighlightedIndex: 0 }}
-            onStateChange={changes => {
-              if (Object.prototype.hasOwnProperty.call(changes, 'inputValue')) {
-                setInputValue((changes as any).inputValue);
-              }
-            }}
-          >
-            <Field>
-              <Label>Vegetables</Label>
-              <Multiselect
-                renderItem={({ value, removeValue }: any) => (
-                  <Tag size="large">
-                    <span>{value}</span>
-                    <Tag.Close onClick={() => removeValue()} />
-                  </Tag>
-                )}
-              />
-            </Field>
-            <Menu>{renderOptions()}</Menu>
-          </Dropdown>
-        </Col>
-      </Row>
-    </Grid>
+    <Dropdown
+      inputValue={inputValue}
+      selectedItems={selectedItems}
+      onSelect={items => setSelectedItems(items)}
+      downshiftProps={{ defaultHighlightedIndex: 0 }}
+      onStateChange={changes => {
+        if (Object.prototype.hasOwnProperty.call(changes, 'inputValue')) {
+          setInputValue((changes as any).inputValue);
+        }
+      }}
+    >
+      <Field>
+        <Label>Vegetables</Label>
+        <Multiselect
+          renderItem={({ value, removeValue }: any) => (
+            <Tag size="large">
+              <span>{value}</span>
+              <Tag.Close onClick={() => removeValue()} />
+            </Tag>
+          )}
+        />
+      </Field>
+      <Menu>{renderOptions()}</Menu>
+    </Dropdown>
   );
 };
 

--- a/src/examples/dropdowns/MultiselectOverflow.tsx
+++ b/src/examples/dropdowns/MultiselectOverflow.tsx
@@ -7,9 +7,8 @@
 
 import React, { useState, useEffect, useRef } from 'react';
 import { Dropdown, Multiselect, Field, Menu, Item, Label } from '@zendeskgarden/react-dropdowns';
-import { Grid, Row, Col } from '@zendeskgarden/react-grid';
-import debounce from 'lodash.debounce';
 import { Tag } from '@zendeskgarden/react-tags';
+import debounce from 'lodash.debounce';
 
 const options = [
   'Asparagus',
@@ -76,36 +75,30 @@ const Example = () => {
   };
 
   return (
-    <Grid>
-      <Row>
-        <Col>
-          <Dropdown
-            inputValue={inputValue}
-            selectedItems={selectedItems}
-            onSelect={items => setSelectedItems(items)}
-            downshiftProps={{ defaultHighlightedIndex: 0 }}
-            onStateChange={changes => {
-              if (Object.prototype.hasOwnProperty.call(changes, 'inputValue')) {
-                setInputValue((changes as any).inputValue);
-              }
-            }}
-          >
-            <Field>
-              <Label>Vegetables</Label>
-              <Multiselect
-                renderItem={({ value, removeValue }: any) => (
-                  <Tag size="large">
-                    <span>{value}</span>
-                    <Tag.Close onClick={() => removeValue()} />
-                  </Tag>
-                )}
-              />
-            </Field>
-            <Menu>{renderOptions()}</Menu>
-          </Dropdown>
-        </Col>
-      </Row>
-    </Grid>
+    <Dropdown
+      inputValue={inputValue}
+      selectedItems={selectedItems}
+      onSelect={items => setSelectedItems(items)}
+      downshiftProps={{ defaultHighlightedIndex: 0 }}
+      onStateChange={changes => {
+        if (Object.prototype.hasOwnProperty.call(changes, 'inputValue')) {
+          setInputValue((changes as any).inputValue);
+        }
+      }}
+    >
+      <Field>
+        <Label>Vegetables</Label>
+        <Multiselect
+          renderItem={({ value, removeValue }: any) => (
+            <Tag size="large">
+              <span>{value}</span>
+              <Tag.Close onClick={() => removeValue()} />
+            </Tag>
+          )}
+        />
+      </Field>
+      <Menu>{renderOptions()}</Menu>
+    </Dropdown>
   );
 };
 

--- a/src/examples/dropdowns/MultiselectSize.tsx
+++ b/src/examples/dropdowns/MultiselectSize.tsx
@@ -6,10 +6,11 @@
  */
 
 import React, { useState, useEffect, useRef } from 'react';
+import styled from 'styled-components';
 import { Dropdown, Multiselect, Field, Menu, Item, Label } from '@zendeskgarden/react-dropdowns';
-import { Grid, Row, Col } from '@zendeskgarden/react-grid';
-import debounce from 'lodash.debounce';
+import { Row, Col } from '@zendeskgarden/react-grid';
 import { Tag } from '@zendeskgarden/react-tags';
+import debounce from 'lodash.debounce';
 
 const options = [
   'Asparagus',
@@ -28,6 +29,12 @@ const options = [
   'Yam',
   'Zucchini'
 ];
+
+const StyledCol = styled(Col)`
+  @media (max-width: ${p => p.theme.breakpoints.sm}) {
+    margin-top: ${p => p.theme.space.sm};
+  }
+`;
 
 const Example = () => {
   const [selectedItems, setSelectedItems] = useState([
@@ -73,63 +80,61 @@ const Example = () => {
   };
 
   return (
-    <Grid>
-      <Row justifyContent="center">
-        <Col>
-          <Dropdown
-            inputValue={inputValue}
-            selectedItems={selectedItems}
-            onSelect={items => setSelectedItems(items)}
-            downshiftProps={{ defaultHighlightedIndex: 0 }}
-            onStateChange={changes => {
-              if (Object.prototype.hasOwnProperty.call(changes, 'inputValue')) {
-                setInputValue((changes as any).inputValue);
-              }
-            }}
-          >
-            <Field>
-              <Label>Vegetables</Label>
-              <Multiselect
-                isCompact
-                renderItem={({ value, removeValue }: any) => (
-                  <Tag>
-                    <span>{value}</span>
-                    <Tag.Close onClick={() => removeValue()} />
-                  </Tag>
-                )}
-              />
-            </Field>
-            <Menu isCompact>{renderOptions()}</Menu>
-          </Dropdown>
-        </Col>
-        <Col>
-          <Dropdown
-            inputValue={inputValue}
-            selectedItems={selectedItems}
-            onSelect={items => setSelectedItems(items)}
-            downshiftProps={{ defaultHighlightedIndex: 0 }}
-            onStateChange={changes => {
-              if (Object.prototype.hasOwnProperty.call(changes, 'inputValue')) {
-                setInputValue((changes as any).inputValue);
-              }
-            }}
-          >
-            <Field>
-              <Label>Vegetables</Label>
-              <Multiselect
-                renderItem={({ value, removeValue }: any) => (
-                  <Tag size="large">
-                    <span>{value}</span>
-                    <Tag.Close onClick={() => removeValue()} />
-                  </Tag>
-                )}
-              />
-            </Field>
-            <Menu>{renderOptions()}</Menu>
-          </Dropdown>
-        </Col>
-      </Row>
-    </Grid>
+    <Row alignItems="center">
+      <Col>
+        <Dropdown
+          inputValue={inputValue}
+          selectedItems={selectedItems}
+          onSelect={items => setSelectedItems(items)}
+          downshiftProps={{ defaultHighlightedIndex: 0 }}
+          onStateChange={changes => {
+            if (Object.prototype.hasOwnProperty.call(changes, 'inputValue')) {
+              setInputValue((changes as any).inputValue);
+            }
+          }}
+        >
+          <Field>
+            <Label>Vegetables</Label>
+            <Multiselect
+              isCompact
+              renderItem={({ value, removeValue }: any) => (
+                <Tag>
+                  <span>{value}</span>
+                  <Tag.Close onClick={() => removeValue()} />
+                </Tag>
+              )}
+            />
+          </Field>
+          <Menu isCompact>{renderOptions()}</Menu>
+        </Dropdown>
+      </Col>
+      <StyledCol>
+        <Dropdown
+          inputValue={inputValue}
+          selectedItems={selectedItems}
+          onSelect={items => setSelectedItems(items)}
+          downshiftProps={{ defaultHighlightedIndex: 0 }}
+          onStateChange={changes => {
+            if (Object.prototype.hasOwnProperty.call(changes, 'inputValue')) {
+              setInputValue((changes as any).inputValue);
+            }
+          }}
+        >
+          <Field>
+            <Label>Vegetables</Label>
+            <Multiselect
+              renderItem={({ value, removeValue }: any) => (
+                <Tag size="large">
+                  <span>{value}</span>
+                  <Tag.Close onClick={() => removeValue()} />
+                </Tag>
+              )}
+            />
+          </Field>
+          <Menu>{renderOptions()}</Menu>
+        </Dropdown>
+      </StyledCol>
+    </Row>
   );
 };
 

--- a/src/examples/dropdowns/SelectDefault.tsx
+++ b/src/examples/dropdowns/SelectDefault.tsx
@@ -7,6 +7,7 @@
 
 import React, { useState } from 'react';
 import { Dropdown, Field, Menu, Item, Select, Label } from '@zendeskgarden/react-dropdowns';
+import { Row, Col } from '@zendeskgarden/react-grid';
 
 interface IItem {
   label: string;
@@ -23,23 +24,27 @@ const Example = () => {
   const [selectedItem, setSelectedItem] = useState(items[0]);
 
   return (
-    <Dropdown
-      selectedItem={selectedItem}
-      onSelect={setSelectedItem}
-      downshiftProps={{ itemToString: (item: IItem) => item && item.label }}
-    >
-      <Field>
-        <Label>Plant</Label>
-        <Select>{selectedItem.label}</Select>
-      </Field>
-      <Menu>
-        {items.map(option => (
-          <Item key={option.value} value={option}>
-            {option.label}
-          </Item>
-        ))}
-      </Menu>
-    </Dropdown>
+    <Row justifyContent="center">
+      <Col sm={5}>
+        <Dropdown
+          selectedItem={selectedItem}
+          onSelect={setSelectedItem}
+          downshiftProps={{ itemToString: (item: IItem) => item && item.label }}
+        >
+          <Field>
+            <Label>Plant</Label>
+            <Select>{selectedItem.label}</Select>
+          </Field>
+          <Menu>
+            {items.map(option => (
+              <Item key={option.value} value={option}>
+                {option.label}
+              </Item>
+            ))}
+          </Menu>
+        </Dropdown>
+      </Col>
+    </Row>
   );
 };
 

--- a/src/examples/dropdowns/SelectDisabled.tsx
+++ b/src/examples/dropdowns/SelectDisabled.tsx
@@ -7,14 +7,19 @@
 
 import React from 'react';
 import { Dropdown, Field, Select, Label } from '@zendeskgarden/react-dropdowns';
+import { Row, Col } from '@zendeskgarden/react-grid';
 
 const Example = () => (
-  <Dropdown>
-    <Field>
-      <Label>Plant</Label>
-      <Select disabled>Cactus</Select>
-    </Field>
-  </Dropdown>
+  <Row justifyContent="center">
+    <Col sm={5}>
+      <Dropdown>
+        <Field>
+          <Label>Plant</Label>
+          <Select disabled>Cactus</Select>
+        </Field>
+      </Dropdown>
+    </Col>
+  </Row>
 );
 
 export default Example;

--- a/src/examples/dropdowns/SelectHint.tsx
+++ b/src/examples/dropdowns/SelectHint.tsx
@@ -7,6 +7,7 @@
 
 import React, { useState } from 'react';
 import { Dropdown, Field, Menu, Item, Hint, Select, Label } from '@zendeskgarden/react-dropdowns';
+import { Row, Col } from '@zendeskgarden/react-grid';
 
 interface IItem {
   label: string;
@@ -23,24 +24,28 @@ const Example = () => {
   const [selectedItem, setSelectedItem] = useState(items[0]);
 
   return (
-    <Dropdown
-      selectedItem={selectedItem}
-      onSelect={setSelectedItem}
-      downshiftProps={{ itemToString: (item: IItem) => item && item.label }}
-    >
-      <Field>
-        <Label>Plant</Label>
-        <Hint>Choose your favorite plant</Hint>
-        <Select>{selectedItem.label}</Select>
-      </Field>
-      <Menu>
-        {items.map(option => (
-          <Item key={option.value} value={option}>
-            {option.label}
-          </Item>
-        ))}
-      </Menu>
-    </Dropdown>
+    <Row justifyContent="center">
+      <Col sm={5}>
+        <Dropdown
+          selectedItem={selectedItem}
+          onSelect={setSelectedItem}
+          downshiftProps={{ itemToString: (item: IItem) => item && item.label }}
+        >
+          <Field>
+            <Label>Plant</Label>
+            <Hint>Choose your favorite plant</Hint>
+            <Select>{selectedItem.label}</Select>
+          </Field>
+          <Menu>
+            {items.map(option => (
+              <Item key={option.value} value={option}>
+                {option.label}
+              </Item>
+            ))}
+          </Menu>
+        </Dropdown>
+      </Col>
+    </Row>
   );
 };
 

--- a/src/examples/dropdowns/SelectSize.tsx
+++ b/src/examples/dropdowns/SelectSize.tsx
@@ -6,8 +6,15 @@
  */
 
 import React, { useState } from 'react';
-import { Grid, Row, Col } from '@zendeskgarden/react-grid';
+import styled from 'styled-components';
+import { Row, Col } from '@zendeskgarden/react-grid';
 import { Dropdown, Field, Menu, Item, Select, Label } from '@zendeskgarden/react-dropdowns';
+
+const StyledCol = styled(Col)`
+  @media (max-width: ${p => p.theme.breakpoints.sm}) {
+    margin-top: ${p => p.theme.space.sm};
+  }
+`;
 
 interface IItem {
   label: string;
@@ -25,48 +32,46 @@ const Example = () => {
   const [selectedCompactItem, setSelectedCompactItem] = useState(items[0]);
 
   return (
-    <Grid>
-      <Row>
-        <Col>
-          <Dropdown
-            selectedItem={selectedDefaultItem}
-            onSelect={setSelectedDefaultItem}
-            downshiftProps={{ itemToString: (item: IItem) => item && item.label }}
-          >
-            <Field>
-              <Label>Plant</Label>
-              <Select>{selectedDefaultItem.label}</Select>
-            </Field>
-            <Menu>
-              {items.map(option => (
-                <Item key={option.value} value={option}>
-                  {option.label}
-                </Item>
-              ))}
-            </Menu>
-          </Dropdown>
-        </Col>
-        <Col>
-          <Dropdown
-            selectedItem={selectedCompactItem}
-            onSelect={setSelectedCompactItem}
-            downshiftProps={{ itemToString: (item: IItem) => item && item.label }}
-          >
-            <Field>
-              <Label>Plant</Label>
-              <Select isCompact>{selectedCompactItem.label}</Select>
-            </Field>
-            <Menu isCompact>
-              {items.map(option => (
-                <Item key={option.value} value={option}>
-                  {option.label}
-                </Item>
-              ))}
-            </Menu>
-          </Dropdown>
-        </Col>
-      </Row>
-    </Grid>
+    <Row alignItems="center" justifyContent="center">
+      <Col sm={5}>
+        <Dropdown
+          selectedItem={selectedDefaultItem}
+          onSelect={setSelectedDefaultItem}
+          downshiftProps={{ itemToString: (item: IItem) => item && item.label }}
+        >
+          <Field>
+            <Label>Plant</Label>
+            <Select>{selectedDefaultItem.label}</Select>
+          </Field>
+          <Menu>
+            {items.map(option => (
+              <Item key={option.value} value={option}>
+                {option.label}
+              </Item>
+            ))}
+          </Menu>
+        </Dropdown>
+      </Col>
+      <StyledCol sm={5}>
+        <Dropdown
+          selectedItem={selectedCompactItem}
+          onSelect={setSelectedCompactItem}
+          downshiftProps={{ itemToString: (item: IItem) => item && item.label }}
+        >
+          <Field>
+            <Label>Plant</Label>
+            <Select isCompact>{selectedCompactItem.label}</Select>
+          </Field>
+          <Menu isCompact>
+            {items.map(option => (
+              <Item key={option.value} value={option}>
+                {option.label}
+              </Item>
+            ))}
+          </Menu>
+        </Dropdown>
+      </StyledCol>
+    </Row>
   );
 };
 

--- a/src/examples/dropdowns/SelectValidation.tsx
+++ b/src/examples/dropdowns/SelectValidation.tsx
@@ -6,7 +6,8 @@
  */
 
 import React from 'react';
-import { Grid, Row, Col } from '@zendeskgarden/react-grid';
+import styled from 'styled-components';
+import { Row, Col } from '@zendeskgarden/react-grid';
 import {
   Dropdown,
   Field,
@@ -17,47 +18,51 @@ import {
   Message
 } from '@zendeskgarden/react-dropdowns';
 
+const StyledCol = styled(Col)`
+  @media (max-width: ${p => p.theme.breakpoints.sm}) {
+    margin-top: ${p => p.theme.space.sm};
+  }
+`;
+
 const Example = () => (
-  <Grid>
-    <Row>
-      <Col>
-        <Dropdown selectedItem="success">
-          <Field>
-            <Label>Plant</Label>
-            <Select validation="success">Cactus</Select>
-            <Message validation="success">Cactus was successfully submitted</Message>
-          </Field>
-          <Menu>
-            <Item disabled>Mock dropdown with no selection logic</Item>
-          </Menu>
-        </Dropdown>
-      </Col>
-      <Col>
-        <Dropdown selectedItem="warning">
-          <Field>
-            <Label>Plant</Label>
-            <Select validation="warning">Cactus</Select>
-            <Message validation="warning">A cactus is a very dry plant</Message>
-          </Field>
-          <Menu>
-            <Item disabled>Mock dropdown with no selection logic</Item>
-          </Menu>
-        </Dropdown>
-      </Col>
-      <Col>
-        <Dropdown selectedItem="error">
-          <Field>
-            <Label>Plant</Label>
-            <Select validation="error">Cactus</Select>
-            <Message validation="error">Cactus is currently unavailable</Message>
-          </Field>
-          <Menu>
-            <Item disabled>Mock dropdown with no selection logic</Item>
-          </Menu>
-        </Dropdown>
-      </Col>
-    </Row>
-  </Grid>
+  <Row>
+    <Col sm>
+      <Dropdown selectedItem="success">
+        <Field>
+          <Label>Plant</Label>
+          <Select validation="success">Cactus</Select>
+          <Message validation="success">Cactus was successfully submitted</Message>
+        </Field>
+        <Menu>
+          <Item disabled>Mock dropdown with no selection logic</Item>
+        </Menu>
+      </Dropdown>
+    </Col>
+    <StyledCol sm>
+      <Dropdown selectedItem="warning">
+        <Field>
+          <Label>Plant</Label>
+          <Select validation="warning">Cactus</Select>
+          <Message validation="warning">A cactus is a very dry plant</Message>
+        </Field>
+        <Menu>
+          <Item disabled>Mock dropdown with no selection logic</Item>
+        </Menu>
+      </Dropdown>
+    </StyledCol>
+    <StyledCol sm>
+      <Dropdown selectedItem="error">
+        <Field>
+          <Label>Plant</Label>
+          <Select validation="error">Cactus</Select>
+          <Message validation="error">Cactus is currently unavailable</Message>
+        </Field>
+        <Menu>
+          <Item disabled>Mock dropdown with no selection logic</Item>
+        </Menu>
+      </Dropdown>
+    </StyledCol>
+  </Row>
 );
 
 export default Example;

--- a/src/examples/forms/inputs/Bare.tsx
+++ b/src/examples/forms/inputs/Bare.tsx
@@ -7,12 +7,17 @@
 
 import React from 'react';
 import { Field, Label, Input } from '@zendeskgarden/react-forms';
+import { Row, Col } from '@zendeskgarden/react-grid';
 
 const Example = () => (
-  <Field>
-    <Label>Plant</Label>
-    <Input isBare placeholder="Type plant name" />
-  </Field>
+  <Row justifyContent="center">
+    <Col sm={5}>
+      <Field>
+        <Label>Plant</Label>
+        <Input isBare placeholder="Type plant name" />
+      </Field>
+    </Col>
+  </Row>
 );
 
 export default Example;

--- a/src/examples/forms/inputs/Disabled.tsx
+++ b/src/examples/forms/inputs/Disabled.tsx
@@ -7,12 +7,17 @@
 
 import React from 'react';
 import { Field, Label, Input } from '@zendeskgarden/react-forms';
+import { Row, Col } from '@zendeskgarden/react-grid';
 
 const Example = () => (
-  <Field>
-    <Label>Plant</Label>
-    <Input disabled />
-  </Field>
+  <Row justifyContent="center">
+    <Col sm={5}>
+      <Field>
+        <Label>Plant</Label>
+        <Input disabled />
+      </Field>
+    </Col>
+  </Row>
 );
 
 export default Example;

--- a/src/examples/forms/inputs/FauxInput.tsx
+++ b/src/examples/forms/inputs/FauxInput.tsx
@@ -7,12 +7,17 @@
 
 import React from 'react';
 import { Field, Label, FauxInput } from '@zendeskgarden/react-forms';
+import { Row, Col } from '@zendeskgarden/react-grid';
 
 const Example = () => (
-  <Field>
-    <Label>Plant</Label>
-    <FauxInput>Tulip</FauxInput>
-  </Field>
+  <Row justifyContent="center">
+    <Col sm={5}>
+      <Field>
+        <Label>Plant</Label>
+        <FauxInput>Tulip</FauxInput>
+      </Field>
+    </Col>
+  </Row>
 );
 
 export default Example;

--- a/src/examples/forms/inputs/FocusInset.tsx
+++ b/src/examples/forms/inputs/FocusInset.tsx
@@ -7,12 +7,17 @@
 
 import React from 'react';
 import { Field, Label, Input } from '@zendeskgarden/react-forms';
+import { Row, Col } from '@zendeskgarden/react-grid';
 
 const Example = () => (
-  <Field>
-    <Label>Plant</Label>
-    <Input focusInset />
-  </Field>
+  <Row justifyContent="center">
+    <Col sm={5}>
+      <Field>
+        <Label>Plant</Label>
+        <Input focusInset />
+      </Field>
+    </Col>
+  </Row>
 );
 
 export default Example;

--- a/src/examples/forms/inputs/Hint.tsx
+++ b/src/examples/forms/inputs/Hint.tsx
@@ -7,13 +7,18 @@
 
 import React from 'react';
 import { Field, Label, Hint, Input } from '@zendeskgarden/react-forms';
+import { Row, Col } from '@zendeskgarden/react-grid';
 
 const Example = () => (
-  <Field>
-    <Label>Plant</Label>
-    <Hint>Plants in the Garden</Hint>
-    <Input />
-  </Field>
+  <Row justifyContent="center">
+    <Col sm={5}>
+      <Field>
+        <Label>Plant</Label>
+        <Hint>Plants in the Garden</Hint>
+        <Input />
+      </Field>
+    </Col>
+  </Row>
 );
 
 export default Example;

--- a/src/examples/forms/inputs/Inline.tsx
+++ b/src/examples/forms/inputs/Inline.tsx
@@ -8,6 +8,7 @@
 import React from 'react';
 import { Field, Label, Input } from '@zendeskgarden/react-forms';
 import styled from 'styled-components';
+import { Row, Col } from '@zendeskgarden/react-grid';
 
 const StyledField = styled(Field)`
   display: flex;
@@ -19,10 +20,14 @@ const StyledLabel = styled(Label)`
 `;
 
 const Example = () => (
-  <StyledField>
-    <StyledLabel>Plant</StyledLabel>
-    <Input style={{ margin: 0, width: 'auto' }} />
-  </StyledField>
+  <Row justifyContent="center">
+    <Col size="auto">
+      <StyledField>
+        <StyledLabel>Plant</StyledLabel>
+        <Input style={{ margin: 0, width: 'auto' }} />
+      </StyledField>
+    </Col>
+  </Row>
 );
 
 export default Example;

--- a/src/examples/forms/inputs/Input.tsx
+++ b/src/examples/forms/inputs/Input.tsx
@@ -7,12 +7,17 @@
 
 import React from 'react';
 import { Field, Label, Input } from '@zendeskgarden/react-forms';
+import { Row, Col } from '@zendeskgarden/react-grid';
 
 const Example = () => (
-  <Field>
-    <Label>Plant</Label>
-    <Input />
-  </Field>
+  <Row justifyContent="center">
+    <Col sm={5}>
+      <Field>
+        <Label>Plant</Label>
+        <Input />
+      </Field>
+    </Col>
+  </Row>
 );
 
 export default Example;

--- a/src/examples/forms/inputs/MediaInput.tsx
+++ b/src/examples/forms/inputs/MediaInput.tsx
@@ -7,14 +7,19 @@
 
 import React from 'react';
 import { Field, Label, MediaInput } from '@zendeskgarden/react-forms';
+import { Row, Col } from '@zendeskgarden/react-grid';
 import { ReactComponent as StartIcon } from '@zendeskgarden/svg-icons/src/16/search-stroke.svg';
 import { ReactComponent as EndIcon } from '@zendeskgarden/svg-icons/src/16/leaf-stroke.svg';
 
 const Example = () => (
-  <Field>
-    <Label>Plant</Label>
-    <MediaInput start={<StartIcon />} end={<EndIcon />} />
-  </Field>
+  <Row justifyContent="center">
+    <Col sm={5}>
+      <Field>
+        <Label>Plant</Label>
+        <MediaInput start={<StartIcon />} end={<EndIcon />} />
+      </Field>
+    </Col>
+  </Row>
 );
 
 export default Example;

--- a/src/examples/forms/inputs/Placeholder.tsx
+++ b/src/examples/forms/inputs/Placeholder.tsx
@@ -7,12 +7,17 @@
 
 import React from 'react';
 import { Field, Label, Input } from '@zendeskgarden/react-forms';
+import { Row, Col } from '@zendeskgarden/react-grid';
 
 const Example = () => (
-  <Field>
-    <Label>Plant</Label>
-    <Input placeholder="Plants" />
-  </Field>
+  <Row justifyContent="center">
+    <Col sm={5}>
+      <Field>
+        <Label>Plant</Label>
+        <Input placeholder="Plants" />
+      </Field>
+    </Col>
+  </Row>
 );
 
 export default Example;

--- a/src/examples/forms/inputs/RegularWeightLabel.tsx
+++ b/src/examples/forms/inputs/RegularWeightLabel.tsx
@@ -7,12 +7,17 @@
 
 import React from 'react';
 import { Field, Label, Input } from '@zendeskgarden/react-forms';
+import { Row, Col } from '@zendeskgarden/react-grid';
 
 const Example = () => (
-  <Field>
-    <Label isRegular>Plant</Label>
-    <Input />
-  </Field>
+  <Row justifyContent="center">
+    <Col sm={5}>
+      <Field>
+        <Label isRegular>Plant</Label>
+        <Input />
+      </Field>
+    </Col>
+  </Row>
 );
 
 export default Example;

--- a/src/examples/forms/inputs/Size.tsx
+++ b/src/examples/forms/inputs/Size.tsx
@@ -6,26 +6,31 @@
  */
 
 import React from 'react';
-import { Grid, Row, Col } from '@zendeskgarden/react-grid';
+import styled from 'styled-components';
+import { Row, Col } from '@zendeskgarden/react-grid';
 import { Field, Label, Input } from '@zendeskgarden/react-forms';
 
+const StyledCol = styled(Col)`
+  @media (max-width: ${p => p.theme.breakpoints.sm}) {
+    margin-top: ${p => p.theme.space.sm};
+  }
+`;
+
 const Example = () => (
-  <Grid>
-    <Row>
-      <Col>
-        <Field>
-          <Label>Plant</Label>
-          <Input />
-        </Field>
-      </Col>
-      <Col>
-        <Field>
-          <Label>Plant</Label>
-          <Input isCompact />
-        </Field>
-      </Col>
-    </Row>
-  </Grid>
+  <Row alignItems="center" justifyContent="center">
+    <Col sm={5}>
+      <Field>
+        <Label>Plant</Label>
+        <Input />
+      </Field>
+    </Col>
+    <StyledCol sm={5}>
+      <Field>
+        <Label>Plant</Label>
+        <Input isCompact />
+      </Field>
+    </StyledCol>
+  </Row>
 );
 
 export default Example;

--- a/src/examples/forms/inputs/Textarea.tsx
+++ b/src/examples/forms/inputs/Textarea.tsx
@@ -6,13 +6,31 @@
  */
 
 import React from 'react';
+import styled from 'styled-components';
+import { Row, Col } from '@zendeskgarden/react-grid';
 import { Field, Label, Textarea } from '@zendeskgarden/react-forms';
 
+const StyledCol = styled(Col)`
+  @media (max-width: ${p => p.theme.breakpoints.sm}) {
+    margin-top: ${p => p.theme.space.sm};
+  }
+`;
+
 const Example = () => (
-  <Field>
-    <Label>Plant</Label>
-    <Textarea />
-  </Field>
+  <Row justifyContent="center">
+    <Col sm={5}>
+      <Field>
+        <Label>Plant</Label>
+        <Textarea />
+      </Field>
+    </Col>
+    <StyledCol sm={5}>
+      <Field>
+        <Label>Plant</Label>
+        <Textarea isResizable />
+      </Field>
+    </StyledCol>
+  </Row>
 );
 
 export default Example;

--- a/src/examples/forms/inputs/Validation.tsx
+++ b/src/examples/forms/inputs/Validation.tsx
@@ -7,7 +7,7 @@
 
 import React from 'react';
 import styled from 'styled-components';
-import { Grid, Row, Col } from '@zendeskgarden/react-grid';
+import { Row, Col } from '@zendeskgarden/react-grid';
 import { Field, Label, Input, Message } from '@zendeskgarden/react-forms';
 
 const StyledCol = styled(Col)`
@@ -17,31 +17,29 @@ const StyledCol = styled(Col)`
 `;
 
 const Example = () => (
-  <Grid>
-    <Row>
-      <Col sm={4}>
-        <Field>
-          <Label>Plant</Label>
-          <Input validation="success" />
-          <Message validation="success">A cactus is a beautiful plant</Message>
-        </Field>
-      </Col>
-      <StyledCol sm={4}>
-        <Field>
-          <Label>Plant</Label>
-          <Input validation="warning" />
-          <Message validation="warning">A cactus has thorns</Message>
-        </Field>
-      </StyledCol>
-      <StyledCol sm={4}>
-        <Field>
-          <Label>Plant</Label>
-          <Input validation="error" />
-          <Message validation="error">A cactus belongs in the desert</Message>
-        </Field>
-      </StyledCol>
-    </Row>
-  </Grid>
+  <Row>
+    <Col sm={4}>
+      <Field>
+        <Label>Plant</Label>
+        <Input validation="success" />
+        <Message validation="success">A cactus is a beautiful plant</Message>
+      </Field>
+    </Col>
+    <StyledCol sm={4}>
+      <Field>
+        <Label>Plant</Label>
+        <Input validation="warning" />
+        <Message validation="warning">A cactus has thorns</Message>
+      </Field>
+    </StyledCol>
+    <StyledCol sm={4}>
+      <Field>
+        <Label>Plant</Label>
+        <Input validation="error" />
+        <Message validation="error">A cactus belongs in the desert</Message>
+      </Field>
+    </StyledCol>
+  </Row>
 );
 
 export default Example;


### PR DESCRIPTION
## Description

Apply consistent grid and field widths.

## Detail

- Code wrapper no longer `flex`; each example determines layout
- Utilize implicit `return` whenever possible
- Removed all `Grid` components in order to allow full-bleed layout
- All individual fields contained within `<Col sm={5}>` (unless 3-column)
- Apply vertical margins when columns stack
- Remove useless grid props

## Checklist

- [x] :ok_hand: website updates are Garden Designer approved (add the designer as a reviewer)
- [ ] :black_nib: ~copy updates are approved (add the content strategist as a reviewer)~
- [ ] :wheelchair: ~analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver~
- [ ] :zap: ~audited via [web.dev](https://web.dev/measure/) for performance and SEO~
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
