### PR TITLE
fix: image quality and sizing

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -82,7 +82,12 @@ module.exports = {
         trackingIds: ['UA-970836-25']
       }
     },
-    `gatsby-plugin-sharp`,
+    {
+      resolve: `gatsby-plugin-sharp`,
+      options: {
+        defaultQuality: 90
+      }
+    },
     `gatsby-plugin-remove-trailing-slashes`,
     `gatsby-plugin-netlify`,
     {

--- a/src/components/MarkdownProvider/components/BestPractice.tsx
+++ b/src/components/MarkdownProvider/components/BestPractice.tsx
@@ -7,13 +7,14 @@
 
 import React, { ReactNode } from 'react';
 import styled from 'styled-components';
-import { ReactComponent as XStrokeIcon } from '@zendeskgarden/svg-icons/src/16/x-stroke.svg';
-import { ReactComponent as CheckLgStrokeIcon } from '@zendeskgarden/svg-icons/src/16/check-lg-stroke.svg';
-import { ReactComponent as AlertErrorStrokeIcon } from '@zendeskgarden/svg-icons/src/16/alert-error-stroke.svg';
+import { math } from 'polished';
+import Img, { FluidObject } from 'gatsby-image';
 import { Well, Title } from '@zendeskgarden/react-notifications';
 import { getColor } from '@zendeskgarden/react-theming';
 import { Row, Col } from '@zendeskgarden/react-grid';
-import { math } from 'polished';
+import { ReactComponent as XStrokeIcon } from '@zendeskgarden/svg-icons/src/16/x-stroke.svg';
+import { ReactComponent as CheckLgStrokeIcon } from '@zendeskgarden/svg-icons/src/16/check-lg-stroke.svg';
+import { ReactComponent as AlertErrorStrokeIcon } from '@zendeskgarden/svg-icons/src/16/alert-error-stroke.svg';
 
 const StyledRow = styled(Row)`
   margin-top: ${p => p.theme.space.lg};
@@ -40,14 +41,13 @@ const StyledFigure = styled.figure`
   flex-grow: 1;
 `;
 
-const StyledImg = styled.img`
+const StyledImgContainer = styled.div`
   border: ${p => `${p.theme.borders.sm} ${getColor('neutralHue', 300, p.theme)}`};
   border-bottom: none;
   border-top-left-radius: ${p => p.theme.borderRadii.md};
   border-top-right-radius: ${p => p.theme.borderRadii.md};
   padding: ${p => p.theme.space.md};
-  object-fit: contain;
-  max-height: 216px;
+  text-align: center;
 `;
 
 interface IStyledCaptionProps {
@@ -100,7 +100,7 @@ interface ICaptionProps {
   hue: string;
   title: string;
   icon: ReactNode;
-  imageSource?: string;
+  imageSource?: string | FluidObject;
 }
 
 const Caption: React.FC<ICaptionProps> = props => (
@@ -115,13 +115,43 @@ const Caption: React.FC<ICaptionProps> = props => (
 
 interface ISectionProps extends ICaptionProps {
   imageAlt?: string;
+  imageHeight?: number;
+  imageWidth?: number;
+  imageIsSquare?: boolean;
 }
 
 export const Section: React.FC<ISectionProps> = props => {
   if (props.imageSource) {
+    const imageStyles = {
+      width: props.imageWidth,
+      height: props.imageHeight,
+      maxWidth: props.imageIsSquare ? 160 : undefined,
+      maxHeight: 160
+    };
+
     return (
       <StyledFigure>
-        <StyledImg alt={props.imageAlt} src={props.imageSource} />
+        <StyledImgContainer>
+          {typeof props.imageSource === 'string' ? (
+            <div
+              css={`
+                display: flex;
+                justify-content: center;
+              `}
+            >
+              <img alt={props.imageAlt} src={props.imageSource} style={imageStyles} />
+            </div>
+          ) : (
+            <Img
+              alt={props.imageAlt}
+              fluid={props.imageSource}
+              style={{
+                margin: '0 auto',
+                ...imageStyles
+              }}
+            />
+          )}
+        </StyledImgContainer>
         <Caption {...props} />
       </StyledFigure>
     );

--- a/src/layouts/Home/components/Foundation.tsx
+++ b/src/layouts/Home/components/Foundation.tsx
@@ -30,8 +30,8 @@ const FoundationLink: React.FC<{
   >
     <Img
       fluid={image.childFile.childImageSharp.fluid}
-      alt={`${group} overview image`}
-      imgStyle={{ width: 288, minWidth: '100%', height: 220, minHeight: '100%', maxHeight: '100%' }}
+      alt=""
+      imgStyle={{ width: 350, minWidth: '100%', height: 266, minHeight: '100%', maxHeight: '100%' }}
     />
     <div
       css={css`
@@ -77,7 +77,7 @@ export const Foundation: React.FC = () => {
         contentImage: abstractAsset(layerName: { eq: "home-pillars-content" }) {
           childFile {
             childImageSharp {
-              fluid(maxWidth: 288, traceSVG: { background: "#03363D", color: "white" }) {
+              fluid(maxWidth: 350, traceSVG: { background: "#F6F4F4", color: "#228F67" }) {
                 ...GatsbyImageSharpFluid_tracedSVG
               }
             }
@@ -86,7 +86,7 @@ export const Foundation: React.FC = () => {
         designImage: abstractAsset(layerName: { eq: "home-pillars-design" }) {
           childFile {
             childImageSharp {
-              fluid(maxWidth: 288, traceSVG: { background: "#03363D", color: "white" }) {
+              fluid(maxWidth: 350, traceSVG: { background: "#EDE0CF", color: "#00363D" }) {
                 ...GatsbyImageSharpFluid_tracedSVG
               }
             }
@@ -95,7 +95,7 @@ export const Foundation: React.FC = () => {
         componentsImage: abstractAsset(layerName: { eq: "home-pillars-components" }) {
           childFile {
             childImageSharp {
-              fluid(maxWidth: 288, traceSVG: { background: "#03363D", color: "white" }) {
+              fluid(maxWidth: 350, traceSVG: { background: "#F6F4F4", color: "#00363D" }) {
                 ...GatsbyImageSharpFluid_tracedSVG
               }
             }

--- a/src/layouts/Home/components/Search.tsx
+++ b/src/layouts/Home/components/Search.tsx
@@ -72,7 +72,7 @@ export const Search: React.FC = () => {
             >
               <Img
                 fluid={bannerImage.childFile.childImageSharp.fluid}
-                alt="Garden search banner image"
+                alt=""
                 css={css`
                   margin-top: ${p => p.theme.space.xxl};
                   margin-right: auto;

--- a/src/pages/components/autocomplete.mdx
+++ b/src/pages/components/autocomplete.mdx
@@ -72,7 +72,7 @@ import SizeCode from '!!raw-loader!../../examples/dropdowns/autocomplete/Size.ts
 ### Use Autocomplete to narrow down options
 
 <BestPractice>
-  <Do imageSource={props.data.dropdownSelectionDo.children[0].publicURL}>
+  <Do imageSource={props.data.dropdownSelectionDo.childFile.childImageSharp.fluid} imageIsSquare>
     <p>
       Autocomplete is useful for lists that are too long to read in full (for example, company
       employees) or that accumulate items over time (for example, an inventory).
@@ -122,9 +122,11 @@ export const pageQuery = graphql`
     dropdownSelectionDo: abstractAsset(
       layerName: { eq: "components-dropdowns-autocomplete-selection-do" }
     ) {
-      children {
-        ... on File {
-          publicURL
+      childFile {
+        childImageSharp {
+          fluid(maxHeight: 200) {
+            ...GatsbyImageSharpFluid
+          }
         }
       }
     }

--- a/src/pages/components/avatar.mdx
+++ b/src/pages/components/avatar.mdx
@@ -70,10 +70,10 @@ Use circles to represent people and rounded squares for objects, brands, or prod
 user distinguish between the two when scanning a page.
 
 <BestPractice>
-  <Do imageSource={props.data.avatarShapeCircle.children[0].publicURL}>
+  <Do imageSource={props.data.avatarShapeCircle.childFile.childImageSharp.fluid}>
     <p>Use a circular Avatar for people.</p>
   </Do>
-  <Do imageSource={props.data.avatarShapeSquare.children[0].publicURL}>
+  <Do imageSource={props.data.avatarShapeSquare.childFile.childImageSharp.fluid}>
     <p>Use a rounded square Avatar for objects, brands, or Zendesk products.</p>
   </Do>
 </BestPractice>
@@ -96,16 +96,20 @@ export const pageQuery = graphql`
   query($fileAbsolutePath: String) {
     ...SidebarPageFragment
     avatarShapeCircle: abstractAsset(layerName: { eq: "components-avatar-shape-circle" }) {
-      children {
-        ... on File {
-          publicURL
+      childFile {
+        childImageSharp {
+          fluid(maxHeight: 200) {
+            ...GatsbyImageSharpFluid
+          }
         }
       }
     }
     avatarShapeSquare: abstractAsset(layerName: { eq: "components-avatar-shape-square" }) {
-      children {
-        ... on File {
-          publicURL
+      childFile {
+        childImageSharp {
+          fluid(maxHeight: 200) {
+            ...GatsbyImageSharpFluid
+          }
         }
       }
     }

--- a/src/pages/components/checkbox.mdx
+++ b/src/pages/components/checkbox.mdx
@@ -121,7 +121,7 @@ import ValidationCode from '!!raw-loader!../../examples/forms/checkbox/Validatio
 ### Use to select any number of options
 
 <BestPractice>
-  <Do imageSource={props.data.checkboxSelectionDo.children[0].publicURL}>
+  <Do imageSource={props.data.checkboxSelectionDo.childFile.childImageSharp.fluid}>
     <p>
       <Markdown>
         Use to turn a standalone setting on and off, as a favorable alternative to a
@@ -129,7 +129,7 @@ import ValidationCode from '!!raw-loader!../../examples/forms/checkbox/Validatio
       </Markdown>
     </p>
   </Do>
-  <Dont imageSource={props.data.checkboxStandaloneOptionDont.children[0].publicURL}>
+  <Dont imageSource={props.data.checkboxStandaloneOptionDont.childFile.childImageSharp.fluid}>
     <p>
       <Markdown>
         Use to select exactly one option from a set of two or more. Use [Radios](/components/radio)
@@ -173,18 +173,22 @@ export const pageQuery = graphql`
     checkboxSelectionDo: abstractAsset(
       layerName: { eq: "components-forms-checkbox-standalone-do" }
     ) {
-      children {
-        ... on File {
-          publicURL
+      childFile {
+        childImageSharp {
+          fluid(maxHeight: 200) {
+            ...GatsbyImageSharpFluid
+          }
         }
       }
     }
     checkboxStandaloneOptionDont: abstractAsset(
       layerName: { eq: "components-forms-checkbox-standalone-option-dont" }
     ) {
-      children {
-        ... on File {
-          publicURL
+      childFile {
+        childImageSharp {
+          fluid(maxHeight: 200) {
+            ...GatsbyImageSharpFluid
+          }
         }
       }
     }

--- a/src/pages/components/icon-button.mdx
+++ b/src/pages/components/icon-button.mdx
@@ -100,7 +100,7 @@ import IconButtonTypesCode from '!!raw-loader!../../examples/button/IconButtonTy
 ### Don't leave users in the dark
 
 <BestPractice>
-  <Do imageSource={props.data.iconButtonTooltipDo.children[0].publicURL}>
+  <Do imageSource={props.data.iconButtonTooltipDo.childFile.childImageSharp.fluid} imageIsSquare>
     <p>Include a Tooltip to help any users who may be unfamiliar with the icon.</p>
   </Do>
 </BestPractice>
@@ -123,9 +123,11 @@ export const pageQuery = graphql`
     iconButtonTooltipDo: abstractAsset(
       layerName: { eq: "components-buttons-iconbutton-tooltip-do" }
     ) {
-      children {
-        ... on File {
-          publicURL
+      childFile {
+        childImageSharp {
+          fluid(maxHeight: 200) {
+            ...GatsbyImageSharpFluid
+          }
         }
       }
     }


### PR DESCRIPTION
## Description

- Bump `defaultQuality` for `gatsby-plugin-sharp` to 90
- Allow `BestPractice` component to receive a `FluidObject` for `<Img>` rendering
- Clear unnecessary `alt` tags
- Improve SVG tracing for home page navigation graphics

## Detail

Refer to internal channel 🧵  for image quality notes.

## Checklist

- [x] :ok_hand: website updates are Garden Designer approved (add the designer as a reviewer)
- [ ] :black_nib: ~copy updates are approved (add the content strategist as a reviewer)~
- [x] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [x] :zap: audited via [web.dev](https://web.dev/measure/) for performance and SEO
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
