### PR TITLE
fix: @media queries

### DIFF
--- a/src/components/MarkdownProvider/components/BestPractice.tsx
+++ b/src/components/MarkdownProvider/components/BestPractice.tsx
@@ -15,19 +15,20 @@ import { Row, Col } from '@zendeskgarden/react-grid';
 import { ReactComponent as XStrokeIcon } from '@zendeskgarden/svg-icons/src/16/x-stroke.svg';
 import { ReactComponent as CheckLgStrokeIcon } from '@zendeskgarden/svg-icons/src/16/check-lg-stroke.svg';
 import { ReactComponent as AlertErrorStrokeIcon } from '@zendeskgarden/svg-icons/src/16/alert-error-stroke.svg';
+import mediaQuery from '../../../temp/mediaQuery';
 
 const StyledRow = styled(Row)`
   margin-top: ${p => p.theme.space.lg};
   margin-bottom: ${p => p.theme.space.xxl};
 
-  @media (max-width: ${p => p.theme.breakpoints.sm}) {
+  ${p => mediaQuery('down', 'xs', p.theme)} {
     margin-top: ${p => `${p.theme.space.base * 6}px`};
     margin-bottom: ${p => p.theme.space.lg};
   }
 `;
 
 const StyledCol = styled(Col)`
-  @media (max-width: ${p => p.theme.breakpoints.sm}) {
+  ${p => mediaQuery('down', 'xs', p.theme)} {
     &:not(:first-child) {
       margin-top: ${p => `${p.theme.space.base * 6}px`};
     }

--- a/src/layouts/Home/components/Foundation.tsx
+++ b/src/layouts/Home/components/Foundation.tsx
@@ -14,6 +14,7 @@ import { LG } from '@zendeskgarden/react-typography';
 import MaxWidthLayout from 'layouts/MaxWidth';
 import { SectionCallout, StyledSectionHeader } from './SectionCallout';
 import { HomeLink } from './HomeLink';
+import mediaQuery from '../../../temp/mediaQuery';
 
 const FoundationLink: React.FC<{
   group: string;
@@ -128,7 +129,7 @@ export const Foundation: React.FC = () => {
               css={css`
                 max-width: 380px;
 
