### PR TITLE
fix: link to textarea on forms component page

### DIFF
--- a/src/pages/components/input.mdx
+++ b/src/pages/components/input.mdx
@@ -18,8 +18,11 @@ components:
   <Use>
     <ul>
       <li>To let the user enter data into a field</li>
-      <li>To enter multiline text, use a Textarea</li>
+      <li>
+        <Markdown>To enter multiline text, use a [Textarea](/components/input/#textarea-input)</Markdown>
+      </li>
     </ul>
+
   </Use>
 </Usage>
 


### PR DESCRIPTION
## Description

Add missing link for Textarea on Inputs component page.

## Checklist

- [x] :ok_hand: website updates are Garden Designer approved (add the designer as a reviewer)
- [x] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [x] :zap: audited via [web.dev](https://web.dev/measure/) for performance and SEO
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
