### PR TITLE
feat: add button group component

### DIFF
--- a/src/examples/button/ButtonGroupSize.tsx
+++ b/src/examples/button/ButtonGroupSize.tsx
@@ -63,13 +63,13 @@ const StyledCol = styled(Col)`
 
 const Example = () => (
   <Row alignItems="center">
-    <Col textAlign="center" sm={5}>
+    <Col textAlign="center" sm>
       <SmallButtonGroup />
     </Col>
-    <StyledCol textAlign="center" sm={5}>
+    <StyledCol textAlign="center" sm>
       <DefaultButtonGroup />
     </StyledCol>
-    <StyledCol textAlign="center" sm={5}>
+    <StyledCol textAlign="center" sm>
       <LargeButtonGroup />
     </StyledCol>
   </Row>

--- a/src/examples/button/ButtonGroupSize.tsx
+++ b/src/examples/button/ButtonGroupSize.tsx
@@ -46,16 +46,14 @@ const LargeButtonGroup = () => {
   );
 };
 
-const Example = () => {
-  return (
-    <Grid>
-      <Row justifyContent="around">
-        <SmallButtonGroup />
-        <DefaultButtonGroup />
-        <LargeButtonGroup />
-      </Row>
-    </Grid>
-  );
-};
+const Example = () => (
+  <Grid>
+    <Row justifyContent="around">
+      <SmallButtonGroup />
+      <DefaultButtonGroup />
+      <LargeButtonGroup />
+    </Row>
+  </Grid>
+);
 
 export default Example;

--- a/src/examples/button/ButtonGroupSize.tsx
+++ b/src/examples/button/ButtonGroupSize.tsx
@@ -6,7 +6,8 @@
  */
 
 import React, { useState } from 'react';
-import { Grid, Row } from '@zendeskgarden/react-grid';
+import styled from 'styled-components';
+import { Row, Col } from '@zendeskgarden/react-grid';
 import { ButtonGroup, Button } from '@zendeskgarden/react-buttons';
 
 const SmallButtonGroup = () => {
@@ -14,8 +15,12 @@ const SmallButtonGroup = () => {
 
   return (
     <ButtonGroup selectedItem={selectedItem} onSelect={newItem => setSelectedItem(newItem)}>
-      <Button value="daisy">Daisy</Button>
-      <Button value="orchid">Orchid</Button>
+      <Button size="small" value="daisy">
+        Daisy
+      </Button>
+      <Button size="small" value="orchid">
+        Orchid
+      </Button>
     </ButtonGroup>
   );
 };
@@ -25,8 +30,12 @@ const DefaultButtonGroup = () => {
 
   return (
     <ButtonGroup selectedItem={selectedItem} onSelect={newItem => setSelectedItem(newItem)}>
-      <Button value="azalea">Azalea</Button>
-      <Button value="violet">Violet</Button>
+      <Button size="medium" value="azalea">
+        Azalea
+      </Button>
+      <Button size="medium" value="violet">
+        Violet
+      </Button>
     </ButtonGroup>
   );
 };
@@ -46,14 +55,24 @@ const LargeButtonGroup = () => {
   );
 };
 
+const StyledCol = styled(Col)`
+  @media (max-width: ${p => p.theme.breakpoints.sm}) {
+    margin-top: ${p => p.theme.space.sm};
+  }
+`;
+
 const Example = () => (
-  <Grid>
-    <Row justifyContent="around">
+  <Row alignItems="center">
+    <Col textAlign="center" sm={5}>
       <SmallButtonGroup />
+    </Col>
+    <StyledCol textAlign="center" sm={5}>
       <DefaultButtonGroup />
+    </StyledCol>
+    <StyledCol textAlign="center" sm={5}>
       <LargeButtonGroup />
-    </Row>
-  </Grid>
+    </StyledCol>
+  </Row>
 );
 
 export default Example;

--- a/src/examples/button/ButtonGroupSize.tsx
+++ b/src/examples/button/ButtonGroupSize.tsx
@@ -1,0 +1,61 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import React, { useState } from 'react';
+import { Grid, Row } from '@zendeskgarden/react-grid';
+import { ButtonGroup, Button } from '@zendeskgarden/react-buttons';
+
+const SmallButtonGroup = () => {
+  const [selectedItem, setSelectedItem] = useState('daisy');
+
+  return (
+    <ButtonGroup selectedItem={selectedItem} onSelect={newItem => setSelectedItem(newItem)}>
+      <Button value="daisy">Daisy</Button>
+      <Button value="orchid">Orchid</Button>
+    </ButtonGroup>
+  );
+};
+
+const DefaultButtonGroup = () => {
+  const [selectedItem, setSelectedItem] = useState('azalea');
+
+  return (
+    <ButtonGroup selectedItem={selectedItem} onSelect={newItem => setSelectedItem(newItem)}>
+      <Button value="azalea">Azalea</Button>
+      <Button value="violet">Violet</Button>
+    </ButtonGroup>
+  );
+};
+
+const LargeButtonGroup = () => {
+  const [selectedItem, setSelectedItem] = useState('jasmine');
+
+  return (
+    <ButtonGroup selectedItem={selectedItem} onSelect={newItem => setSelectedItem(newItem)}>
+      <Button size="large" value="jasmine">
+        Jasmine
+      </Button>
+      <Button size="large" value="marigold">
+        Marigold
+      </Button>
+    </ButtonGroup>
+  );
+};
+
+const Example = () => {
+  return (
+    <Grid>
+      <Row justifyContent="around">
+        <SmallButtonGroup />
+        <DefaultButtonGroup />
+        <LargeButtonGroup />
+      </Row>
+    </Grid>
+  );
+};
+
+export default Example;

--- a/src/examples/button/ButtonGroupType.tsx
+++ b/src/examples/button/ButtonGroupType.tsx
@@ -6,7 +6,8 @@
  */
 
 import React, { useState } from 'react';
-import { Grid, Row } from '@zendeskgarden/react-grid';
+import styled from 'styled-components';
+import { Row, Col } from '@zendeskgarden/react-grid';
 import { ButtonGroup, Button } from '@zendeskgarden/react-buttons';
 
 const DefaultButtonGroup = () => {
@@ -39,13 +40,21 @@ const PrimaryButtonGroup = () => {
   );
 };
 
+const StyledCol = styled(Col)`
+  @media (max-width: ${p => p.theme.breakpoints.sm}) {
+    margin-top: ${p => p.theme.space.sm};
+  }
+`;
+
 const Example = () => (
-  <Grid>
-    <Row justifyContent="around">
+  <Row alignItems="center">
+    <Col textAlign="center" sm={5}>
       <DefaultButtonGroup />
+    </Col>
+    <StyledCol textAlign="center" sm={5}>
       <PrimaryButtonGroup />
-    </Row>
-  </Grid>
+    </StyledCol>
+  </Row>
 );
 
 export default Example;

--- a/src/examples/button/ButtonGroupType.tsx
+++ b/src/examples/button/ButtonGroupType.tsx
@@ -1,0 +1,53 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import React, { useState } from 'react';
+import { Grid, Row } from '@zendeskgarden/react-grid';
+import { ButtonGroup, Button } from '@zendeskgarden/react-buttons';
+
+const DefaultButtonGroup = () => {
+  const [selectedItem, setSelectedItem] = useState('daisy');
+
+  return (
+    <ButtonGroup selectedItem={selectedItem} onSelect={newItem => setSelectedItem(newItem)}>
+      <Button value="daisy">Daisy</Button>
+      <Button value="orchid">Orchid</Button>
+      <Button value="lily">Lily</Button>
+    </ButtonGroup>
+  );
+};
+
+const PrimaryButtonGroup = () => {
+  const [selectedItem, setSelectedItem] = useState('jasmine');
+
+  return (
+    <ButtonGroup selectedItem={selectedItem} onSelect={newItem => setSelectedItem(newItem)}>
+      <Button isPrimary value="jasmine">
+        Jasmine
+      </Button>
+      <Button isPrimary value="marigold">
+        Marigold
+      </Button>
+      <Button isPrimary value="sunflower">
+        Sunflower
+      </Button>
+    </ButtonGroup>
+  );
+};
+
+const Example = () => {
+  return (
+    <Grid>
+      <Row justifyContent="around">
+        <DefaultButtonGroup />
+        <PrimaryButtonGroup />
+      </Row>
+    </Grid>
+  );
+};
+
+export default Example;

--- a/src/examples/button/ButtonGroupType.tsx
+++ b/src/examples/button/ButtonGroupType.tsx
@@ -47,11 +47,11 @@ const StyledCol = styled(Col)`
 `;
 
 const Example = () => (
-  <Row alignItems="center">
-    <Col textAlign="center" sm={5}>
+  <Row>
+    <Col textAlign="center" sm>
       <DefaultButtonGroup />
     </Col>
-    <StyledCol textAlign="center" sm={5}>
+    <StyledCol textAlign="center" sm>
       <PrimaryButtonGroup />
     </StyledCol>
   </Row>

--- a/src/examples/button/ButtonGroupType.tsx
+++ b/src/examples/button/ButtonGroupType.tsx
@@ -39,15 +39,13 @@ const PrimaryButtonGroup = () => {
   );
 };
 
-const Example = () => {
-  return (
-    <Grid>
-      <Row justifyContent="around">
-        <DefaultButtonGroup />
-        <PrimaryButtonGroup />
-      </Row>
-    </Grid>
-  );
-};
+const Example = () => (
+  <Grid>
+    <Row justifyContent="around">
+      <DefaultButtonGroup />
+      <PrimaryButtonGroup />
+    </Row>
+  </Grid>
+);
 
 export default Example;

--- a/src/pages/components/button-group.mdx
+++ b/src/pages/components/button-group.mdx
@@ -46,11 +46,7 @@ import ButtonGroupSizeCode from '!!raw-loader!../../examples/button/ButtonGroupS
 
 ## How to use it well
 
-<!-- markdownlint-disable -->
-
-#### This is a legacy component
-
-Garden does not presently recommend the use of Button Groups.
+This is a legacy component. Garden does not presently recommend the use of Button Groups.
 
 ## Configuration
 

--- a/src/pages/components/button-group.mdx
+++ b/src/pages/components/button-group.mdx
@@ -18,11 +18,6 @@ components:
       </li>
     </ul>
   </Use>
-  <Misuse>
-    <ul>
-      <li>To alternate between views on a page, use Tabs instead</li>
-    </ul>
-  </Misuse>
 </Usage>
 
 ## How to use it
@@ -51,7 +46,9 @@ import ButtonGroupSizeCode from '!!raw-loader!../../examples/button/ButtonGroupS
 
 ## How to use it well
 
-### This is a legacy component
+<!-- markdownlint-disable -->
+
+#### This is a legacy component
 
 Garden does not presently recommend the use of Button Groups.
 

--- a/src/pages/components/button-group.mdx
+++ b/src/pages/components/button-group.mdx
@@ -1,10 +1,73 @@
 ---
 title: Button Group
 description: >
-  Description will be here
+  A Button Group lets users make a selection from a set of options.
+package: '@zendeskgarden/react-buttons'
+components:
+  - buttons/src/elements/ButtonGroup.tsx
+  - buttons/src/elements/Button.tsx
 ---
 
-Content here
+<Usage>
+  <Use>
+    <ul>
+      <li>To make a selection from a set of options</li>
+      <li>
+        This is a legacy component and may be deprecated in the future. Garden does not presently
+        recommend the use of Button Groups.
+      </li>
+    </ul>
+  </Use>
+  <Misuse>
+    <ul>
+      <li>To alternate between views on a page, use Tabs instead</li>
+    </ul>
+  </Misuse>
+</Usage>
+
+## How to use it
+
+### Type
+
+Button Groups can be default or primary.
+
+import ButtonGroupType from '../../examples/button/ButtonGroupType.tsx';
+import ButtonGroupTypeCode from '!!raw-loader!../../examples/button/ButtonGroupType.tsx';
+
+<CodeExample code={ButtonGroupTypeCode}>
+  <ButtonGroupType />
+</CodeExample>
+
+### Size
+
+Button Groups can be small, default, or large.
+
+import ButtonGroupSize from '../../examples/button/ButtonGroupSize.tsx';
+import ButtonGroupSizeCode from '!!raw-loader!../../examples/button/ButtonGroupSize.tsx';
+
+<CodeExample code={ButtonGroupSizeCode}>
+  <ButtonGroupSize />
+</CodeExample>
+
+## How to use it well
+
+### This is a legacy component
+
+Garden does not presently recommend the use of Button Groups.
+
+## Configuration
+
+<Configuration reactPackage={props.data.mdx.package} components={props.data.mdx.components} />
+
+## API
+
+### ButtonGroup
+
+<PropSheet components={props.data.mdx.components} componentName="buttonGroup" />
+
+### Button
+
+<PropSheet components={props.data.mdx.components} componentName="button" />
 
 import { graphql } from 'gatsby';
 


### PR DESCRIPTION
<!-- structure the Title above as the first line of a
  https://conventionalcommits.org/ message. example: "chore:
  add a new 'thing' component page". -->

## Description

This PR introduces the `<ButtonGroup>` component to the website. 

## Detail

<!-- supporting details; screen shot, code, etc. -->

<!-- closes GITHUB_ISSUE -->

## Checklist

- [ ] :ok_hand: website updates are Garden Designer approved (add the designer as a reviewer)
- [ ] :black_nib: copy updates are approved (add the content strategist as a reviewer)
- [ ] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [ ] :zap: audited via [web.dev](https://web.dev/measure/) for performance and SEO
- [ ] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
