### PR TITLE
fix(examples): static copy for code icon button tooltips

### DIFF
--- a/src/components/MarkdownProvider/components/CodeExample/index.tsx
+++ b/src/components/MarkdownProvider/components/CodeExample/index.tsx
@@ -5,7 +5,7 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import React, { useRef, useState, useMemo, useEffect } from 'react';
+import React, { useRef, useState, useMemo } from 'react';
 import { css, DefaultTheme } from 'styled-components';
 import { ThemeProvider, DEFAULT_THEME, getColor } from '@zendeskgarden/react-theming';
 import { Tooltip } from '@zendeskgarden/react-tooltips';
@@ -22,8 +22,6 @@ export const CodeExample: React.FC<{ code: string }> = ({ children, code }) => {
   const [isRtl, setIsRtl] = useState(false);
   const [isCodeVisible, setIsCodeVisible] = useState(false);
   const focusVisibleRef = useRef(null);
-  const initialTooltipContent = 'Copy to clipboard';
-  const [tooltipContent, setTooltipContent] = useState(initialTooltipContent);
   const COPYRIGHT_REGEXP = /\/\*\*\n\s\*\sCopyright[\s\S]*\*\/\n\n/gmu;
 
   const exampleTheme = useMemo<DefaultTheme>(() => {
@@ -33,20 +31,6 @@ export const CodeExample: React.FC<{ code: string }> = ({ children, code }) => {
   const parameters = useMemo(() => {
     return retrieveCodesandboxParameters(code);
   }, [code]);
-
-  useEffect(() => {
-    let timeout: NodeJS.Timeout;
-
-    if (tooltipContent !== initialTooltipContent) {
-      timeout = setTimeout(() => {
-        setTooltipContent(initialTooltipContent);
-      }, 3000);
-    }
-
-    return () => {
-      clearTimeout(timeout);
-    };
-  }, [tooltipContent]);
 
   return (
     <div
@@ -88,7 +72,7 @@ export const CodeExample: React.FC<{ code: string }> = ({ children, code }) => {
         <form action="https://codesandbox.io/api/v1/sandboxes/define" method="POST" target="_blank">
           <input type="hidden" name="parameters" value={parameters} />
           <input type="hidden" name="query" value="module=src/Example.tsx" />
-          <Tooltip content="Fork in Codesandbox">
+          <Tooltip content="Open in Codesandbox">
             <IconButton
               isPill={false}
               focusInset
@@ -101,12 +85,9 @@ export const CodeExample: React.FC<{ code: string }> = ({ children, code }) => {
             </IconButton>
           </Tooltip>
         </form>
-        <Tooltip content={tooltipContent}>
+        <Tooltip content="Copy code">
           <IconButton
-            onClick={() => {
-              copyToClipboard(code);
-              setTooltipContent('Code copied to clipboard...');
-            }}
+            onClick={() => copyToClipboard(code)}
             isPill={false}
             focusInset
             css={css`
@@ -116,7 +97,7 @@ export const CodeExample: React.FC<{ code: string }> = ({ children, code }) => {
             <CopyStroke />
           </IconButton>
         </Tooltip>
-        <Tooltip content={isCodeVisible ? 'Hide code' : 'Show code'}>
+        <Tooltip content="View code">
           <ToggleIconButton
             onClick={() => setIsCodeVisible(!isCodeVisible)}
             isPressed={isCodeVisible}

--- a/src/layouts/Root/components/Header.tsx
+++ b/src/layouts/Root/components/Header.tsx
@@ -32,7 +32,7 @@ const StyledDesktopNavLink = styled(StyledNavigationLink).attrs({ partiallyActiv
 `;
 
 const StyledHeader = styled.header.attrs({ role: 'banner' })`
-  z-index: 999; /* Ensure header is always placed above menus and content */
+  z-index: 1;
   box-shadow: ${p =>
     p.theme.shadows.lg(
       `${p.theme.space.base * 4}px`,

--- a/src/layouts/Root/index.tsx
+++ b/src/layouts/Root/index.tsx
@@ -40,14 +40,14 @@ const RootLayout: React.FC = ({ children }) => {
     >
       <GlobalStyling />
       <Header />
-      <div
+      <main
         css={`
           flex-grow: 1;
           flex-shrink: 1;
         `}
       >
         {children}
-      </div>
+      </main>
       <Footer />
     </div>
   );

--- a/src/layouts/Titled/components/TOC.tsx
+++ b/src/layouts/Titled/components/TOC.tsx
@@ -119,7 +119,7 @@ export const TOC: React.FC<{ data: IHeading[] }> = ({ data }) => {
     <div
       css={css`
         position: sticky;
-        top: 32px;
+        top: ${p => p.theme.space.lg};
         margin-left: ${p => p.theme.space.base * 15}px;
       `}
     >


### PR DESCRIPTION
## Description

Update code example button tooltip copy per design feedback.

## Detail

The `Toast` notifications for copy/copied will be done in a follow-on PR.

## Checklist

- [x] :ok_hand: website updates are Garden Designer approved (add the designer as a reviewer)
- [x] :black_nib: copy updates are approved (add the content strategist as a reviewer)
- [ ] :wheelchair: ~analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver~
- [x] :zap: audited via [web.dev](https://web.dev/measure/) for performance and SEO
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
