### PR TITLE
chore: update typography examples

### DIFF
--- a/src/examples/typography/CodeColor.tsx
+++ b/src/examples/typography/CodeColor.tsx
@@ -16,7 +16,7 @@ const StyledDiv = styled.div`
 const Example = () => (
   <>
     <StyledDiv>
-      <Code hue="grey">Veggies es bonus vobis</Code>
+      <Code>Veggies es bonus vobis</Code>
     </StyledDiv>
     <StyledDiv>
       <Code hue="red">Veggies es bonus vobis</Code>

--- a/src/examples/typography/CodeColor.tsx
+++ b/src/examples/typography/CodeColor.tsx
@@ -16,16 +16,12 @@ const StyledDiv = styled.div`
 const Example = () => (
   <>
     <StyledDiv>
-      <Code size="small">Veggies es bonus vobis</Code>
+      <Code>Veggies es bonus vobis</Code>
     </StyledDiv>
     <StyledDiv>
-      <Code size="medium" hue="green">
-        Veggies es bonus vobis
-      </Code>
+      <Code hue="green">Veggies es bonus vobis</Code>
     </StyledDiv>
-    <Code size="large" hue="yellow">
-      Veggies es bonus vobis
-    </Code>
+    <Code hue="yellow">Veggies es bonus vobis</Code>
   </>
 );
 

--- a/src/examples/typography/CodeColor.tsx
+++ b/src/examples/typography/CodeColor.tsx
@@ -16,6 +16,9 @@ const StyledDiv = styled.div`
 const Example = () => (
   <>
     <StyledDiv>
+      <Code hue="grey">Veggies es bonus vobis</Code>
+    </StyledDiv>
+    <StyledDiv>
       <Code hue="red">Veggies es bonus vobis</Code>
     </StyledDiv>
     <StyledDiv>

--- a/src/examples/typography/CodeColor.tsx
+++ b/src/examples/typography/CodeColor.tsx
@@ -10,13 +10,13 @@ import styled from 'styled-components';
 import { Code } from '@zendeskgarden/react-typography';
 
 const StyledDiv = styled.div`
