### PR TITLE
fix: favicons and code example tools container

### DIFF
--- a/src/components/MarkdownProvider/components/CodeExample/index.tsx
+++ b/src/components/MarkdownProvider/components/CodeExample/index.tsx
@@ -55,6 +55,8 @@ export const CodeExample: React.FC<{ code: string }> = ({ children, code }) => {
           display: flex;
           justify-content: flex-end;
           border-top: ${p => p.theme.borders.sm} ${p => getColor('grey', 300, p.theme)};
+          border-bottom-left-radius: ${p => p.theme.borderRadii.md};
+          border-bottom-right-radius: ${p => p.theme.borderRadii.md};
           background-color: ${p => getColor('grey', 100, p.theme)};
           padding: ${p => p.theme.space.xxs} ${p => p.theme.space.sm};
         `}

--- a/src/components/SEO.tsx
+++ b/src/components/SEO.tsx
@@ -82,9 +82,9 @@ const SEO: React.FC<{
         }
       ].concat(meta!)}
       link={[
-        { rel: 'mask-icon', href: 'mask-icon.svg', color: PALETTE.kale[700] },
-        { rel: 'apple-touch-icon', href: 'apple-touch-icon.png' },
-        { rel: 'shortcut icon', href: 'favicon.ico' }
+        { rel: 'mask-icon', href: '/mask-icon.svg', color: PALETTE.kale[700] },
+        { rel: 'apple-touch-icon', href: '/apple-touch-icon.png' },
+        { rel: 'shortcut icon', href: '/favicon.ico' }
       ]}
     />
   );


### PR DESCRIPTION
## Description

- Set favicon URLs so that they continue to work on non-root pages
- Fix code example tool container bottom `border-radius` to prevent over-bleed

## Checklist

- [x] :ok_hand: website updates are Garden Designer approved (add the designer as a reviewer)
- [ ] :black_nib: ~copy updates are approved (add the content strategist as a reviewer)~
- [ ] :wheelchair: ~analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver~
- [ ] :zap: ~audited via [web.dev](https://web.dev/measure/) for performance and SEO~
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
