### PR TITLE
fix: remove duplicate unordered list 

### DIFF
--- a/src/components/MarkdownProvider/components/OverviewLinks.tsx
+++ b/src/components/MarkdownProvider/components/OverviewLinks.tsx
@@ -21,7 +21,7 @@ const StyledListItem = styled(UnorderedList.Item)`
 
 export const OverviewLinks: React.FC<{ nav: ISidebarSection[] }> = ({ nav }) => {
   const content = nav.map(section => (
-    <StyledUnorderedList key={section.title}>
+    <>
       <LG isBold>{section.title}</LG>
       {section.items && (
         <StyledUnorderedList>
@@ -31,13 +31,11 @@ export const OverviewLinks: React.FC<{ nav: ISidebarSection[] }> = ({ nav }) => 
                 <StyledListItem key={group.title}>
                   {group.title}
                   <UnorderedList type="disc">
-                    {group.items.map(child => {
-                      return (
-                        <UnorderedList.Item key={child.title}>
-                          <Link to={`${child.id}`}>{child.title}</Link>
-                        </UnorderedList.Item>
-                      );
-                    })}
+                    {group.items.map(child => (
+                      <UnorderedList.Item key={child.id}>
+                        <Link to={`${child.id}`}>{child.title}</Link>
+                      </UnorderedList.Item>
+                    ))}
                   </UnorderedList>
                 </StyledListItem>
               );
@@ -51,7 +49,7 @@ export const OverviewLinks: React.FC<{ nav: ISidebarSection[] }> = ({ nav }) => 
           })}
         </StyledUnorderedList>
       )}
-    </StyledUnorderedList>
+    </>
   ));
 
   return <nav>{content}</nav>;


### PR DESCRIPTION
## Description

The lists used to render overview links were invalid because they contained a nested `ul` element. 

## Detail

This PR removes the unnecessary nested `ul` within a `ul` and ensures that `ul` elements only have `li` elements as its children.

## Checklist

- [ ] ~:ok_hand: website updates are Garden Designer approved (add the designer as a reviewer)~
- [ ] ~:black_nib: copy updates are approved (add the content strategist as a reviewer)~
- [x] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [x] :zap: audited via [web.dev](https://web.dev/measure/) for performance and SEO
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