-                @media (max-width: ${p => p.theme.breakpoints.lg}) {
+                ${p => mediaQuery('down', 'md', p.theme)} {
                   max-width: 420px;
                 }
               `}

--- a/src/layouts/Home/components/Patterns.tsx
+++ b/src/layouts/Home/components/Patterns.tsx
@@ -10,10 +10,10 @@ import { useStaticQuery, graphql } from 'gatsby';
 import Img from 'gatsby-image';
 import { css } from 'styled-components';
 import { Grid, Row, Col } from '@zendeskgarden/react-grid';
-
 import { SectionCallout } from './SectionCallout';
 import MaxWidthLayout from 'layouts/MaxWidth';
 import { HomeLink } from './HomeLink';
+import mediaQuery from '../../../temp/mediaQuery';
 
 export const Patterns: React.FC = () => {
   const { patternsImage } = useStaticQuery(
@@ -48,7 +48,7 @@ export const Patterns: React.FC = () => {
             order={1}
             orderMd={0}
             css={css`
-              @media (max-width: ${p => p.theme.breakpoints.md}) {
+              ${p => mediaQuery('down', 'sm', p.theme)} {
                 margin-bottom: ${p => p.theme.space.lg};
               }
             `}
@@ -78,7 +78,7 @@ export const Patterns: React.FC = () => {
                 margin-left: auto;
                 max-width: 380px;
 
-                @media (max-width: ${p => p.theme.breakpoints.md}) {
+                ${p => mediaQuery('down', 'sm', p.theme)} {
                   margin-right: 0;
                   margin-left: 0;
                   max-width: 420px;

--- a/src/layouts/Home/components/Search.tsx
+++ b/src/layouts/Home/components/Search.tsx
@@ -6,16 +6,16 @@
  */
 
 import React from 'react';
+import { useStaticQuery, graphql } from 'gatsby';
 import Img from 'gatsby-image';
 import { css, ThemeProps, DefaultTheme } from 'styled-components';
+import { getLineHeight } from '@zendeskgarden/react-theming';
 import { Grid, Row, Col } from '@zendeskgarden/react-grid';
 // import { MediaInput } from '@zendeskgarden/react-forms';
 import { LG } from '@zendeskgarden/react-typography';
 // import { ReactComponent as SearchStroke } from '@zendeskgarden/svg-icons/src/16/search-stroke.svg';
-
 import MaxWidthLayout from 'layouts/MaxWidth';
-import { useStaticQuery, graphql } from 'gatsby';
-import { getLineHeight } from '@zendeskgarden/react-theming';
+import mediaQuery from '../../../temp/mediaQuery';
 
 const headerStyling = (p: ThemeProps<DefaultTheme>) => {
   const fontSize = `${p.theme.space.base * 12}px`;
@@ -26,7 +26,7 @@ const headerStyling = (p: ThemeProps<DefaultTheme>) => {
     font-size: ${fontSize};
     font-weight: ${p.theme.fontWeights.bold};
 
-    @media (max-width: ${p.theme.breakpoints.lg}) {
+    ${mediaQuery('down', 'md', p.theme)} {
       line-height: ${p.theme.lineHeights.xxxl};
       font-size: ${p.theme.fontSizes.xxxl};
     }
@@ -65,7 +65,7 @@ export const Search: React.FC = () => {
               order={1}
               orderMd={0}
               css={css`
-                @media (max-width: ${p => p.theme.breakpoints.lg}) {
+                ${p => mediaQuery('down', 'md', p.theme)} {
                   padding: 0 ${p => p.theme.space.lg};
                 }
               `}
@@ -88,7 +88,7 @@ export const Search: React.FC = () => {
               css={css`
                 padding: ${p => p.theme.space.xxl};
 
-                @media (max-width: ${p => p.theme.breakpoints.lg}) {
+                ${p => mediaQuery('down', 'md', p.theme)} {
                   padding: ${p => p.theme.space.lg};
                   padding-bottom: 0;
                 }
@@ -116,7 +116,7 @@ export const Search: React.FC = () => {
                   css={css`
                     width: 340px;
 
-                    @media (max-width: ${p => p.theme.breakpoints.sm}) {
+                    ${p => mediaQuery('down', 'xs', p.theme)} {
                       width: 100%;
                     }
                   `}

--- a/src/layouts/Root/components/Footer.tsx
+++ b/src/layouts/Root/components/Footer.tsx
@@ -12,6 +12,7 @@ import { getColor } from '@zendeskgarden/react-theming';
 import { ReactComponent as GardenIcon } from '@zendeskgarden/svg-icons/src/26/garden.svg';
 import { Link } from './StyledNavigationLink';
 import MaxWidthLayout from 'layouts/MaxWidth';
+import mediaQuery from '../../../temp/mediaQuery';
 
 const StyledFooterItem = styled(Link)`
   margin-right: ${p => p.theme.space.lg};
@@ -33,7 +34,8 @@ const Footer: React.FC = () => (
         css={css`
           display: flex;
           padding-bottom: ${p => p.theme.space.md};
-          @media (max-width: ${p => p.theme.breakpoints.md}) {
+
+          ${p => mediaQuery('down', 'sm', p.theme)} {
             flex-direction: column;
             padding-left: ${p => math(`${p.theme.iconSizes.md} + ${p.theme.space.md}`)};
             text-align: center;
@@ -51,7 +53,8 @@ const Footer: React.FC = () => (
           align-items: center;
           border-top: ${p => p.theme.borders.sm} ${p => getColor('kale', 500, p.theme)};
           padding-top: ${p => p.theme.space.md};
-          @media (max-width: ${p => p.theme.breakpoints.md}) {
+
+          ${p => mediaQuery('down', 'sm', p.theme)} {
             flex-direction: column;
             align-items: center;
             text-align: center;
@@ -62,7 +65,8 @@ const Footer: React.FC = () => (
           css={css`
             display: flex;
             align-items: center;
-            @media (max-width: ${p => p.theme.breakpoints.md}) {
+
+            ${p => mediaQuery('down', 'sm', p.theme)} {
               margin-bottom: ${p => p.theme.space.md};
             }
           `}
@@ -87,7 +91,7 @@ const Footer: React.FC = () => (
         </div>
         <div
           css={css`
-            @media (max-width: ${p => p.theme.breakpoints.lg}) {
+            ${p => mediaQuery('down', 'md', p.theme)} {
               margin-top: ${p => p.theme.space.md};
               width: 100%;
               text-align: center;

--- a/src/layouts/Root/components/Header.tsx
+++ b/src/layouts/Root/components/Header.tsx
@@ -18,6 +18,7 @@ import { ReactComponent as GardenIcon } from '@zendeskgarden/svg-icons/src/26/ga
 import { ReactComponent as GardenWordmark } from '@zendeskgarden/svg-icons/src/26/wordmark-garden.svg';
 import MaxWidthLayout from 'layouts/MaxWidth';
 import { StyledNavigationLink } from './StyledNavigationLink';
+import mediaQuery from '../../../temp/mediaQuery';
 
 const StyledDesktopNavItem = styled.div`
   display: flex;
@@ -46,7 +47,7 @@ const StyledHeader = styled.header.attrs({ role: 'banner' })`
     border-bottom-color: ${p => p.theme.palette.white};
   }
 
-  @media (max-width: ${p => p.theme.breakpoints.md}) {
+  ${p => mediaQuery('down', 'sm', p.theme)} {
     padding: 0;
     height: ${p => p.theme.space.base * 15}px;
   }
@@ -59,7 +60,7 @@ const Logo: React.FC = () => (
       align-items: center;
       justify-content: center;
 
-      @media (max-width: ${p => p.theme.breakpoints.md}) {
+      ${p => mediaQuery('down', 'sm', p.theme)} {
         flex-grow: 1;
       }
     `}
@@ -85,7 +86,7 @@ const Logo: React.FC = () => (
             height: ${p => p.theme.iconSizes.lg};
             color: ${PALETTE.kale[700]};
 
-            @media (max-width: ${p => p.theme.breakpoints.md}) {
+            ${p => mediaQuery('down', 'sm', p.theme)} {
               display: none;
             }
           `}
@@ -133,7 +134,7 @@ const MobileNavButton: React.FC<
       css={css`
         padding: ${p => p.theme.space.base * 1.5}px; /* (header - button) x .5 */
 
-        @media (min-width: ${p => p.theme.breakpoints.md}) {
+        ${p => mediaQuery('up', 'md', p.theme)} {
           display: none;
         }
       `}
@@ -156,7 +157,7 @@ const TemporaryBox = styled.div`
   width: 60px;
   height: 60px;
 
-  @media (min-width: ${p => p.theme.breakpoints.md}) {
+  ${p => mediaQuery('up', 'md', p.theme)} {
     display: none;
   }
 `;
@@ -205,7 +206,7 @@ const DesktopNav: React.FC = () => (
       flex-grow: 1;
       justify-content: flex-end;
 
-      @media (max-width: ${p => p.theme.breakpoints.md}) {
+      ${p => mediaQuery('down', 'sm', p.theme)} {
         display: none;
       }
     `}

--- a/src/layouts/Sidebar/components/DesktopSidebar.tsx
+++ b/src/layouts/Sidebar/components/DesktopSidebar.tsx
@@ -12,6 +12,7 @@ import { getColor } from '@zendeskgarden/react-theming';
 import { ISidebarSection } from '..';
 import { StyledNavigationLink } from 'layouts/Root/components/StyledNavigationLink';
 import { StyledSectionHeader } from 'layouts/Home/components/SectionCallout';
+import mediaQuery from '../../../temp/mediaQuery';
 
 const StyledSidebarLink = styled(StyledNavigationLink)`
   display: block;
@@ -100,7 +101,7 @@ export const DesktopSidebar: React.FC<{ sidebar: ISidebarSection[] }> = ({ sideb
           padding: ${p => p.theme.space.lg} ${p => p.theme.space.md};
         }
 
-        @media (max-width: ${p => p.theme.breakpoints.lg}) {
+        ${p => mediaQuery('down', 'md', p.theme)} {
           display: none;
         }
       `}
@@ -115,7 +116,7 @@ export const DesktopSidebar: React.FC<{ sidebar: ISidebarSection[] }> = ({ sideb
           z-index: -1;
           background-color: ${p => p.theme.palette.tofu};
 
-          @media (max-width: ${p => p.theme.breakpoints.lg}) {
+          ${p => mediaQuery('down', 'md', p.theme)} {
             display: none;
           }
         `}

--- a/src/layouts/Sidebar/components/MobileSidebar.tsx
+++ b/src/layouts/Sidebar/components/MobileSidebar.tsx
@@ -12,6 +12,7 @@ import { getColor } from '@zendeskgarden/react-theming';
 import { StyledNavigationLink } from 'layouts/Root/components/StyledNavigationLink';
 import { StyledSectionHeader } from 'layouts/Home/components/SectionCallout';
 import { ISidebarSection } from '..';
+import mediaQuery from '../../../temp/mediaQuery';
 
 const StyledSidebarLink = styled(StyledNavigationLink)`
   display: block;
@@ -102,11 +103,11 @@ export const MobileSidebar: React.FC<{ sidebar: ISidebarSection[] }> = ({ sideba
         padding: ${p => p.theme.space.lg} ${p => p.theme.space.xxl};
         overflow: scroll;
 
-        @media (max-width: ${p => p.theme.breakpoints.md}) {
+        ${p => mediaQuery('down', 'sm', p.theme)} {
           top: ${p => p.theme.space.base * 15}px;
         }
 
-        @media (min-width: ${p => p.theme.breakpoints.lg}) {
+        ${p => mediaQuery('up', 'lg', p.theme)} {
           display: none;
         }
       `}

--- a/src/layouts/Sidebar/index.tsx
+++ b/src/layouts/Sidebar/index.tsx
@@ -14,6 +14,7 @@ import { ReactComponent as CloseStroke } from '@zendeskgarden/svg-icons/src/16/x
 import MaxWidthLayout from 'layouts/MaxWidth';
 import { MobileSidebar } from './components/MobileSidebar';
 import { DesktopSidebar } from './components/DesktopSidebar';
+import mediaQuery from '../../temp/mediaQuery';
 
 export interface ISidebarSection {
   title: string;
@@ -44,7 +45,7 @@ const StyledMobileNavButton = styled.button`
     height: ${p => p.theme.iconSizes.lg};
   }
 
-  @media (max-width: ${p => p.theme.breakpoints.lg}) {
+  ${p => mediaQuery('down', 'md', p.theme)} {
     display: flex;
   }
 `;
@@ -74,7 +75,7 @@ export const SidebarLayout: React.FC<{ sidebar: ISidebarSection[] }> = ({ childr
               padding: ${p => p.theme.space.lg} ${p => p.theme.space.md};
               max-width: 100vw;
 
-              @media (max-width: ${p => p.theme.breakpoints.lg}) {
+              ${p => mediaQuery('down', 'md', p.theme)} {
                 padding: ${p => p.theme.space.lg} ${p => p.theme.space.sm};
               }
             `}

--- a/src/layouts/Titled/index.tsx
+++ b/src/layouts/Titled/index.tsx
@@ -11,6 +11,7 @@ import { Grid, Row, Col } from '@zendeskgarden/react-grid';
 import { Subtitle } from './components/Subtitle';
 import { TOCBlock, TOC, IHeading } from './components/TOC';
 import { StyledH1, StyledHr } from 'components/MarkdownProvider/components/Typography';
+import mediaQuery from '../../temp/mediaQuery';
 
 const TitledLayout: React.FC<{
   title: React.ReactNode;
@@ -27,7 +28,7 @@ const TitledLayout: React.FC<{
           <TOCBlock
             data={toc}
             css={css`
-              @media (min-width: ${p => p.theme.breakpoints.xl}) {
+              ${p => mediaQuery('up', 'xl', p.theme)} {
                 display: none;
               }
             `}
@@ -39,7 +40,7 @@ const TitledLayout: React.FC<{
         lg={12}
         xl={3}
         css={css`
-          @media (max-width: ${p => p.theme.breakpoints.xl}) {
+          ${p => mediaQuery('down', 'lg', p.theme)} {
             display: none;
           }
         `}

--- a/src/pages/404.tsx
+++ b/src/pages/404.tsx
@@ -16,6 +16,7 @@ import { getColor } from '@zendeskgarden/react-theming';
 import { Grid, Row, Col } from '@zendeskgarden/react-grid';
 import { XL, LG } from '@zendeskgarden/react-typography';
 import { StyledH1 } from 'components/MarkdownProvider/components/Typography';
+import mediaQuery from '../temp/mediaQuery';
 
 const NotFoundPage: React.FC = () => {
   const { notFoundImage } = useStaticQuery(
@@ -43,7 +44,7 @@ const NotFoundPage: React.FC = () => {
             margin-top: 180px;
             margin-bottom: 368px;
 
-            @media (max-width: ${p => p.theme.breakpoints.sm}) {
+            ${p => mediaQuery('down', 'xs', p.theme)} {
               margin-top: 60px;
               margin-bottom: 200px;
             }
@@ -55,7 +56,7 @@ const NotFoundPage: React.FC = () => {
                 fixed={notFoundImage.childFile.childImageSharp.fixed}
                 alt=""
                 css={css`
-                  @media (max-width: ${p => p.theme.breakpoints.sm}) {
+                  ${p => mediaQuery('down', 'xs', p.theme)} {
                     /* stylelint-disable declaration-no-important */
                     width: 112px !important;
                     height: 112px !important;
@@ -69,7 +70,7 @@ const NotFoundPage: React.FC = () => {
                 css={css`
                   margin-left: ${p => p.theme.space.base * 12}px;
 
-                  @media (max-width: ${p => p.theme.breakpoints.sm}) {
+                  ${p => mediaQuery('down', 'xs', p.theme)} {
                     margin-left: 0;
                   }
                 `}
@@ -82,7 +83,7 @@ const NotFoundPage: React.FC = () => {
                     color: ${p => getColor('neutralHue', 600, p.theme)};
                     font-size: ${p => p.theme.space.base * 4}px;
 
-                    @media (max-width: ${p => p.theme.breakpoints.sm}) {
+                    ${p => mediaQuery('down', 'xs', p.theme)} {
                       font-size: ${p => p.theme.fontSizes.sm};
                     }
                   `}
@@ -91,7 +92,7 @@ const NotFoundPage: React.FC = () => {
                 </LG>
                 <StyledH1
                   css={css`
-                    @media (max-width: ${p => p.theme.breakpoints.sm}) {
+                    ${p => mediaQuery('down', 'xs', p.theme)} {
                       margin-bottom: ${p => p.theme.space.xs};
                       line-height: ${p => p.theme.lineHeights.xxl};
                       font-size: ${p => p.theme.fontSizes.xxl};
@@ -105,7 +106,7 @@ const NotFoundPage: React.FC = () => {
                   css={css`
                     color: ${p => getColor('neutralHue', 600, p.theme)};
 
-                    @media (max-width: ${p => p.theme.breakpoints.sm}) {
+                    ${p => mediaQuery('down', 'xs', p.theme)} {
                       line-height: ${p => p.theme.lineHeights.md};
                       font-size: ${p => p.theme.fontSizes.md};
                     }

--- a/src/temp/mediaQuery.ts
+++ b/src/temp/mediaQuery.ts
@@ -1,0 +1,79 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import { DEFAULT_THEME } from '@zendeskgarden/react-theming';
+import { DefaultTheme } from 'styled-components';
+import { getValueAndUnit } from 'polished';
+
+type QUERY = 'up' | 'down' | 'only' | 'between';
+type KEY = 'xs' | 'sm' | 'md' | 'lg' | 'xl';
+type BREAKPOINT = KEY | [KEY, KEY];
+
+const maxWidth = (breakpoints: DefaultTheme['breakpoints'], key: KEY) => {
+  const keys = Object.keys(breakpoints);
+  const index = keys.indexOf(key) + 1;
+
+  if (keys[index]) {
+    const elements = getValueAndUnit(breakpoints[keys[index] as KEY]);
+    const value = elements[0] - 0.02;
+    const unit = elements[1];
+
+    return `${value}${unit}`;
+  }
+
+  return undefined;
+};
+
+/**
+ * Get a media query string for the given function specifier, breakpoint name, and theme.
+ *
+ * @param {string} query A query specifier, one of:
+ * - `'up'` = match screen widths greater than and including the given breakpoint.
+ * - `'down'` = match screen widths less than and included within the given breakpoint.
+ * - `'only'` = match screen widths included within the given breakpoint.
+ * - `'between'` = match screen widths greater than and including the first breakpoint,
+ *   and less than and included within the second breakpoint.
+ * @param {string} breakpoint A `theme.breakpoints` key, one of: `'xs'`, `'sm'`, `'md'`, `'lg'`, `'xl'`.
+ * @param {Object} theme Context `theme` object.
+ */
+export default function mediaQuery(query: QUERY, breakpoint: BREAKPOINT, theme?: DefaultTheme) {
+  let retVal;
+  let min;
+  let max;
+  const breakpoints = theme && theme.breakpoints ? theme.breakpoints : DEFAULT_THEME.breakpoints;
+
+  if (typeof breakpoint === 'string') {
+    if (query === 'up') {
+      min = breakpoints[breakpoint];
+    } else if (query === 'down') {
+      if (breakpoint === 'xl') {
+        // Down from the XL breakpoint is the same as up from zero.
+        min = '0';
+      } else {
+        max = maxWidth(breakpoints, breakpoint);
+      }
+    } else if (query === 'only') {
+      min = breakpoints[breakpoint];
+      max = maxWidth(breakpoints, breakpoint);
+    }
+  } else if (query === 'between') {
+    min = breakpoints[breakpoint[0]];
+    max = maxWidth(breakpoints, breakpoint[1]);
+  }
+
+  if (min) {
+    retVal = `@media (min-width: ${min})`;
+
+    if (max) {
+      retVal = `${retVal} and (max-width: ${max})`;
+    }
+  } else if (max) {
+    retVal = `@media (max-width: ${max})`;
+  }
+
+  return retVal;
+}


### PR DESCRIPTION
## Description

Since `@media` queries in CSS are by definition inclusive, all `max-width` queries need to bump slightly (`.02px`) down from the top-end breakpoint in order to play nicely with corresponding `min-width` queries.

For review:
- all `max-width` media queries get replaced with `mediaQuery('down', size /* key is one less */)`
- all `min-width` media queries get replaced with `mediaQuery('up', size /* key is equal */)`

## Detail

The `mediaQuery` utility added to this PR is a **temporary** solution to be deleted and replaced by `import { mediaQuery } from @zendeskgarden/react-theming` once https://github.com/zendeskgarden/react-components/pull/814 is merged and a new feature release of `react-components` is available.

At that time, we'll continue to sweep through and replace all `@media` queries within code examples.

## Checklist

- [x] :ok_hand: website updates are Garden Designer approved (add the designer as a reviewer)
- [ ] :black_nib: ~copy updates are approved (add the content strategist as a reviewer)~
- [ ] :wheelchair: ~analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver~
- [ ] :zap: ~audited via [web.dev](https://web.dev/measure/) for performance and SEO~
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
