### PR TITLE
chore: update svg-icons to v6.20.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "@zendeskgarden/react-typography": "8.17.0",
     "@zendeskgarden/scripts": "0.1.10",
     "@zendeskgarden/stylelint-config": "13.0.0",
-    "@zendeskgarden/svg-icons": "6.17.0",
+    "@zendeskgarden/svg-icons": "6.20.0",
     "abstract-sdk": "7.0.1",
     "babel-eslint": "10.1.0",
     "babel-plugin-styled-components": "1.10.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2518,10 +2518,10 @@
   resolved "https://registry.yarnpkg.com/@zendeskgarden/stylelint-config/-/stylelint-config-13.0.0.tgz#9cad63a317337b1b3efde45a03b34076c711fc38"
   integrity sha512-FuLFv3pmTUVVbSMOu1TD8a5ceGuIRdfb0LrY2+Njcpvqf4ZMgNC8g9t3WZ3Dfb1YM5E/2XIuIrgjpKucMAJCHw==
 
-"@zendeskgarden/svg-icons@6.17.0":
-  version "6.17.0"
-  resolved "https://registry.yarnpkg.com/@zendeskgarden/svg-icons/-/svg-icons-6.17.0.tgz#400fc11b2ebd3f54b9d2226b370d457d87beb34c"
-  integrity sha512-hLBV2sCA1Z7fSQuFLXT39b/BawtL07UAIzQq1rs/l+m42qAkomW0TqUB+si2AAUzJ9rxUD++fJCd7yaz/F9rlA==
+"@zendeskgarden/svg-icons@6.20.0":
+  version "6.20.0"
+  resolved "https://registry.yarnpkg.com/@zendeskgarden/svg-icons/-/svg-icons-6.20.0.tgz#ac2d56e6979d7fe24c4ba6fe36c4209cb873c4c8"
+  integrity sha512-piupmvKBwlas4pRLB7LuZoGWA5sYI1X88b4vHwvLbnh63+UbShAJtkgyrO6ZSfdQxZcaIic+oIUCi67Ma93mww==
 
 abstract-sdk@7.0.1:
   version "7.0.1"


### PR DESCRIPTION
## Description

Need to manually update until an automated process is in place for keeping components fresh.

## Checklist

- [x] :ok_hand: website updates are Garden Designer approved (add the designer as a reviewer)
- [ ] :black_nib: ~copy updates are approved (add the content strategist as a reviewer)~
- [ ] :wheelchair: ~analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver~
- [ ] :zap: ~audited via [web.dev](https://web.dev/measure/) for performance and SEO~
- [ ] :memo: ~tested in Chrome, Firefox, Safari, Edge, and IE11~
