### PR TITLE
fix: revise icon button icon size

### DIFF
--- a/src/examples/button/IconButtonDanger.tsx
+++ b/src/examples/button/IconButtonDanger.tsx
@@ -8,23 +8,23 @@
 import React from 'react';
 import { Row, Col } from '@zendeskgarden/react-grid';
 import { IconButton } from '@zendeskgarden/react-buttons';
-import { ReactComponent as ZendeskIcon } from '@zendeskgarden/svg-icons/src/26/zendesk.svg';
+import { ReactComponent as LeafIcon } from '@zendeskgarden/svg-icons/src/16/leaf-stroke.svg';
 
 const Example = () => (
   <Row>
     <Col textAlign="center">
       <IconButton isDanger>
-        <ZendeskIcon />
+        <LeafIcon />
       </IconButton>
     </Col>
     <Col textAlign="center">
       <IconButton isDanger isBasic={false}>
-        <ZendeskIcon />
+        <LeafIcon />
       </IconButton>
     </Col>
     <Col textAlign="center">
       <IconButton isDanger isPrimary>
-        <ZendeskIcon />
+        <LeafIcon />
       </IconButton>
     </Col>
   </Row>

--- a/src/examples/button/IconButtonDisabled.tsx
+++ b/src/examples/button/IconButtonDisabled.tsx
@@ -8,13 +8,13 @@
 import React from 'react';
 import { Row, Col } from '@zendeskgarden/react-grid';
 import { IconButton } from '@zendeskgarden/react-buttons';
-import { ReactComponent as ZendeskIcon } from '@zendeskgarden/svg-icons/src/26/zendesk.svg';
+import { ReactComponent as LeafIcon } from '@zendeskgarden/svg-icons/src/16/leaf-stroke.svg';
 
 const Example = () => (
   <Row>
     <Col textAlign="center">
       <IconButton disabled>
-        <ZendeskIcon />
+        <LeafIcon />
       </IconButton>
     </Col>
   </Row>

--- a/src/examples/button/IconButtonShapes.tsx
+++ b/src/examples/button/IconButtonShapes.tsx
@@ -8,18 +8,18 @@
 import React from 'react';
 import { Row, Col } from '@zendeskgarden/react-grid';
 import { IconButton } from '@zendeskgarden/react-buttons';
-import { ReactComponent as ZendeskIcon } from '@zendeskgarden/svg-icons/src/26/zendesk.svg';
+import { ReactComponent as LeafIcon } from '@zendeskgarden/svg-icons/src/16/leaf-stroke.svg';
 
 const Example = () => (
   <Row>
     <Col textAlign="center">
       <IconButton isBasic={false} isPill={false}>
-        <ZendeskIcon />
+        <LeafIcon />
       </IconButton>
     </Col>
     <Col textAlign="center">
       <IconButton isBasic={false}>
-        <ZendeskIcon />
+        <LeafIcon />
       </IconButton>
     </Col>
   </Row>

--- a/src/examples/button/IconButtonSizes.tsx
+++ b/src/examples/button/IconButtonSizes.tsx
@@ -8,23 +8,23 @@
 import React from 'react';
 import { Row, Col } from '@zendeskgarden/react-grid';
 import { IconButton } from '@zendeskgarden/react-buttons';
-import { ReactComponent as ZendeskIcon } from '@zendeskgarden/svg-icons/src/26/zendesk.svg';
+import { ReactComponent as LeafIcon } from '@zendeskgarden/svg-icons/src/16/leaf-stroke.svg';
 
 const Example = () => (
   <Row alignItems="center">
     <Col textAlign="center">
       <IconButton size="small">
-        <ZendeskIcon />
+        <LeafIcon />
       </IconButton>
     </Col>
     <Col textAlign="center">
       <IconButton size="medium">
-        <ZendeskIcon />
+        <LeafIcon />
       </IconButton>
     </Col>
     <Col textAlign="center">
       <IconButton size="large">
-        <ZendeskIcon />
+        <LeafIcon />
       </IconButton>
     </Col>
   </Row>

--- a/src/examples/button/IconButtonTypes.tsx
+++ b/src/examples/button/IconButtonTypes.tsx
@@ -8,23 +8,23 @@
 import React from 'react';
 import { Row, Col } from '@zendeskgarden/react-grid';
 import { IconButton } from '@zendeskgarden/react-buttons';
-import { ReactComponent as ZendeskIcon } from '@zendeskgarden/svg-icons/src/26/zendesk.svg';
+import { ReactComponent as LeafIcon } from '@zendeskgarden/svg-icons/src/16/leaf-stroke.svg';
 
 const Example = () => (
   <Row>
     <Col textAlign="center">
       <IconButton>
-        <ZendeskIcon />
+        <LeafIcon />
       </IconButton>
     </Col>
     <Col textAlign="center">
       <IconButton isBasic={false}>
-        <ZendeskIcon />
+        <LeafIcon />
       </IconButton>
     </Col>
     <Col textAlign="center">
       <IconButton isPrimary>
-        <ZendeskIcon />
+        <LeafIcon />
       </IconButton>
     </Col>
   </Row>


### PR DESCRIPTION
<!-- structure the Title above as the first line of a
  https://conventionalcommits.org/ message. example: "chore:
  add a new 'thing' component page". -->

## Description

This PR introduces a fix to the icon size in the examples of `IconButton` components from 26 to 16 to match the current Garden site implementation. 
<!-- a summary of the changes introduced by this PR. this description
     may populate the commit body if the PR is merged. -->

## Detail

<!-- supporting details; screen shot, code, etc. -->

<!-- closes GITHUB_ISSUE -->

## Checklist

- [ ] :ok_hand: website updates are Garden Designer approved (add the designer as a reviewer)
- [ ] :black_nib: copy updates are approved (add the content strategist as a reviewer)
- [ ] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [ ] :zap: audited via [web.dev](https://web.dev/measure/) for performance and SEO
- [ ] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
