### PR TITLE
fix: skip past Overview link-to-self

### DIFF
--- a/src/components/MarkdownProvider/components/OverviewLinks.tsx
+++ b/src/components/MarkdownProvider/components/OverviewLinks.tsx
@@ -20,37 +20,44 @@ const StyledListItem = styled(UnorderedList.Item)`
 `;
 
 export const OverviewLinks: React.FC<{ nav: ISidebarSection[] }> = ({ nav }) => {
-  const content = nav.map(section => (
-    <>
-      <LG isBold>{section.title}</LG>
-      {section.items && (
-        <StyledUnorderedList>
-          {section.items?.map(group => {
-            if (group.items) {
-              return (
-                <StyledListItem key={group.title}>
-                  {group.title}
-                  <UnorderedList>
-                    {group.items.map(child => (
-                      <UnorderedList.Item key={child.id}>
-                        <Link to={`${child.id}`}>{child.title}</Link>
-                      </UnorderedList.Item>
-                    ))}
-                  </UnorderedList>
-                </StyledListItem>
-              );
-            }
+  const content = nav.map((section, index) => {
+    /* skip past Overview link-to-self */
+    if (index > 0) {
+      return (
+        <>
+          <LG isBold>{section.title}</LG>
+          {section.items && (
+            <StyledUnorderedList>
+              {section.items?.map(group => {
+                if (group.items) {
+                  return (
+                    <StyledListItem key={group.title}>
+                      {group.title}
+                      <UnorderedList>
+                        {group.items.map(child => (
+                          <UnorderedList.Item key={child.id}>
+                            <Link to={`${child.id}`}>{child.title}</Link>
+                          </UnorderedList.Item>
+                        ))}
+                      </UnorderedList>
+                    </StyledListItem>
+                  );
+                }
 
-            return (
-              <StyledListItem key={group.title}>
-                <Link to={`${group.id}`}>{group.title}</Link>
-              </StyledListItem>
-            );
-          })}
-        </StyledUnorderedList>
-      )}
-    </>
-  ));
+                return (
+                  <StyledListItem key={group.title}>
+                    <Link to={`${group.id}`}>{group.title}</Link>
+                  </StyledListItem>
+                );
+              })}
+            </StyledUnorderedList>
+          )}
+        </>
+      );
+    }
+
+    return <></>;
+  });
 
   return <nav>{content}</nav>;
 };


### PR DESCRIPTION
## Description

Current `Overview` link that reloads the Overview page is confusing to users. Skip past rendering the first item in the navigation list.

## Detail

**Before**

<img width="563" alt="Screen Shot 2020-07-31 at 12 44 46 PM" src="https://user-images.githubusercontent.com/143773/89071525-c9beca80-d32b-11ea-98fe-b0dcdf5b287c.png">

**After**

<img width="537" alt="Screen Shot 2020-07-31 at 12 45 38 PM" src="https://user-images.githubusercontent.com/143773/89071539-d0e5d880-d32b-11ea-9e81-a8a06b3df21b.png">

## Checklist

- [x] :ok_hand: website updates are Garden Designer approved (add the designer as a reviewer)
- [ ] :black_nib: ~copy updates are approved (add the content strategist as a reviewer)~
- [ ] :wheelchair: ~analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver~
- [ ] :zap: ~audited via [web.dev](https://web.dev/measure/) for performance and SEO~
- [ ] :memo: ~tested in Chrome, Firefox, Safari, Edge, and IE11~
