### PR TITLE
fix: failing contrast ratios

### DIFF
--- a/src/layouts/Home/components/SectionCallout.tsx
+++ b/src/layouts/Home/components/SectionCallout.tsx
@@ -14,7 +14,7 @@ export const StyledSectionHeader = styled.div`
   text-transform: uppercase;
   line-height: ${p => p.theme.lineHeights.sm};
   letter-spacing: 0.5px;
-  color: ${p => getColor('neutralHue', 500, p.theme)};
+  color: ${p => getColor('neutralHue', 600, p.theme)};
   font-size: ${p => p.theme.fontSizes.xs};
   font-weight: ${p => p.theme.fontWeights.semibold};
 `;


### PR DESCRIPTION
## Description

This pull request fixes failing contrast ratios for:

* Home page section headers "_FOUNDATION_", "_CONTENT_", "_DESIGN_", and "_COMPONENTS_" 
* Component pages that include a "_Table of Contents_" section header 

## Detail

❌ **before: 3.17 failing contrast ratio**
<img width="846" alt="Screen Shot 2020-07-08 at 1 06 41 PM" src="https://user-images.githubusercontent.com/1811365/86965332-37f0e280-c11c-11ea-88f0-b906a8b3e330.png">
<img width="713" alt="Screen Shot 2020-07-08 at 12 47 27 PM" src="https://user-images.githubusercontent.com/1811365/86965336-3a533c80-c11c-11ea-9369-b2d3888362cd.png">


✅ **after: 4.84 passing contrast ratio**
<img width="846" alt="Screen Shot 2020-07-08 at 1 06 12 PM" src="https://user-images.githubusercontent.com/1811365/86965320-32939800-c11c-11ea-9e98-46bd2c962f63.png">
<img width="712" alt="Screen Shot 2020-07-08 at 12 49 16 PM" src="https://user-images.githubusercontent.com/1811365/86965339-3c1d0000-c11c-11ea-99cb-a026f907cc9c.png">


<!-- closes GITHUB_ISSUE -->

## Checklist

- [ ] :ok_hand: website updates are Garden Designer approved (add the designer as a reviewer)
- [x] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [x] :zap: audited via [web.dev](https://web.dev/measure/) for performance and SEO
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
