### PR TITLE
fix(examples): update dropdown size examples to use separate state

### DIFF
--- a/src/examples/dropdowns/autocomplete/Size.tsx
+++ b/src/examples/dropdowns/autocomplete/Size.tsx
@@ -39,6 +39,8 @@ const options = [
 const Example = () => {
   const [selectedItem, setSelectedItem] = useState(options[0]);
   const [inputValue, setInputValue] = useState('');
+  const [compactSelectedItem, setCompactSelectedItem] = useState(options[0]);
+  const [compactInputValue, setCompactInputValue] = useState('');
   const [matchingOptions, setMatchingOptions] = useState(options);
 
   /**
@@ -88,16 +90,16 @@ const Example = () => {
       </Col>
       <Col sm={5}>
         <Dropdown
-          inputValue={inputValue}
-          selectedItem={selectedItem}
-          onSelect={item => setSelectedItem(item)}
-          onInputValueChange={value => setInputValue(value)}
+          inputValue={compactInputValue}
+          selectedItem={compactSelectedItem}
+          onSelect={item => setCompactSelectedItem(item)}
+          onInputValueChange={value => setCompactInputValue(value)}
           downshiftProps={{ defaultHighlightedIndex: 0 }}
         >
           <Field>
             <Label>Compact</Label>
             <Hint>Choose a vegetable</Hint>
-            <Autocomplete isCompact>{selectedItem}</Autocomplete>
+            <Autocomplete isCompact>{compactSelectedItem}</Autocomplete>
           </Field>
           <Menu isCompact>
             {matchingOptions.length ? (

--- a/src/examples/dropdowns/multiselect/Size.tsx
+++ b/src/examples/dropdowns/multiselect/Size.tsx
@@ -36,14 +36,13 @@ const StyledCol = styled(Col)`
   }
 `;
 
+const initialSelectedItems = [options[0], options[1], options[2], options[3]];
+
 const Example = () => {
-  const [selectedItems, setSelectedItems] = useState([
-    options[0],
-    options[1],
-    options[2],
-    options[3]
-  ]);
+  const [selectedItems, setSelectedItems] = useState(initialSelectedItems);
+  const [compactSelectedItems, setCompactSelectedItems] = useState(initialSelectedItems);
   const [inputValue, setInputValue] = useState('');
+  const [compactInputValue, setCompactInputValue] = useState('');
   const [isLoading, setIsLoading] = useState(false);
   const [matchingOptions, setMatchingOptions] = useState(options);
 
@@ -62,6 +61,11 @@ const Example = () => {
     setIsLoading(true);
     filterMatchingOptionsRef.current(inputValue);
   }, [inputValue]);
+
+  useEffect(() => {
+    setIsLoading(true);
+    filterMatchingOptionsRef.current(compactInputValue);
+  }, [compactInputValue]);
 
   const renderOptions = () => {
     if (isLoading) {
@@ -109,13 +113,13 @@ const Example = () => {
       </Col>
       <StyledCol>
         <Dropdown
-          inputValue={inputValue}
-          selectedItems={selectedItems}
-          onSelect={items => setSelectedItems(items)}
+          inputValue={compactInputValue}
+          selectedItems={compactSelectedItems}
+          onSelect={items => setCompactSelectedItems(items)}
           downshiftProps={{ defaultHighlightedIndex: 0 }}
           onStateChange={changes => {
             if (Object.prototype.hasOwnProperty.call(changes, 'inputValue')) {
-              setInputValue((changes as any).inputValue);
+              setCompactInputValue((changes as any).inputValue);
             }
           }}
         >


### PR DESCRIPTION
## Description

This PR updates the Autocomplete and Multiselect to use individual component state so that interaction with one component does not affect the other.

## Detail

❌  **before (autocomplete)**: selecting one autocomplete affects the other
<img src="https://user-images.githubusercontent.com/1811365/86956572-24d71600-c10e-11ea-8317-76d18bf35e46.gif" width="500" />

✅ **after (autocomplete)**: selecting one autocomplete does not affects the other
<img src="https://user-images.githubusercontent.com/1811365/86956531-1426a000-c10e-11ea-8e5d-256578a2ef31.gif" width="500" />

❌ **before (multiselect)**: interacting with one multiselect affects the other
<img src="https://user-images.githubusercontent.com/1811365/86956588-2dc7e780-c10e-11ea-9f0e-9beda0fabf76.gif" width="500" />

✅ **after (multiselect)**: interacting with one multiselect does not affects the other
<img src="https://user-images.githubusercontent.com/1811365/86956670-50f29700-c10e-11ea-8c80-91f4fdf49bac.gif" width="500" />




<!-- closes GITHUB_ISSUE -->

## Checklist

- [ ] :ok_hand: website updates are Garden Designer approved (add the designer as a reviewer)
- [x] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [x] :zap: audited via [web.dev](https://web.dev/measure/) for performance and SEO
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
