### PR TITLE
fix(home): restore hidden news section

### DIFF
--- a/src/layouts/Home/components/News.tsx
+++ b/src/layouts/Home/components/News.tsx
@@ -40,42 +40,14 @@ export const News: React.FC = () => {
     <div
       css={`
         position: relative;
+        background-color: ${p => getColor('grey', 200, p.theme)};
       `}
     >
-      <div
-        css={css`
-          position: absolute;
-          top: 0;
-          right: 50%;
-          bottom: 0;
-          left: 0;
-          background-color: ${p => getColor('grey', 200, p.theme)};
-
-          @media (max-width: ${p => p.theme.breakpoints.lg}) {
-            display: none;
-          }
-        `}
-      />
-      <div
-        css={css`
-          position: absolute;
-          top: 0;
-          right: 0;
-          bottom: 0;
-          left: 50%;
-          background-color: ${p => getColor('grey', 200, p.theme)};
-
-          @media (max-width: ${p => p.theme.breakpoints.lg}) {
-            display: none;
-          }
-        `}
-      />
       <MaxWidthLayout>
         <Grid gutters="lg">
           <Row>
             <Col
               css={css`
-                background-color: ${p => getColor('grey', 200, p.theme)};
                 padding: ${p => p.theme.space.xxl};
               `}
             >

--- a/src/layouts/Home/components/News.tsx
+++ b/src/layouts/Home/components/News.tsx
@@ -38,7 +38,7 @@ export const News: React.FC = () => {
 
   return (
     <div
-      css={`
+      css={css`
         position: relative;
         background-color: ${p => getColor('grey', 200, p.theme)};
       `}


### PR DESCRIPTION
## Description

Somewhere along recent commits, the `z-index` for the 50/50 news panels got altered so they were covering the content. This PR removes those as they are not currently relevant for the design.

## Checklist

- [x] :ok_hand: website updates are Garden Designer approved (add the designer as a reviewer)
- [ ] :black_nib: ~copy updates are approved (add the content strategist as a reviewer)~
- [ ] :wheelchair: ~analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver~
- [ ] :zap: ~audited via [web.dev](https://web.dev/measure/) for performance and SEO~
- [ ] :memo: ~tested in Chrome, Firefox, Safari, Edge, and IE11~
