### PR TITLE
fix: autolink header styling

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -6,6 +6,7 @@
  */
 
 const envalid = require('envalid');
+const fs = require('fs');
 const path = require('path');
 
 require('dotenv').config();
@@ -110,9 +111,15 @@ module.exports = {
           {
             resolve: 'gatsby-remark-autolink-headers',
             options: {
-              className: 'anchor',
-              icon:
-                '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" focusable="false" viewBox="0 0 16 16"><path fill="none" stroke="currentColor" stroke-linecap="round" d="M3.4 8.4L1.6 6.6C.3 5.2.3 3 1.6 1.6 3 .2 5.2.2 6.5 1.6l3.2 3.2c1.4 1.4 1.4 3.6 0 4.9-.4.4-.8.7-1.3.8m4.2-2.8l1.8 1.8c1.4 1.4 1.4 3.6 0 4.9-1.4 1.4-3.6 1.4-4.9 0l-3.2-3.2c-1.4-1.4-1.4-3.6 0-4.9.4-.4.8-.7 1.3-.8"/></svg>'
+              icon: fs
+                .readFileSync(
+                  path.join(
+                    __dirname,
+                    'node_modules/@zendeskgarden/svg-icons/src/16/link-stroke.svg'
+                  )
+                )
+                .toString('utf-8')
+                .trim()
             }
           }
         ]

--- a/src/components/MarkdownProvider/components/Anchor.ts
+++ b/src/components/MarkdownProvider/components/Anchor.ts
@@ -1,0 +1,29 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import styled from 'styled-components';
+import { Anchor } from '@zendeskgarden/react-buttons';
+import { math } from 'polished';
+
+export const StyledAnchor = styled(Anchor)`
+  &.anchor.before {
+    margin-left: -${p => math(`${p.theme.space.xs} * 2 + ${p.theme.iconSizes.md}`)};
+    padding: 0 ${p => p.theme.space.xs};
+    color: transparent;
+
+    /* stylelint-disable-next-line selector-max-specificity */
+    &[data-garden-focus-visible] {
+      color: inherit;
+    }
+
+    & > svg {
+      position: relative;
+      top: -1px;
+      vertical-align: middle;
+    }
+  }
+`;

--- a/src/components/MarkdownProvider/components/Anchor.ts
+++ b/src/components/MarkdownProvider/components/Anchor.ts
@@ -6,6 +6,7 @@
  */
 
 import styled from 'styled-components';
+import { mediaQuery } from '@zendeskgarden/react-theming';
 import { Anchor } from '@zendeskgarden/react-buttons';
 import { math } from 'polished';
 
@@ -15,7 +16,12 @@ export const StyledAnchor = styled(Anchor)`
     padding: 0 ${p => p.theme.space.xs};
     color: transparent;
 
-    /* stylelint-disable-next-line selector-max-specificity */
+    /* stylelint-disable selector-max-specificity */
+    ${p => mediaQuery('down', 'md', p.theme)} {
+      margin-left: -${p => math(`${p.theme.space.xxs} * 2 + ${p.theme.iconSizes.md}`)};
+      padding: 0 ${p => p.theme.space.xxs};
+    }
+
     &[data-garden-focus-visible] {
       color: inherit;
     }

--- a/src/components/MarkdownProvider/components/Markdown.tsx
+++ b/src/components/MarkdownProvider/components/Markdown.tsx
@@ -9,8 +9,8 @@ import React, { ReactElement, ReactNode } from 'react';
 import remark from 'remark';
 import remark2react from 'remark-react';
 import VFile from 'vfile';
-import { Anchor } from '@zendeskgarden/react-buttons';
 import { Code } from '@zendeskgarden/react-typography';
+import { StyledAnchor as Anchor } from './Anchor';
 import { UL, OL, LI } from './Lists';
 import { StyledTable as Table, TR, TH, TD, TBody, THead } from './Table';
 import {

--- a/src/components/MarkdownProvider/components/Typography.tsx
+++ b/src/components/MarkdownProvider/components/Typography.tsx
@@ -8,12 +8,17 @@
 import styled, { css, ThemeProps, DefaultTheme } from 'styled-components';
 import { getColor, getLineHeight } from '@zendeskgarden/react-theming';
 import { XXXL, XXL, XL, LG, MD, Span, Paragraph } from '@zendeskgarden/react-typography';
+import { StyledAnchor } from './Anchor';
 
 const headerStyles = (p: ThemeProps<DefaultTheme>) => {
   return css`
     margin-bottom: ${p.theme.space.sm};
     color: ${getColor('chromeHue', 700, p.theme)};
     font-weight: ${p.theme.fontWeights.semibold};
+
+    &:hover ${StyledAnchor} {
+      color: inherit;
+    }
   `;
 };
 

--- a/src/components/MarkdownProvider/index.tsx
+++ b/src/components/MarkdownProvider/index.tsx
@@ -6,7 +6,6 @@
  */
 
 import React from 'react';
-import { createGlobalStyle } from 'styled-components';
 import { MDXProvider } from '@mdx-js/react';
 import { Code } from '@zendeskgarden/react-typography';
 import { CodeExample } from './components/CodeExample';
@@ -18,32 +17,6 @@ import { COMPONENTS, Markdown } from './components/Markdown';
 import { MDSyntaxHighlighter } from './components/Code';
 import { OverviewLinks } from './components/OverviewLinks';
 
-const GlobalStyle = createGlobalStyle`
-  .anchor {
-    visibility: hidden;
-    margin-left: -${p => p.theme.space.md};
-    padding-right: ${p => p.theme.space.xxs};
-    line-height: 1;
-    color: ${p => p.theme.colors.foreground};
-  }
-
-  .anchor:hover {
-    color: inherit;
-  }
-
-  .anchor[data-garden-focus-visible] {
-    visibility: visible;
-  }
-
-  h2:hover .anchor,
-  h3:hover .anchor,
-  h4:hover .anchor,
-  h5:hover .anchor,
-  h6:hover .anchor {
-    visibility: visible;
-  }
-`;
-
 /**
  * The SyntaxHighlighter component provides it's own `<pre>` tag.
  * This ensures valid DOM nesting.
@@ -54,7 +27,6 @@ export const Pre: React.FC = ({ children }) => {
 
 export const MarkdownProvider: React.FC = ({ children }) => (
   <>
-    <GlobalStyle />
     <MDXProvider
       components={{
         /**


### PR DESCRIPTION
## Description

This PR addresses the following issues with [autolink](https://www.gatsbyjs.org/packages/gatsby-remark-autolink-headers/) header styling:

- pull the (previously outdated) link icon directly from the `svg-icons` package
- replace [`GlobalStyle`](https://styled-components.com/docs/api#createglobalstyle) with more predictable extension of the Garden `Anchor` component
- improve CSS by manipulating `color` instead of `visibility`, which:
  - allows the component to take advantage of inherent color transitions
  - importantly retains the link within the tab index for improved accessibility
- improve CSS spacing to mimic [`Span.StartIcon`](https://zendeskgarden.github.io/react-components/typography/#span) styling and increase desktop tap target

## Detail

@allisonacs you'll be pleased to know that this nabs the annoying indentation bug as it stabilizes CSS ordering :tada:

## Checklist

- [x] :ok_hand: website updates are Garden Designer approved (add the designer as a reviewer)
- [ ] :black_nib: ~copy updates are approved (add the content strategist as a reviewer)~
- [x] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [x] :zap: audited via [web.dev](https://web.dev/measure/) for performance and SEO
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
