### PR TITLE
fix(examples): menu and icon buttons

### DIFF
--- a/src/examples/button/IconButtonDanger.tsx
+++ b/src/examples/button/IconButtonDanger.tsx
@@ -14,17 +14,17 @@ const Example = () => (
   <Row>
     <Col textAlign="center">
       <IconButton isDanger>
-        <ZendeskIcon />
+        <ZendeskIcon aria-label="Zendesk" />
       </IconButton>
     </Col>
     <Col textAlign="center">
       <IconButton isDanger isBasic={false}>
-        <ZendeskIcon />
+        <ZendeskIcon aria-label="Zendesk" />
       </IconButton>
     </Col>
     <Col textAlign="center">
       <IconButton isDanger isPrimary>
-        <ZendeskIcon />
+        <ZendeskIcon aria-label="Zendesk" />
       </IconButton>
     </Col>
   </Row>

--- a/src/examples/button/IconButtonDisabled.tsx
+++ b/src/examples/button/IconButtonDisabled.tsx
@@ -14,7 +14,7 @@ const Example = () => (
   <Row>
     <Col textAlign="center">
       <IconButton disabled>
-        <ZendeskIcon />
+        <ZendeskIcon aria-label="Zendesk" />
       </IconButton>
     </Col>
   </Row>

--- a/src/examples/button/IconButtonShapes.tsx
+++ b/src/examples/button/IconButtonShapes.tsx
@@ -14,12 +14,12 @@ const Example = () => (
   <Row>
     <Col textAlign="center">
       <IconButton isBasic={false} isPill={false}>
-        <ZendeskIcon />
+        <ZendeskIcon aria-label="Zendesk" />
       </IconButton>
     </Col>
     <Col textAlign="center">
       <IconButton isBasic={false}>
-        <ZendeskIcon />
+        <ZendeskIcon aria-label="Zendesk" />
       </IconButton>
     </Col>
   </Row>

--- a/src/examples/button/IconButtonSizes.tsx
+++ b/src/examples/button/IconButtonSizes.tsx
@@ -14,17 +14,17 @@ const Example = () => (
   <Row alignItems="center">
     <Col textAlign="center">
       <IconButton size="small">
-        <ZendeskIcon />
+        <ZendeskIcon aria-label="Zendesk" />
       </IconButton>
     </Col>
     <Col textAlign="center">
       <IconButton size="medium">
-        <ZendeskIcon />
+        <ZendeskIcon aria-label="Zendesk" />
       </IconButton>
     </Col>
     <Col textAlign="center">
       <IconButton size="large">
-        <ZendeskIcon />
+        <ZendeskIcon aria-label="Zendesk" />
       </IconButton>
     </Col>
   </Row>

--- a/src/examples/button/IconButtonTypes.tsx
+++ b/src/examples/button/IconButtonTypes.tsx
@@ -14,17 +14,17 @@ const Example = () => (
   <Row>
     <Col textAlign="center">
       <IconButton>
-        <ZendeskIcon />
+        <ZendeskIcon aria-label="Zendesk" />
       </IconButton>
     </Col>
     <Col textAlign="center">
       <IconButton isBasic={false}>
-        <ZendeskIcon />
+        <ZendeskIcon aria-label="Zendesk" />
       </IconButton>
     </Col>
     <Col textAlign="center">
       <IconButton isPrimary>
-        <ZendeskIcon />
+        <ZendeskIcon aria-label="Zendesk" />
       </IconButton>
     </Col>
   </Row>

--- a/src/examples/button/SplitButtonSizes.tsx
+++ b/src/examples/button/SplitButtonSizes.tsx
@@ -5,7 +5,7 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import React from 'react';
+import React, { useState } from 'react';
 import styled from 'styled-components';
 import { Row, Col } from '@zendeskgarden/react-grid';
 import { SplitButton, Button, ChevronButton } from '@zendeskgarden/react-buttons';
@@ -17,54 +17,75 @@ const StyledCol = styled(Col)`
   }
 `;
 
-const Example = () => (
-  <Row alignItems="center">
-    <Col textAlign="center" sm>
-      <SplitButton>
-        <Button size="small">Harvest</Button>
-        <Dropdown>
-          <Trigger>
-            <ChevronButton size="small" />
-          </Trigger>
-          <Menu>
-            <Item value="prune">Prune</Item>
-            <Item value="water">Water</Item>
-            <Item value="fertilize">Fertilize</Item>
-          </Menu>
-        </Dropdown>
-      </SplitButton>
-    </Col>
-    <StyledCol textAlign="center" sm>
-      <SplitButton>
-        <Button size="medium">Harvest</Button>
-        <Dropdown>
-          <Trigger>
-            <ChevronButton size="medium" />
-          </Trigger>
-          <Menu>
-            <Item value="prune">Prune</Item>
-            <Item value="water">Water</Item>
-            <Item value="fertilize">Fertilize</Item>
-          </Menu>
-        </Dropdown>
-      </SplitButton>
-    </StyledCol>
-    <StyledCol textAlign="center" sm>
-      <SplitButton>
-        <Button size="large">Harvest</Button>
-        <Dropdown>
-          <Trigger>
-            <ChevronButton size="large" />
-          </Trigger>
-          <Menu>
-            <Item value="prune">Prune</Item>
-            <Item value="water">Water</Item>
-            <Item value="fertilize">Fertilize</Item>
-          </Menu>
-        </Dropdown>
-      </SplitButton>
-    </StyledCol>
-  </Row>
-);
+const Example = () => {
+  const [smallRotated, setSmallRotated] = useState<boolean | undefined>();
+  const [mediumRotated, setMediumRotated] = useState<boolean | undefined>();
+  const [largeRotated, setLargeRotated] = useState<boolean | undefined>();
+
+  return (
+    <Row alignItems="center">
+      <Col textAlign="center" sm>
+        <SplitButton>
+          <Button size="small">Harvest</Button>
+          <Dropdown
+            onStateChange={options =>
+              Object.prototype.hasOwnProperty.call(options, 'isOpen') &&
+              setSmallRotated(options.isOpen)
+            }
+          >
+            <Trigger>
+              <ChevronButton size="small" isRotated={smallRotated} />
+            </Trigger>
+            <Menu placement="bottom-end">
+              <Item value="prune">Prune</Item>
+              <Item value="water">Water</Item>
+              <Item value="fertilize">Fertilize</Item>
+            </Menu>
+          </Dropdown>
+        </SplitButton>
+      </Col>
+      <StyledCol textAlign="center" sm>
+        <SplitButton>
+          <Button size="medium">Harvest</Button>
+          <Dropdown
+            onStateChange={options =>
+              Object.prototype.hasOwnProperty.call(options, 'isOpen') &&
+              setMediumRotated(options.isOpen)
+            }
+          >
+            <Trigger>
+              <ChevronButton size="medium" isRotated={mediumRotated} />
+            </Trigger>
+            <Menu placement="bottom-end">
+              <Item value="prune">Prune</Item>
+              <Item value="water">Water</Item>
+              <Item value="fertilize">Fertilize</Item>
+            </Menu>
+          </Dropdown>
+        </SplitButton>
+      </StyledCol>
+      <StyledCol textAlign="center" sm>
+        <SplitButton>
+          <Button size="large">Harvest</Button>
+          <Dropdown
+            onStateChange={options =>
+              Object.prototype.hasOwnProperty.call(options, 'isOpen') &&
+              setLargeRotated(options.isOpen)
+            }
+          >
+            <Trigger>
+              <ChevronButton size="large" isRotated={largeRotated} />
+            </Trigger>
+            <Menu placement="bottom-end">
+              <Item value="prune">Prune</Item>
+              <Item value="water">Water</Item>
+              <Item value="fertilize">Fertilize</Item>
+            </Menu>
+          </Dropdown>
+        </SplitButton>
+      </StyledCol>
+    </Row>
+  );
+};
 
 export default Example;

--- a/src/examples/button/SplitButtonSizes.tsx
+++ b/src/examples/button/SplitButtonSizes.tsx
@@ -34,7 +34,7 @@ const Example = () => {
             }
           >
             <Trigger>
-              <ChevronButton size="small" isRotated={smallRotated} />
+              <ChevronButton aria-label="other actions" size="small" isRotated={smallRotated} />
             </Trigger>
             <Menu placement="bottom-end">
               <Item value="prune">Prune</Item>
@@ -54,7 +54,7 @@ const Example = () => {
             }
           >
             <Trigger>
-              <ChevronButton size="medium" isRotated={mediumRotated} />
+              <ChevronButton aria-label="other actions" size="medium" isRotated={mediumRotated} />
             </Trigger>
             <Menu placement="bottom-end">
               <Item value="prune">Prune</Item>
@@ -74,7 +74,7 @@ const Example = () => {
             }
           >
             <Trigger>
-              <ChevronButton size="large" isRotated={largeRotated} />
+              <ChevronButton aria-label="other actions" size="large" isRotated={largeRotated} />
             </Trigger>
             <Menu placement="bottom-end">
               <Item value="prune">Prune</Item>

--- a/src/examples/button/SplitButtonTypes.tsx
+++ b/src/examples/button/SplitButtonTypes.tsx
@@ -5,44 +5,59 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import React from 'react';
+import React, { useState } from 'react';
 import { Row, Col } from '@zendeskgarden/react-grid';
 import { SplitButton, Button, ChevronButton } from '@zendeskgarden/react-buttons';
 import { Dropdown, Trigger, Menu, Item } from '@zendeskgarden/react-dropdowns';
 
-const Example = () => (
-  <Row>
-    <Col textAlign="center">
-      <SplitButton>
-        <Button>Harvest</Button>
-        <Dropdown>
-          <Trigger>
-            <ChevronButton />
-          </Trigger>
-          <Menu>
-            <Item value="prune">Prune</Item>
-            <Item value="water">Water</Item>
-            <Item value="fertilize">Fertilize</Item>
-          </Menu>
-        </Dropdown>
-      </SplitButton>
-    </Col>
-    <Col textAlign="center">
-      <SplitButton>
-        <Button isPrimary>Harvest</Button>
-        <Dropdown>
-          <Trigger>
-            <ChevronButton isPrimary />
-          </Trigger>
-          <Menu>
-            <Item value="prune">Prune</Item>
-            <Item value="water">Water</Item>
-            <Item value="fertilize">Fertilize</Item>
-          </Menu>
-        </Dropdown>
-      </SplitButton>
-    </Col>
-  </Row>
-);
+const Example = () => {
+  const [defaultRotated, setDefaultRotated] = useState<boolean | undefined>();
+  const [primaryRotated, setPrimaryRotated] = useState<boolean | undefined>();
+
+  return (
+    <Row>
+      <Col textAlign="center">
+        <SplitButton>
+          <Button>Harvest</Button>
+          <Dropdown
+            onStateChange={options =>
+              Object.prototype.hasOwnProperty.call(options, 'isOpen') &&
+              setDefaultRotated(options.isOpen)
+            }
+          >
+            <Trigger>
+              <ChevronButton isRotated={defaultRotated} />
+            </Trigger>
+            <Menu placement="bottom-end">
+              <Item value="prune">Prune</Item>
+              <Item value="water">Water</Item>
+              <Item value="fertilize">Fertilize</Item>
+            </Menu>
+          </Dropdown>
+        </SplitButton>
+      </Col>
+      <Col textAlign="center">
+        <SplitButton>
+          <Button isPrimary>Harvest</Button>
+          <Dropdown
+            onStateChange={options =>
+              Object.prototype.hasOwnProperty.call(options, 'isOpen') &&
+              setPrimaryRotated(options.isOpen)
+            }
+          >
+            <Trigger>
+              <ChevronButton isPrimary isRotated={primaryRotated} />
+            </Trigger>
+            <Menu placement="bottom-end">
+              <Item value="prune">Prune</Item>
+              <Item value="water">Water</Item>
+              <Item value="fertilize">Fertilize</Item>
+            </Menu>
+          </Dropdown>
+        </SplitButton>
+      </Col>
+    </Row>
+  );
+};
 
 export default Example;

--- a/src/examples/button/SplitButtonTypes.tsx
+++ b/src/examples/button/SplitButtonTypes.tsx
@@ -26,7 +26,7 @@ const Example = () => {
             }
           >
             <Trigger>
-              <ChevronButton isRotated={defaultRotated} />
+              <ChevronButton aria-label="other actions" isRotated={defaultRotated} />
             </Trigger>
             <Menu placement="bottom-end">
               <Item value="prune">Prune</Item>
@@ -46,7 +46,7 @@ const Example = () => {
             }
           >
             <Trigger>
-              <ChevronButton isPrimary isRotated={primaryRotated} />
+              <ChevronButton aria-label="other actions" isPrimary isRotated={primaryRotated} />
             </Trigger>
             <Menu placement="bottom-end">
               <Item value="prune">Prune</Item>

--- a/src/examples/dropdowns/menu/Arrow.tsx
+++ b/src/examples/dropdowns/menu/Arrow.tsx
@@ -7,15 +7,18 @@
 
 import React from 'react';
 import { Dropdown, Menu, Item, Trigger } from '@zendeskgarden/react-dropdowns';
-import { Button } from '@zendeskgarden/react-buttons';
+import { IconButton } from '@zendeskgarden/react-buttons';
 import { Row, Col } from '@zendeskgarden/react-grid';
+import { ReactComponent as LeafIcon } from '@zendeskgarden/svg-icons/src/16/leaf-stroke.svg';
 
 const Example = () => (
   <Row>
     <Col textAlign="center">
       <Dropdown onSelect={item => alert(`You planted a ${item}`)}>
         <Trigger>
-          <Button>Menu</Button>
+          <IconButton aria-label="plant">
+            <LeafIcon />
+          </IconButton>
         </Trigger>
         <Menu hasArrow>
           <Item value="cactus">Cactus</Item>

--- a/src/examples/dropdowns/menu/Button.tsx
+++ b/src/examples/dropdowns/menu/Button.tsx
@@ -5,26 +5,41 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import React from 'react';
+import React, { useState } from 'react';
 import { Dropdown, Menu, Item, Trigger } from '@zendeskgarden/react-dropdowns';
 import { Button } from '@zendeskgarden/react-buttons';
 import { Row, Col } from '@zendeskgarden/react-grid';
+import { ReactComponent as ChevronIcon } from '@zendeskgarden/svg-icons/src/16/chevron-down-stroke.svg';
 
-const Example = () => (
-  <Row>
-    <Col textAlign="center">
-      <Dropdown onSelect={item => alert(`You planted a ${item}`)}>
-        <Trigger>
-          <Button>Menu</Button>
-        </Trigger>
-        <Menu>
-          <Item value="cactus">Cactus</Item>
-          <Item value="flower">Flower</Item>
-          <Item value="succulent">Succulent</Item>
-        </Menu>
-      </Dropdown>
-    </Col>
-  </Row>
-);
+const Example = () => {
+  const [rotated, setRotated] = useState<boolean | undefined>();
+
+  return (
+    <Row>
+      <Col textAlign="center">
+        <Dropdown
+          onSelect={item => alert(`You planted a ${item}`)}
+          onStateChange={options =>
+            Object.prototype.hasOwnProperty.call(options, 'isOpen') && setRotated(options.isOpen)
+          }
+        >
+          <Trigger>
+            <Button>
+              Menu
+              <Button.EndIcon isRotated={rotated}>
+                <ChevronIcon />
+              </Button.EndIcon>
+            </Button>
+          </Trigger>
+          <Menu>
+            <Item value="cactus">Cactus</Item>
+            <Item value="flower">Flower</Item>
+            <Item value="succulent">Succulent</Item>
+          </Menu>
+        </Dropdown>
+      </Col>
+    </Row>
+  );
+};
 
 export default Example;

--- a/src/examples/dropdowns/menu/Disabled.tsx
+++ b/src/examples/dropdowns/menu/Disabled.tsx
@@ -5,28 +5,43 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import React from 'react';
+import React, { useState } from 'react';
 import { Dropdown, Menu, Item, Trigger } from '@zendeskgarden/react-dropdowns';
 import { Button } from '@zendeskgarden/react-buttons';
 import { Row, Col } from '@zendeskgarden/react-grid';
+import { ReactComponent as ChevronIcon } from '@zendeskgarden/svg-icons/src/16/chevron-down-stroke.svg';
 
-const Example = () => (
-  <Row>
-    <Col textAlign="center">
-      <Dropdown onSelect={item => alert(`You planted a ${item}`)}>
-        <Trigger>
-          <Button>Menu</Button>
-        </Trigger>
-        <Menu>
-          <Item value="cactus">Cactus</Item>
-          <Item value="flower" disabled>
-            Flower
-          </Item>
-          <Item value="succulent">Succulent</Item>
-        </Menu>
-      </Dropdown>
-    </Col>
-  </Row>
-);
+const Example = () => {
+  const [rotated, setRotated] = useState<boolean | undefined>();
+
+  return (
+    <Row>
+      <Col textAlign="center">
+        <Dropdown
+          onSelect={item => alert(`You planted a ${item}`)}
+          onStateChange={options =>
+            Object.prototype.hasOwnProperty.call(options, 'isOpen') && setRotated(options.isOpen)
+          }
+        >
+          <Trigger>
+            <Button>
+              Menu
+              <Button.EndIcon isRotated={rotated}>
+                <ChevronIcon />
+              </Button.EndIcon>
+            </Button>
+          </Trigger>
+          <Menu>
+            <Item value="cactus">Cactus</Item>
+            <Item value="flower" disabled>
+              Flower
+            </Item>
+            <Item value="succulent">Succulent</Item>
+          </Menu>
+        </Dropdown>
+      </Col>
+    </Row>
+  );
+};
 
 export default Example;

--- a/src/examples/dropdowns/menu/Media.tsx
+++ b/src/examples/dropdowns/menu/Media.tsx
@@ -5,7 +5,7 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import React from 'react';
+import React, { useState } from 'react';
 import { Button } from '@zendeskgarden/react-buttons';
 import {
   Dropdown,
@@ -22,52 +22,65 @@ import {
   MediaFigure
 } from '@zendeskgarden/react-dropdowns';
 import { Row, Col } from '@zendeskgarden/react-grid';
+import { ReactComponent as ChevronIcon } from '@zendeskgarden/svg-icons/src/16/chevron-down-stroke.svg';
 import { ReactComponent as LeafIcon } from '@zendeskgarden/svg-icons/src/16/leaf-stroke.svg';
 
-const Example = () => (
-  <Row>
-    <Col textAlign="center">
-      <Dropdown
-        onSelect={item => {
-          const message =
-            item === 'add-plant' ? 'A plant can be added soon' : `You planted a ${item}`;
+const Example = () => {
+  const [rotated, setRotated] = useState<boolean | undefined>();
 
-          alert(message);
-        }}
-      >
-        <Trigger>
-          <Button>Menu</Button>
-        </Trigger>
-        <Menu>
-          <HeaderItem hasIcon>
-            <HeaderIcon>
-              <LeafIcon />
-            </HeaderIcon>
-            Plants
-          </HeaderItem>
-          <Separator />
-          <MediaItem value="cactus">
-            <MediaFigure>
-              <LeafIcon />
-            </MediaFigure>
-            <MediaBody>
-              Cactus
-              <ItemMeta>15 available</ItemMeta>
-            </MediaBody>
-          </MediaItem>
-          <Item value="flower">
-            <MediaFigure>
-              <LeafIcon />
-            </MediaFigure>
-            <MediaBody>Flower</MediaBody>
-          </Item>
-          <Item value="succulent">Succulent</Item>
-          <Separator />
-          <AddItem value="add-plant">Add plant</AddItem>
-        </Menu>
-      </Dropdown>
-    </Col>
-  </Row>
-);
+  return (
+    <Row>
+      <Col textAlign="center">
+        <Dropdown
+          onSelect={item => {
+            const message =
+              item === 'add-plant' ? 'A plant can be added soon' : `You planted a ${item}`;
+
+            alert(message);
+          }}
+          onStateChange={options =>
+            Object.prototype.hasOwnProperty.call(options, 'isOpen') && setRotated(options.isOpen)
+          }
+        >
+          <Trigger>
+            <Button>
+              Menu
+              <Button.EndIcon isRotated={rotated}>
+                <ChevronIcon />
+              </Button.EndIcon>
+            </Button>
+          </Trigger>
+          <Menu>
+            <HeaderItem hasIcon>
+              <HeaderIcon>
+                <LeafIcon />
+              </HeaderIcon>
+              Plants
+            </HeaderItem>
+            <Separator />
+            <MediaItem value="cactus">
+              <MediaFigure>
+                <LeafIcon />
+              </MediaFigure>
+              <MediaBody>
+                Cactus
+                <ItemMeta>15 available</ItemMeta>
+              </MediaBody>
+            </MediaItem>
+            <Item value="flower">
+              <MediaFigure>
+                <LeafIcon />
+              </MediaFigure>
+              <MediaBody>Flower</MediaBody>
+            </Item>
+            <Item value="succulent">Succulent</Item>
+            <Separator />
+            <AddItem value="add-plant">Add plant</AddItem>
+          </Menu>
+        </Dropdown>
+      </Col>
+    </Row>
+  );
+};
 
 export default Example;

--- a/src/examples/dropdowns/menu/Meta.tsx
+++ b/src/examples/dropdowns/menu/Meta.tsx
@@ -5,35 +5,50 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import React from 'react';
+import React, { useState } from 'react';
 import { Dropdown, Menu, Item, ItemMeta, Trigger } from '@zendeskgarden/react-dropdowns';
 import { Button } from '@zendeskgarden/react-buttons';
 import { Row, Col } from '@zendeskgarden/react-grid';
+import { ReactComponent as ChevronIcon } from '@zendeskgarden/svg-icons/src/16/chevron-down-stroke.svg';
 
-const Example = () => (
-  <Row>
-    <Col textAlign="center">
-      <Dropdown onSelect={item => alert(`You planted a ${item}`)}>
-        <Trigger>
-          <Button>Menu</Button>
-        </Trigger>
-        <Menu>
-          <Item value="cactus">
-            Cactus
-            <ItemMeta>10 available</ItemMeta>
-          </Item>
-          <Item value="flower">
-            Flower
-            <ItemMeta>20 available</ItemMeta>
-          </Item>
-          <Item value="succulent">
-            Succulent
-            <ItemMeta>30 available</ItemMeta>
-          </Item>
-        </Menu>
-      </Dropdown>
-    </Col>
-  </Row>
-);
+const Example = () => {
+  const [rotated, setRotated] = useState<boolean | undefined>();
+
+  return (
+    <Row>
+      <Col textAlign="center">
+        <Dropdown
+          onSelect={item => alert(`You planted a ${item}`)}
+          onStateChange={options =>
+            Object.prototype.hasOwnProperty.call(options, 'isOpen') && setRotated(options.isOpen)
+          }
+        >
+          <Trigger>
+            <Button>
+              Menu
+              <Button.EndIcon isRotated={rotated}>
+                <ChevronIcon />
+              </Button.EndIcon>
+            </Button>
+          </Trigger>
+          <Menu>
+            <Item value="cactus">
+              Cactus
+              <ItemMeta>10 available</ItemMeta>
+            </Item>
+            <Item value="flower">
+              Flower
+              <ItemMeta>20 available</ItemMeta>
+            </Item>
+            <Item value="succulent">
+              Succulent
+              <ItemMeta>30 available</ItemMeta>
+            </Item>
+          </Menu>
+        </Dropdown>
+      </Col>
+    </Row>
+  );
+};
 
 export default Example;

--- a/src/examples/dropdowns/menu/Nested.tsx
+++ b/src/examples/dropdowns/menu/Nested.tsx
@@ -17,6 +17,7 @@ import {
 } from '@zendeskgarden/react-dropdowns';
 import { Button } from '@zendeskgarden/react-buttons';
 import { Row, Col } from '@zendeskgarden/react-grid';
+import { ReactComponent as ChevronIcon } from '@zendeskgarden/svg-icons/src/16/chevron-down-stroke.svg';
 
 const Example = () => {
   const [state, setState] = useState({
@@ -60,7 +61,12 @@ const Example = () => {
           }}
         >
           <Trigger>
-            <Button>Menu</Button>
+            <Button>
+              Menu
+              <Button.EndIcon isRotated={state.isOpen}>
+                <ChevronIcon />
+              </Button.EndIcon>
+            </Button>
           </Trigger>
           <Menu placement="end">
             {state.tempSelectedItem === 'flowers' ? (

--- a/src/examples/dropdowns/menu/Placement.tsx
+++ b/src/examples/dropdowns/menu/Placement.tsx
@@ -5,10 +5,11 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import React from 'react';
+import React, { useState } from 'react';
 import { Dropdown, Menu, Item, Trigger, GARDEN_PLACEMENT } from '@zendeskgarden/react-dropdowns';
 import { Button } from '@zendeskgarden/react-buttons';
 import { Row, Col } from '@zendeskgarden/react-grid';
+import { ReactComponent as ChevronIcon } from '@zendeskgarden/svg-icons/src/16/chevron-down-stroke.svg';
 
 const PLACEMENTS: Record<string, GARDEN_PLACEMENT> = {
   auto: 'auto',
@@ -26,21 +27,35 @@ const PLACEMENTS: Record<string, GARDEN_PLACEMENT> = {
   startBottom: 'start-bottom'
 };
 
-const Example = () => (
-  <Row style={{ margin: 140 }}>
-    <Col textAlign="center">
-      <Dropdown onSelect={item => alert(`You planted a ${item}`)}>
-        <Trigger>
-          <Button>Menu</Button>
-        </Trigger>
-        <Menu placement={PLACEMENTS.topStart}>
-          <Item value="cactus">Cactus</Item>
-          <Item value="flower">Flower</Item>
-          <Item value="succulent">Succulent</Item>
-        </Menu>
-      </Dropdown>
-    </Col>
-  </Row>
-);
+const Example = () => {
+  const [rotated, setRotated] = useState<boolean | undefined>();
+
+  return (
+    <Row style={{ margin: 140 }}>
+      <Col textAlign="center">
+        <Dropdown
+          onSelect={item => alert(`You planted a ${item}`)}
+          onStateChange={options =>
+            Object.prototype.hasOwnProperty.call(options, 'isOpen') && setRotated(options.isOpen)
+          }
+        >
+          <Trigger>
+            <Button>
+              Menu
+              <Button.EndIcon isRotated={rotated}>
+                <ChevronIcon />
+              </Button.EndIcon>
+            </Button>
+          </Trigger>
+          <Menu placement={PLACEMENTS.topStart}>
+            <Item value="cactus">Cactus</Item>
+            <Item value="flower">Flower</Item>
+            <Item value="succulent">Succulent</Item>
+          </Menu>
+        </Dropdown>
+      </Col>
+    </Row>
+  );
+};
 
 export default Example;

--- a/src/examples/dropdowns/menu/Size.tsx
+++ b/src/examples/dropdowns/menu/Size.tsx
@@ -5,38 +5,66 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import React from 'react';
+import React, { useState } from 'react';
 import { Dropdown, Menu, Item, Trigger } from '@zendeskgarden/react-dropdowns';
 import { Button } from '@zendeskgarden/react-buttons';
 import { Row, Col } from '@zendeskgarden/react-grid';
+import { ReactComponent as ChevronIcon } from '@zendeskgarden/svg-icons/src/16/chevron-down-stroke.svg';
 
-const Example = () => (
-  <Row alignItems="center">
-    <Col textAlign="center">
-      <Dropdown onSelect={item => alert(`You planted a ${item}`)}>
-        <Trigger>
-          <Button>Default</Button>
-        </Trigger>
-        <Menu>
-          <Item value="cactus">Cactus</Item>
-          <Item value="flower">Flower</Item>
-          <Item value="succulent">Succulent</Item>
-        </Menu>
-      </Dropdown>
-    </Col>
-    <Col textAlign="center">
-      <Dropdown onSelect={item => alert(`You planted a ${item}`)}>
-        <Trigger>
-          <Button size="small">Compact</Button>
-        </Trigger>
-        <Menu isCompact>
-          <Item value="cactus">Cactus</Item>
-          <Item value="flower">Flower</Item>
-          <Item value="succulent">Succulent</Item>
-        </Menu>
-      </Dropdown>
-    </Col>
-  </Row>
-);
+const Example = () => {
+  const [defaultRotated, setDefaultRotated] = useState<boolean | undefined>();
+  const [compactRotated, setCompactRotated] = useState<boolean | undefined>();
+
+  return (
+    <Row alignItems="center">
+      <Col textAlign="center">
+        <Dropdown
+          onSelect={item => alert(`You planted a ${item}`)}
+          onStateChange={options =>
+            Object.prototype.hasOwnProperty.call(options, 'isOpen') &&
+            setDefaultRotated(options.isOpen)
+          }
+        >
+          <Trigger>
+            <Button>
+              Default
+              <Button.EndIcon isRotated={defaultRotated}>
+                <ChevronIcon />
+              </Button.EndIcon>
+            </Button>
+          </Trigger>
+          <Menu>
+            <Item value="cactus">Cactus</Item>
+            <Item value="flower">Flower</Item>
+            <Item value="succulent">Succulent</Item>
+          </Menu>
+        </Dropdown>
+      </Col>
+      <Col textAlign="center">
+        <Dropdown
+          onSelect={item => alert(`You planted a ${item}`)}
+          onStateChange={options =>
+            Object.prototype.hasOwnProperty.call(options, 'isOpen') &&
+            setCompactRotated(options.isOpen)
+          }
+        >
+          <Trigger>
+            <Button size="small">
+              Compact
+              <Button.EndIcon isRotated={compactRotated}>
+                <ChevronIcon />
+              </Button.EndIcon>
+            </Button>
+          </Trigger>
+          <Menu isCompact>
+            <Item value="cactus">Cactus</Item>
+            <Item value="flower">Flower</Item>
+            <Item value="succulent">Succulent</Item>
+          </Menu>
+        </Dropdown>
+      </Col>
+    </Row>
+  );
+};
 
 export default Example;

--- a/src/pages/components/menu.mdx
+++ b/src/pages/components/menu.mdx
@@ -4,6 +4,7 @@ description: >
   Menus display a list of available choices.
 package: '@zendeskgarden/react-dropdowns'
 components:
+  - dropdowns/src/elements/Dropdown/Dropdown.tsx
   - dropdowns/src/elements/Menu/Menu.tsx
   - dropdowns/src/elements/Menu/Separator.tsx
   - dropdowns/src/elements/Menu/Items/AddItem.tsx
@@ -134,6 +135,10 @@ import MenuMediaCode from '!!raw-loader!../../examples/dropdowns/menu/Media.tsx'
 <Configuration reactPackage={props.data.mdx.package} components={props.data.mdx.components} />
 
 ## API
+
+### Dropdown
+
+<PropSheet components={props.data.mdx.components} componentName="dropdown" />
 
 ### Menu
 


### PR DESCRIPTION
## Description

- Unless icon buttons have a tooltip, they should include an `aria-label`.
- Update split button examples to incorporate chevron rotation.
- Improve split button menu placement (should be `bottom-end`).
- Update menu examples to use chevron media buttons.
- Update menu-arrow example to use an icon button trigger.
- Add `Dropdown` prop sheet to the Menu component page.

## Checklist

- [x] :ok_hand: website updates are Garden Designer approved (add the designer as a reviewer)
- [ ] :black_nib: ~copy updates are approved (add the content strategist as a reviewer)~
- [x] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [x] :zap: audited via [web.dev](https://web.dev/measure/) for performance and SEO
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
