### PR TITLE
fix: use hr for visual presentation

### DIFF
--- a/src/components/MarkdownProvider/components/Typography.tsx
+++ b/src/components/MarkdownProvider/components/Typography.tsx
@@ -57,7 +57,9 @@ export const StyledBlockquote = styled(LG).attrs({ tag: 'blockquote' })`
   font-size: ${p => p.theme.space.base * 4}px;
 `;
 
-export const StyledHr = styled.hr`
+export const StyledHr = styled.hr.attrs({
+  role: 'presentation'
+})`
   margin: ${p => p.theme.space.md} 0;
   border-top: ${p => p.theme.borders.sm} ${p => getColor('grey', 200, p.theme)};
 `;


### PR DESCRIPTION
## Description

VoiceOver reads aloud horizontal rules and their interactions, but the horizontal rules are used for visual presentation alone. This affects all component pages and the "Word List" page.

## Detail

A `role="presentation"` has been added to the horizontal rules.

**before**:
![2020-07-10 11 27 28](https://user-images.githubusercontent.com/1811365/87187399-fb4ef380-c2a1-11ea-9d0f-6fbe971054a0.gif)

**after**:
Horizontal rules and their interactions are no longer read aloud by VoiceOver.

## Checklist

- [ ] :ok_hand: website updates are Garden Designer approved (add the designer as a reviewer)
- [ ] ~:black_nib: copy updates are approved (add the content strategist as a reviewer)~
- [x] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [x] :zap: audited via [web.dev](https://web.dev/measure/) for performance and SEO
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
