### PR TITLE
fix: allow table of contents to scroll

### DIFF
--- a/src/layouts/Root/index.tsx
+++ b/src/layouts/Root/index.tsx
@@ -27,6 +27,10 @@ const GlobalStyling = createGlobalStyle`
   #gatsby-focus-wrapper {
     height: 100%;
   }
+
+  * {
+    -ms-overflow-style: -ms-autohiding-scrollbar;
+  }
 `;
 
 const RootLayout: React.FC = ({ children }) => {

--- a/src/layouts/Titled/components/TOC.tsx
+++ b/src/layouts/Titled/components/TOC.tsx
@@ -121,7 +121,7 @@ export const TOC: React.FC<{ data: IHeading[] }> = ({ data }) => {
         position: sticky;
         top: ${p => p.theme.space.lg};
         margin-left: ${p => p.theme.space.base * 15}px;
-        max-height: calc(100vh - 64px);
+        max-height: calc(100vh - ${p => p.theme.space.base * 16}px);
         overflow-y: scroll;
         -ms-overflow-style: scrollbar;
       `}

--- a/src/layouts/Titled/components/TOC.tsx
+++ b/src/layouts/Titled/components/TOC.tsx
@@ -121,6 +121,8 @@ export const TOC: React.FC<{ data: IHeading[] }> = ({ data }) => {
         position: sticky;
         top: ${p => p.theme.space.lg};
         margin-left: ${p => p.theme.space.base * 15}px;
+        max-height: ${OFFSET}px;
+        overflow-y: scroll;
       `}
     >
       <StyledSectionHeader
@@ -133,7 +135,6 @@ export const TOC: React.FC<{ data: IHeading[] }> = ({ data }) => {
       </StyledSectionHeader>
       <ul
         css={css`
-          margin-left: -${p => p.theme.borderWidths.sm};
           border-left: ${p => p.theme.borders.sm} ${p => getColor('grey', 200, p.theme)};
         `}
       >

--- a/src/layouts/Titled/components/TOC.tsx
+++ b/src/layouts/Titled/components/TOC.tsx
@@ -122,6 +122,7 @@ export const TOC: React.FC<{ data: IHeading[] }> = ({ data }) => {
         position: sticky;
         top: ${p => p.theme.space.lg};
         margin-left: ${p => p.theme.space.base * 15}px;
+        padding-right: ${p => p.theme.space.base * 4}px;
         max-height: calc(100vh - ${p => math(`${p.theme.space.lg} * 2`)});
         overflow-y: scroll;
         -ms-overflow-style: scrollbar;

--- a/src/layouts/Titled/components/TOC.tsx
+++ b/src/layouts/Titled/components/TOC.tsx
@@ -122,7 +122,7 @@ export const TOC: React.FC<{ data: IHeading[] }> = ({ data }) => {
         position: sticky;
         top: ${p => p.theme.space.lg};
         margin-left: ${p => p.theme.space.base * 15}px;
-        padding-right: ${p => p.theme.space.base * 4}px;
+        padding-right: ${p => p.theme.space.md};
         max-height: calc(100vh - ${p => math(`${p.theme.space.lg} * 2`)});
         overflow-y: scroll;
         -ms-overflow-style: scrollbar;

--- a/src/layouts/Titled/components/TOC.tsx
+++ b/src/layouts/Titled/components/TOC.tsx
@@ -121,7 +121,7 @@ export const TOC: React.FC<{ data: IHeading[] }> = ({ data }) => {
         position: sticky;
         top: ${p => p.theme.space.lg};
         margin-left: ${p => p.theme.space.base * 15}px;
-        max-height: ${OFFSET}px;
+        max-height: calc(100vh - 64px);
         overflow-y: scroll;
         -ms-overflow-style: scrollbar;
       `}

--- a/src/layouts/Titled/components/TOC.tsx
+++ b/src/layouts/Titled/components/TOC.tsx
@@ -125,7 +125,6 @@ export const TOC: React.FC<{ data: IHeading[] }> = ({ data }) => {
         padding-right: ${p => p.theme.space.md};
         max-height: calc(100vh - ${p => math(`${p.theme.space.lg} * 2`)});
         overflow-y: scroll;
-        -ms-overflow-style: scrollbar;
       `}
     >
       <StyledSectionHeader

--- a/src/layouts/Titled/components/TOC.tsx
+++ b/src/layouts/Titled/components/TOC.tsx
@@ -123,6 +123,7 @@ export const TOC: React.FC<{ data: IHeading[] }> = ({ data }) => {
         margin-left: ${p => p.theme.space.base * 15}px;
         max-height: ${OFFSET}px;
         overflow-y: scroll;
+        -ms-overflow-style: scrollbar;
       `}
     >
       <StyledSectionHeader

--- a/src/layouts/Titled/components/TOC.tsx
+++ b/src/layouts/Titled/components/TOC.tsx
@@ -8,6 +8,7 @@
 import React, { useState, useCallback, useEffect, HTMLAttributes } from 'react';
 import styled, { css } from 'styled-components';
 import throttle from 'lodash/throttle';
+import { math } from 'polished';
 import { getColor } from '@zendeskgarden/react-theming';
 import { Anchor } from '@zendeskgarden/react-buttons';
 import { StyledSectionHeader } from 'layouts/Home/components/SectionCallout';
@@ -121,7 +122,7 @@ export const TOC: React.FC<{ data: IHeading[] }> = ({ data }) => {
         position: sticky;
         top: ${p => p.theme.space.lg};
         margin-left: ${p => p.theme.space.base * 15}px;
-        max-height: calc(100vh - ${p => p.theme.space.base * 16}px);
+        max-height: calc(100vh - ${p => math(`${p.theme.space.lg} * 2`)});
         overflow-y: scroll;
         -ms-overflow-style: scrollbar;
       `}


### PR DESCRIPTION
## Description

Users should be able to scroll through the Table of Contents (on Desktop sizes) with lots of content (e.g. [Word List](https://zendeskgarden.netlify.app/content/word-list)). This PR updates the `TOC` component so that long Tabe of Contents can be scrolled.

## Checklist

- [ ] :ok_hand: website updates are Garden Designer approved (add the designer as a reviewer)
- [x] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [x] :zap: audited via [web.dev](https://web.dev/measure/) for performance and SEO
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
