### PR TITLE
chore: update subdomain URLs

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -14,7 +14,7 @@ envalid.cleanEnv(process.env, { ABSTRACT_TOKEN: envalid.str() });
 module.exports = {
   siteMetadata: {
     title: 'Zendesk Garden',
-    siteUrl: 'https://zendeskgarden.netlify.app',
+    siteUrl: 'https://garden.zendesk.com',
     description: `Garden is a design system for Zendesk where we grow beautifully simple and accessible UI components.`
   },
   plugins: [

--- a/src/examples/avatar/AvatarType.tsx
+++ b/src/examples/avatar/AvatarType.tsx
@@ -20,10 +20,7 @@ const Example = () => (
     </Col>
     <Col textAlign="center">
       <Avatar backgroundColor={PALETTE.grey[600]}>
-        <img
-          alt="image avatar"
-          src="https://zendeskgarden.netlify.app/components/avatar/user.png"
-        />
+        <img alt="image avatar" src="https://garden.zendesk.com/components/avatar/user.png" />
       </Avatar>
     </Col>
     <Col textAlign="center">


### PR DESCRIPTION
## Description

Setup for garden.zendesk.com DNS update. A merge will break a couple image URLs for `zendeskgarden.netlify.app` but will prepare the site to be ready for TTL.

## Detail

- updates the siteUrl used for `og:image` social sharing
- updates avatar img to source from the new location
