### PR TITLE
feat: add autocomplete component page

### DIFF
--- a/src/examples/dropdowns/autocomplete/Default.tsx
+++ b/src/examples/dropdowns/autocomplete/Default.tsx
@@ -60,7 +60,7 @@ const Example = () => {
 
   return (
     <Row justifyContent="center">
-      <Col size="5">
+      <Col size="auto">
         <Dropdown
           inputValue={inputValue}
           selectedItem={selectedItem}

--- a/src/examples/dropdowns/autocomplete/Default.tsx
+++ b/src/examples/dropdowns/autocomplete/Default.tsx
@@ -7,15 +7,7 @@
 
 import React, { useRef, useState, useEffect } from 'react';
 import debounce from 'lodash.debounce';
-import {
-  Item,
-  Hint,
-  Menu,
-  Label,
-  Field,
-  Dropdown,
-  Autocomplete
-} from '@zendeskgarden/react-dropdowns';
+import { Item, Menu, Label, Field, Dropdown, Autocomplete } from '@zendeskgarden/react-dropdowns';
 import { Row, Col } from '@zendeskgarden/react-grid';
 
 const options = [
@@ -70,7 +62,6 @@ const Example = () => {
         >
           <Field>
             <Label>Choose a vegetable</Label>
-            <Hint>This example includes debounce logic</Hint>
             <Autocomplete>{selectedItem}</Autocomplete>
           </Field>
           <Menu>

--- a/src/examples/dropdowns/autocomplete/Default.tsx
+++ b/src/examples/dropdowns/autocomplete/Default.tsx
@@ -60,7 +60,7 @@ const Example = () => {
 
   return (
     <Row justifyContent="center">
-      <Col size="auto">
+      <Col sm={5}>
         <Dropdown
           inputValue={inputValue}
           selectedItem={selectedItem}

--- a/src/examples/dropdowns/autocomplete/Default.tsx
+++ b/src/examples/dropdowns/autocomplete/Default.tsx
@@ -1,0 +1,93 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import React, { useRef, useState, useEffect } from 'react';
+import debounce from 'lodash.debounce';
+import {
+  Item,
+  Hint,
+  Menu,
+  Label,
+  Field,
+  Dropdown,
+  Autocomplete
+} from '@zendeskgarden/react-dropdowns';
+import { Row, Col } from '@zendeskgarden/react-grid';
+
+const options = [
+  'Asparagus',
+  'Brussel sprouts',
+  'Cauliflower',
+  'Garlic',
+  'Jerusalem artichoke',
+  'Kale',
+  'Lettuce',
+  'Onion',
+  'Mushroom',
+  'Potato',
+  'Radish',
+  'Spinach',
+  'Tomato',
+  'Yam',
+  'Zucchini'
+];
+
+const Example = () => {
+  const [selectedItem, setSelectedItem] = useState(options[0]);
+  const [inputValue, setInputValue] = useState('');
+  const [matchingOptions, setMatchingOptions] = useState(options);
+
+  /**
+   * Debounce filtering
+   */
+  const filterMatchingOptionsRef = useRef(
+    debounce((value: string) => {
+      const matchedOptions = options.filter(
+        option => option.trim().toLowerCase().indexOf(value.trim().toLowerCase()) !== -1
+      );
+
+      setMatchingOptions(matchedOptions);
+    }, 300)
+  );
+
+  useEffect(() => {
+    filterMatchingOptionsRef.current(inputValue);
+  }, [inputValue]);
+
+  return (
+    <Row justifyContent="center">
+      <Col size="5">
+        <Dropdown
+          inputValue={inputValue}
+          selectedItem={selectedItem}
+          onSelect={item => setSelectedItem(item)}
+          onInputValueChange={value => setInputValue(value)}
+          downshiftProps={{ defaultHighlightedIndex: 0 }}
+        >
+          <Field>
+            <Label>Choose a vegetable</Label>
+            <Hint>This example includes debounce logic</Hint>
+            <Autocomplete>{selectedItem}</Autocomplete>
+          </Field>
+          <Menu>
+            {matchingOptions.length ? (
+              matchingOptions.map(option => (
+                <Item key={option} value={option}>
+                  <span>{option}</span>
+                </Item>
+              ))
+            ) : (
+              <Item disabled>No matches found</Item>
+            )}
+          </Menu>
+        </Dropdown>
+      </Col>
+    </Row>
+  );
+};
+
+export default Example;

--- a/src/examples/dropdowns/autocomplete/Media.tsx
+++ b/src/examples/dropdowns/autocomplete/Media.tsx
@@ -1,0 +1,85 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import React, { useRef, useState, useEffect } from 'react';
+import debounce from 'lodash.debounce';
+import { Item, Menu, Label, Field, Dropdown, Autocomplete } from '@zendeskgarden/react-dropdowns';
+import { Row, Col } from '@zendeskgarden/react-grid';
+import { ReactComponent as SearchIcon } from '@zendeskgarden/svg-icons/src/16/search-stroke.svg';
+
+const options = [
+  'Asparagus',
+  'Brussel sprouts',
+  'Cauliflower',
+  'Garlic',
+  'Jerusalem artichoke',
+  'Kale',
+  'Lettuce',
+  'Onion',
+  'Mushroom',
+  'Potato',
+  'Radish',
+  'Spinach',
+  'Tomato',
+  'Yam',
+  'Zucchini'
+];
+
+const Example = () => {
+  const [selectedItem, setSelectedItem] = useState(options[0]);
+  const [inputValue, setInputValue] = useState('');
+  const [matchingOptions, setMatchingOptions] = useState(options);
+
+  /**
+   * Debounce filtering
+   */
+  const filterMatchingOptionsRef = useRef(
+    debounce((value: string) => {
+      const matchedOptions = options.filter(
+        option => option.trim().toLowerCase().indexOf(value.trim().toLowerCase()) !== -1
+      );
+
+      setMatchingOptions(matchedOptions);
+    }, 300)
+  );
+
+  useEffect(() => {
+    filterMatchingOptionsRef.current(inputValue);
+  }, [inputValue]);
+
+  return (
+    <Row justifyContent="center">
+      <Col size="4">
+        <Dropdown
+          inputValue={inputValue}
+          selectedItem={selectedItem}
+          onSelect={item => setSelectedItem(item)}
+          onInputValueChange={value => setInputValue(value)}
+          downshiftProps={{ defaultHighlightedIndex: 0 }}
+        >
+          <Field>
+            <Label>Choose a vegetable</Label>
+            <Autocomplete start={<SearchIcon />}>{selectedItem}</Autocomplete>
+          </Field>
+          <Menu>
+            {matchingOptions.length ? (
+              matchingOptions.map(option => (
+                <Item key={option} value={option}>
+                  <span>{option}</span>
+                </Item>
+              ))
+            ) : (
+              <Item disabled>No matches found</Item>
+            )}
+          </Menu>
+        </Dropdown>
+      </Col>
+    </Row>
+  );
+};
+
+export default Example;

--- a/src/examples/dropdowns/autocomplete/Media.tsx
+++ b/src/examples/dropdowns/autocomplete/Media.tsx
@@ -53,7 +53,7 @@ const Example = () => {
 
   return (
     <Row justifyContent="center">
-      <Col size="auto">
+      <Col sm={5}>
         <Dropdown
           inputValue={inputValue}
           selectedItem={selectedItem}

--- a/src/examples/dropdowns/autocomplete/Media.tsx
+++ b/src/examples/dropdowns/autocomplete/Media.tsx
@@ -53,7 +53,7 @@ const Example = () => {
 
   return (
     <Row justifyContent="center">
-      <Col size="4">
+      <Col size="auto">
         <Dropdown
           inputValue={inputValue}
           selectedItem={selectedItem}

--- a/src/examples/dropdowns/autocomplete/Size.tsx
+++ b/src/examples/dropdowns/autocomplete/Size.tsx
@@ -60,7 +60,7 @@ const Example = () => {
 
   return (
     <Row justifyContent="center" alignItems="center">
-      <Col>
+      <Col sm={5}>
         <Dropdown
           inputValue={inputValue}
           selectedItem={selectedItem}
@@ -86,7 +86,7 @@ const Example = () => {
           </Menu>
         </Dropdown>
       </Col>
-      <Col>
+      <Col sm={5}>
         <Dropdown
           inputValue={inputValue}
           selectedItem={selectedItem}

--- a/src/examples/dropdowns/autocomplete/Size.tsx
+++ b/src/examples/dropdowns/autocomplete/Size.tsx
@@ -1,0 +1,119 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import React, { useRef, useState, useEffect } from 'react';
+import debounce from 'lodash.debounce';
+import {
+  Item,
+  Hint,
+  Menu,
+  Label,
+  Field,
+  Dropdown,
+  Autocomplete
+} from '@zendeskgarden/react-dropdowns';
+import { Row, Col } from '@zendeskgarden/react-grid';
+
+const options = [
+  'Asparagus',
+  'Brussel sprouts',
+  'Cauliflower',
+  'Garlic',
+  'Jerusalem artichoke',
+  'Kale',
+  'Lettuce',
+  'Onion',
+  'Mushroom',
+  'Potato',
+  'Radish',
+  'Spinach',
+  'Tomato',
+  'Yam',
+  'Zucchini'
+];
+
+const Example = () => {
+  const [selectedItem, setSelectedItem] = useState(options[0]);
+  const [inputValue, setInputValue] = useState('');
+  const [matchingOptions, setMatchingOptions] = useState(options);
+
+  /**
+   * Debounce filtering
+   */
+  const filterMatchingOptionsRef = useRef(
+    debounce((value: string) => {
+      const matchedOptions = options.filter(
+        option => option.trim().toLowerCase().indexOf(value.trim().toLowerCase()) !== -1
+      );
+
+      setMatchingOptions(matchedOptions);
+    }, 300)
+  );
+
+  useEffect(() => {
+    filterMatchingOptionsRef.current(inputValue);
+  }, [inputValue]);
+
+  return (
+    <Row justifyContent="center">
+      <Col size="4">
+        <Dropdown
+          inputValue={inputValue}
+          selectedItem={selectedItem}
+          onSelect={item => setSelectedItem(item)}
+          onInputValueChange={value => setInputValue(value)}
+          downshiftProps={{ defaultHighlightedIndex: 0 }}
+        >
+          <Field>
+            <Label>Default</Label>
+            <Hint>Choose a vegetable</Hint>
+            <Autocomplete>{selectedItem}</Autocomplete>
+          </Field>
+          <Menu>
+            {matchingOptions.length ? (
+              matchingOptions.map(option => (
+                <Item key={option} value={option}>
+                  <span>{option}</span>
+                </Item>
+              ))
+            ) : (
+              <Item disabled>No matches found</Item>
+            )}
+          </Menu>
+        </Dropdown>
+      </Col>
+      <Col size="4">
+        <Dropdown
+          inputValue={inputValue}
+          selectedItem={selectedItem}
+          onSelect={item => setSelectedItem(item)}
+          onInputValueChange={value => setInputValue(value)}
+          downshiftProps={{ defaultHighlightedIndex: 0 }}
+        >
+          <Field>
+            <Label>Compact</Label>
+            <Hint>Choose a vegetable</Hint>
+            <Autocomplete isCompact>{selectedItem}</Autocomplete>
+          </Field>
+          <Menu isCompact>
+            {matchingOptions.length ? (
+              matchingOptions.map(option => (
+                <Item key={option} value={option}>
+                  <span>{option}</span>
+                </Item>
+              ))
+            ) : (
+              <Item disabled>No matches found</Item>
+            )}
+          </Menu>
+        </Dropdown>
+      </Col>
+    </Row>
+  );
+};
+
+export default Example;

--- a/src/examples/dropdowns/autocomplete/Size.tsx
+++ b/src/examples/dropdowns/autocomplete/Size.tsx
@@ -59,7 +59,7 @@ const Example = () => {
   }, [inputValue]);
 
   return (
-    <Row justifyContent="center">
+    <Row justifyContent="center" alignItems="center">
       <Col>
         <Dropdown
           inputValue={inputValue}

--- a/src/examples/dropdowns/autocomplete/Size.tsx
+++ b/src/examples/dropdowns/autocomplete/Size.tsx
@@ -60,7 +60,7 @@ const Example = () => {
 
   return (
     <Row justifyContent="center">
-      <Col size="4">
+      <Col>
         <Dropdown
           inputValue={inputValue}
           selectedItem={selectedItem}
@@ -86,7 +86,7 @@ const Example = () => {
           </Menu>
         </Dropdown>
       </Col>
-      <Col size="4">
+      <Col>
         <Dropdown
           inputValue={inputValue}
           selectedItem={selectedItem}

--- a/src/pages/components/autocomplete.mdx
+++ b/src/pages/components/autocomplete.mdx
@@ -45,7 +45,7 @@ import DefaultCode from '!!raw-loader!../../examples/dropdowns/autocomplete/Defa
 
 ### Size
 
-Autocomplete comes in two sizes: regular (default) and compact.
+Autocomplete comes in two sizes: default and compact.
 
 import Size from '../../examples/dropdowns/autocomplete/Size.tsx';
 import SizeCode from '!!raw-loader!../../examples/dropdowns/autocomplete/Size.tsx';
@@ -73,7 +73,7 @@ import MediaCode from '!!raw-loader!../../examples/dropdowns/autocomplete/Media.
   <Do imageSource={props.data.dropdownSelectionDo.children[0].publicURL}>
     <p>
       Autocomplete is useful for lists that are too long to read in full (for example, company
-      employees) or that accumulate items over time (for example, inventory).
+      employees) or that accumulate items over time (for example, an inventory).
     </p>
   </Do>
 </BestPractice>

--- a/src/pages/components/autocomplete.mdx
+++ b/src/pages/components/autocomplete.mdx
@@ -69,8 +69,14 @@ import MediaCode from '!!raw-loader!../../examples/dropdowns/autocomplete/Media.
 
 ### Use Autocomplete to narrow down options
 
-Autocomplete is useful for lists that are too long to read in full (for example, company employees)
-or that accumulate items over time (for example, inventory).
+<BestPractice>
+  <Do imageSource={props.data.dropdownSelectionDo.children[0].publicURL}>
+    <p>
+      Autocomplete is useful for lists that are too long to read in full (for example, company
+      employees) or that accumulate items over time (for example, inventory).
+    </p>
+  </Do>
+</BestPractice>
 
 ## Configuration
 
@@ -111,5 +117,14 @@ import { graphql } from 'gatsby';
 export const pageQuery = graphql`
   query($fileAbsolutePath: String) {
     ...SidebarPageFragment
+    dropdownSelectionDo: abstractAsset(
+      layerName: { eq: "components-dropdowns-autocomplete-selection-do" }
+    ) {
+      children {
+        ... on File {
+          publicURL
+        }
+      }
+    }
   }
 `;

--- a/src/pages/components/autocomplete.mdx
+++ b/src/pages/components/autocomplete.mdx
@@ -1,10 +1,110 @@
 ---
 title: Autocomplete
 description: >
-  Description will be here
+  Autocomplete is an input field that filters results as users type. This helps users find
+  something quickly in a large list of options.
+package: '@zendeskgarden/react-dropdowns'
+components:
+  - dropdowns/src/elements/Autocomplete/Autocomplete.tsx
+  - dropdowns/src/elements/Dropdown/Dropdown.tsx
+  - dropdowns/src/elements/Menu/Menu.tsx
+  - dropdowns/src/elements/Menu/Items/Item.tsx
+  - dropdowns/src/elements/Fields/Field.tsx
+  - dropdowns/src/elements/Fields/Hint.tsx
+  - dropdowns/src/elements/Fields/Label.tsx
 ---
 
-Content here
+<Usage>
+  <Use>
+    <ul>
+      <li>To filter down a large list of options</li>
+      <li>To quickly find a known option</li>
+    </ul>
+  </Use>
+  <Misuse>
+    <ul>
+      <li>
+        To make more than one selection use <a href="./multiselect">Multiselect</a> instead
+      </li>
+    </ul>
+  </Misuse>
+</Usage>
+
+## How to use it
+
+### Default
+
+The basic usage of an Autocomplete component.
+
+import Default from '../../examples/dropdowns/autocomplete/Default.tsx';
+import DefaultCode from '!!raw-loader!../../examples/dropdowns/autocomplete/Default.tsx';
+
+<CodeExample code={DefaultCode}>
+  <Default />
+</CodeExample>
+
+### Size
+
+Autocomplete comes in two sizes: regular (default) and compact.
+
+import Size from '../../examples/dropdowns/autocomplete/Size.tsx';
+import SizeCode from '!!raw-loader!../../examples/dropdowns/autocomplete/Size.tsx';
+
+<CodeExample code={SizeCode}>
+  <Size />
+</CodeExample>
+
+### Media
+
+Media elements add even more context to an Autocomplete.
+
+import Media from '../../examples/dropdowns/autocomplete/Media.tsx';
+import MediaCode from '!!raw-loader!../../examples/dropdowns/autocomplete/Media.tsx';
+
+<CodeExample code={MediaCode}>
+  <Media />
+</CodeExample>
+
+## How to use it well
+
+### Use Autocomplete to narrow down options
+
+Autocomplete is useful for lists that are too long to read in full (for example, company employees)
+or that accumulate items over time (for example, inventory).
+
+## Configuration
+
+<Configuration reactPackage={props.data.mdx.package} components={props.data.mdx.components} />
+
+## API
+
+### Autocomplete
+
+<PropSheet components={props.data.mdx.components} componentName="autocomplete" />
+
+### Dropdown
+
+<PropSheet components={props.data.mdx.components} componentName="dropdown" />
+
+### Menu
+
+<PropSheet components={props.data.mdx.components} componentName="menu" />
+
+### Item
+
+<PropSheet components={props.data.mdx.components} componentName="item" />
+
+### Field
+
+<PropSheet components={props.data.mdx.components} componentName="field" />
+
+### Hint
+
+<PropSheet components={props.data.mdx.components} componentName="hint" />
+
+### Label
+
+<PropSheet components={props.data.mdx.components} componentName="label" />
 
 import { graphql } from 'gatsby';
 


### PR DESCRIPTION
## Description

This PR introduces the Autocomplete component page.

## Checklist

- [x] :ok_hand: website updates are Garden Designer approved (add the designer as a reviewer)
- [ ] :black_nib: copy updates are approved (add the content strategist as a reviewer)
- [x] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [x] :zap: audited via [web.dev](https://web.dev/measure/) for performance and SEO
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