-  margin-bottom: 12px;
+  margin-bottom: ${p => p.theme.space.sm};
 `;
 
 const Example = () => (
   <>
     <StyledDiv>
-      <Code>Veggies es bonus vobis</Code>
+      <Code hue="red">Veggies es bonus vobis</Code>
     </StyledDiv>
     <StyledDiv>
       <Code hue="green">Veggies es bonus vobis</Code>

--- a/src/examples/typography/CodeColor.tsx
+++ b/src/examples/typography/CodeColor.tsx
@@ -16,9 +16,6 @@ const StyledDiv = styled.div`
 const Example = () => (
   <>
     <StyledDiv>
-      <Code>Veggies es bonus vobis</Code>
-    </StyledDiv>
-    <StyledDiv>
       <Code hue="red">Veggies es bonus vobis</Code>
     </StyledDiv>
     <StyledDiv>

--- a/src/examples/typography/CodeSize.tsx
+++ b/src/examples/typography/CodeSize.tsx
@@ -1,0 +1,28 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import React from 'react';
+import styled from 'styled-components';
+import { Code } from '@zendeskgarden/react-typography';
+
+const StyledDiv = styled.div`
+  margin-bottom: 12px;
+`;
+
+const Example = () => (
+  <>
+    <StyledDiv>
+      <Code size="small">Veggies es bonus vobis</Code>
+    </StyledDiv>
+    <StyledDiv>
+      <Code size="medium">Veggies es bonus vobis</Code>
+    </StyledDiv>
+    <Code size="large">Veggies es bonus vobis</Code>
+  </>
+);
+
+export default Example;

--- a/src/examples/typography/CodeSize.tsx
+++ b/src/examples/typography/CodeSize.tsx
@@ -10,18 +10,24 @@ import styled from 'styled-components';
 import { Code } from '@zendeskgarden/react-typography';
 
 const StyledDiv = styled.div`
-  margin-bottom: 12px;
+  margin-bottom: ${p => p.theme.space.sm};
 `;
 
 const Example = () => (
   <>
     <StyledDiv>
-      <Code size="small">Veggies es bonus vobis</Code>
+      <Code hue="grey" size="small">
+        Veggies es bonus vobis
+      </Code>
     </StyledDiv>
     <StyledDiv>
-      <Code size="medium">Veggies es bonus vobis</Code>
+      <Code hue="grey" size="medium">
+        Veggies es bonus vobis
+      </Code>
     </StyledDiv>
-    <Code size="large">Veggies es bonus vobis</Code>
+    <Code hue="grey" size="large">
+      Veggies es bonus vobis
+    </Code>
   </>
 );
 

--- a/src/examples/typography/CodeSize.tsx
+++ b/src/examples/typography/CodeSize.tsx
@@ -16,18 +16,12 @@ const StyledDiv = styled.div`
 const Example = () => (
   <>
     <StyledDiv>
-      <Code hue="grey" size="small">
-        Veggies es bonus vobis
-      </Code>
+      <Code size="small">Veggies es bonus vobis</Code>
     </StyledDiv>
     <StyledDiv>
-      <Code hue="grey" size="medium">
-        Veggies es bonus vobis
-      </Code>
+      <Code size="medium">Veggies es bonus vobis</Code>
     </StyledDiv>
-    <Code hue="grey" size="large">
-      Veggies es bonus vobis
-    </Code>
+    <Code size="large">Veggies es bonus vobis</Code>
   </>
 );
 

--- a/src/examples/typography/ListSize.tsx
+++ b/src/examples/typography/ListSize.tsx
@@ -10,7 +10,7 @@ import styled from 'styled-components';
 import { UnorderedList } from '@zendeskgarden/react-typography';
 
 const StyledDiv = styled.div`
-  margin-bottom: 18px;
+  margin-bottom: ${p => p.theme.space.md};
 `;
 
 const Example = () => (

--- a/src/examples/typography/ListSize.tsx
+++ b/src/examples/typography/ListSize.tsx
@@ -1,0 +1,46 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import React from 'react';
+import styled from 'styled-components';
+import { UnorderedList } from '@zendeskgarden/react-typography';
+
+const StyledDiv = styled.div`
+  margin-bottom: 18px;
+`;
+
+const Example = () => (
+  <>
+    <StyledDiv>
+      <UnorderedList type="disc" size="small">
+        <UnorderedList.Item>
+          The world&apos;s tallest-growing tree is the coast redwood
+        </UnorderedList.Item>
+        <UnorderedList.Item>Bamboo can grow 35 inches in a single day</UnorderedList.Item>
+        <UnorderedList.Item>During the 1600s, tulips were worth more than gold</UnorderedList.Item>
+      </UnorderedList>
+    </StyledDiv>
+    <StyledDiv>
+      <UnorderedList type="disc" size="medium">
+        <UnorderedList.Item>
+          The world&apos;s tallest-growing tree is the coast redwood
+        </UnorderedList.Item>
+        <UnorderedList.Item>Bamboo can grow 35 inches in a single day</UnorderedList.Item>
+        <UnorderedList.Item>During the 1600s, tulips were worth more than gold</UnorderedList.Item>
+      </UnorderedList>
+    </StyledDiv>
+    <UnorderedList type="disc" size="large">
+      <UnorderedList.Item>
+        The world&apos;s tallest-growing tree is the coast redwood
+      </UnorderedList.Item>
+      <UnorderedList.Item>Bamboo can grow 35 inches in a single day</UnorderedList.Item>
+      <UnorderedList.Item>During the 1600s, tulips were worth more than gold</UnorderedList.Item>
+    </UnorderedList>
+  </>
+);
+
+export default Example;

--- a/src/examples/typography/Lists.tsx
+++ b/src/examples/typography/Lists.tsx
@@ -10,7 +10,7 @@ import styled from 'styled-components';
 import { OrderedList, UnorderedList } from '@zendeskgarden/react-typography';
 
 const StyledDiv = styled.div`
-  margin-bottom: 18px;
+  margin-bottom: ${p => p.theme.space.md};
 `;
 
 const Example = () => (

--- a/src/examples/typography/Lists.tsx
+++ b/src/examples/typography/Lists.tsx
@@ -16,7 +16,7 @@ const StyledDiv = styled.div`
 const Example = () => (
   <>
     <StyledDiv>
-      <OrderedList size="small">
+      <OrderedList>
         <OrderedList.Item>
           The world&apos;s tallest-growing tree is the coast redwood
         </OrderedList.Item>
@@ -24,16 +24,7 @@ const Example = () => (
         <OrderedList.Item>During the 1600s, tulips were worth more than gold</OrderedList.Item>
       </OrderedList>
     </StyledDiv>
-    <StyledDiv>
-      <OrderedList size="medium">
-        <OrderedList.Item>
-          The world&apos;s tallest-growing tree is the coast redwood
-        </OrderedList.Item>
-        <OrderedList.Item>Bamboo can grow 35 inches in a single day</OrderedList.Item>
-        <OrderedList.Item>During the 1600s, tulips were worth more than gold</OrderedList.Item>
-      </OrderedList>
-    </StyledDiv>
-    <UnorderedList type="disc" size="large">
+    <UnorderedList type="disc">
       <UnorderedList.Item>
         The world&apos;s tallest-growing tree is the coast redwood
       </UnorderedList.Item>

--- a/src/examples/typography/TypeScale.tsx
+++ b/src/examples/typography/TypeScale.tsx
@@ -10,7 +10,7 @@ import styled from 'styled-components';
 import { SM, MD, LG, XL, XXL, XXXL } from '@zendeskgarden/react-typography';
 
 const StyledDiv = styled.div`
-  margin-bottom: 12px;
+  margin-bottom: ${p => p.theme.space.sm};
 `;
 
 const Example = () => (

--- a/src/pages/components/typography.mdx
+++ b/src/pages/components/typography.mdx
@@ -23,14 +23,22 @@ components:
 
 ### Code highlight
 
-Use Code to style and format `<code>` elements. You can change text size and background color. Code
-components come in small, medium, and large.
+Use Code to style and format `<code>` elements. Code components come in small, medium, and large.
 
-import Code from '../../examples/typography/Code.tsx';
-import CodeCode from '!!raw-loader!../../examples/typography/Code.tsx';
+import CodeSize from '../../examples/typography/CodeSize.tsx';
+import CodeSizeCode from '!!raw-loader!../../examples/typography/CodeSize.tsx';
 
-<CodeExample code={CodeCode}>
-  <Code />
+<CodeExample code={CodeSizeCode}>
+  <CodeSize />
+</CodeExample>
+
+You can also change background and text color.
+
+import CodeColor from '../../examples/typography/CodeColor.tsx';
+import CodeColorCode from '!!raw-loader!../../examples/typography/CodeColor.tsx';
+
+<CodeExample code={CodeColorCode}>
+  <CodeColor />
 </CodeExample>
 
 ### Ellipsis text
@@ -47,14 +55,22 @@ import EllipsisCode from '!!raw-loader!../../examples/typography/Ellipsis.tsx';
 
 ### Lists
 
-Use Lists to style and format ordered (`<ol>`) and unordered (`<ul>`) lists. List components come
-in small, medium, and large.
+Use Lists to style and format ordered (`<ol>`) and unordered (`<ul>`) lists.
 
 import Lists from '../../examples/typography/Lists.tsx';
 import ListsCode from '!!raw-loader!../../examples/typography/Lists.tsx';
 
 <CodeExample code={ListsCode}>
   <Lists />
+</CodeExample>
+
+List components come in small, medium, and large.
+
+import ListSize from '../../examples/typography/ListSize.tsx';
+import ListSizeCode from '!!raw-loader!../../examples/typography/ListSize.tsx';
+
+<CodeExample code={ListSize}>
+  <ListSize />
 </CodeExample>
 
 ### Paragraph text

--- a/src/pages/components/typography.mdx
+++ b/src/pages/components/typography.mdx
@@ -69,7 +69,7 @@ List components come in small, medium, and large.
 import ListSize from '../../examples/typography/ListSize.tsx';
 import ListSizeCode from '!!raw-loader!../../examples/typography/ListSize.tsx';
 
-<CodeExample code={ListSize}>
+<CodeExample code={ListSizeCode}>
   <ListSize />
 </CodeExample>
 


### PR DESCRIPTION
## Description

When building out the Typography component page @allisonacs noticed that some examples (Lists and Code highlight) [weren't clear](https://github.com/zendeskgarden/website/pull/100#pullrequestreview-446058820). 

## Detail

This PR updates the copy and adds examples which clearly demonstrate the following:

1) Types of lists, e.g. ordered vs unordered
2) List sizes
3) Code highlight background colors
4) Code highlight sizes

## Checklist

- [ ] :ok_hand: website updates are Garden Designer approved (add the designer as a reviewer)
- [ ] :black_nib: copy updates are approved (add the content strategist as a reviewer)
- [x] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [x] :zap: audited via [web.dev](https://web.dev/measure/) for performance and SEO
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
