### PR TITLE
fix(avatar): fix image in codesandbox example

### DIFF
--- a/src/examples/avatar/AvatarType.tsx
+++ b/src/examples/avatar/AvatarType.tsx
@@ -20,7 +20,10 @@ const Example = () => (
     </Col>
     <Col textAlign="center">
       <Avatar backgroundColor={PALETTE.grey[600]}>
-        <img alt="image avatar" src="/components/avatar/user.png" />
+        <img
+          alt="image avatar"
+          src="https://zendeskgarden.netlify.app/components/avatar/user.png"
+        />
       </Avatar>
     </Col>
     <Col textAlign="center">


### PR DESCRIPTION
## Description

The image in the Avatar types CodeSandbox example is broken because CodeSandbox cannot resolve the relative path to the image. This PR proposes using the URL from the published site. @jzempel @austin94 does a better solution than this come to mind? Open to suggestions.

## Detail

❌ **before**:
<img width="946" alt="Screen Shot 2020-07-08 at 2 30 05 PM" src="https://user-images.githubusercontent.com/1811365/86972293-92dc0700-c127-11ea-9884-9910a3b07994.png">

✅ **after**:
<img width="949" alt="Screen Shot 2020-07-08 at 2 30 14 PM" src="https://user-images.githubusercontent.com/1811365/86972325-9e2f3280-c127-11ea-84ba-b48fc7b5756a.png">


## Checklist

- [ ] ~:ok_hand: website updates are Garden Designer approved (add the designer as a reviewer)~
- [ ] ~:black_nib: copy updates are approved (add the content strategist as a reviewer)~
- [x] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [x] :zap: audited via [web.dev](https://web.dev/measure/) for performance and SEO
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
