### PR TITLE
chore: update overview tags

### DIFF
--- a/src/components/MarkdownProvider/components/OverviewLinks.tsx
+++ b/src/components/MarkdownProvider/components/OverviewLinks.tsx
@@ -25,14 +25,16 @@ export const OverviewLinks: React.FC<{ nav: ISidebarSection[] }> = ({ nav }) => 
     if (index > 0) {
       return (
         <>
-          <LG isBold>{section.title}</LG>
+          <LG isBold as="h2">
+            {section.title}
+          </LG>
           {section.items && (
             <StyledUnorderedList>
               {section.items?.map(group => {
                 if (group.items) {
                   return (
                     <StyledListItem key={group.title}>
-                      {group.title}
+                      <h3>{group.title}</h3>
                       <UnorderedList>
                         {group.items.map(child => (
                           <UnorderedList.Item key={child.id}>

--- a/src/components/MarkdownProvider/components/OverviewLinks.tsx
+++ b/src/components/MarkdownProvider/components/OverviewLinks.tsx
@@ -25,7 +25,7 @@ export const OverviewLinks: React.FC<{ nav: ISidebarSection[] }> = ({ nav }) => 
     if (index > 0) {
       return (
         <>
-          <LG isBold as="h2">
+          <LG isBold tag="h2">
             {section.title}
           </LG>
           {section.items && (


### PR DESCRIPTION
<!-- structure the Title above as the first line of a
  https://conventionalcommits.org/ message. example: "chore:
  add a new 'thing' component page". -->

## Description

**Jira - GARDEN-1370**
This PR aims to better handle the semantic tags on the overview pages.


## Detail

<!-- supporting details; screen shot, code, etc. -->

<!-- closes GITHUB_ISSUE -->

## Checklist

- [ ] :ok_hand: website updates are Garden Designer approved (add the designer as a reviewer)
- [ ] :black_nib: copy updates are approved (add the content strategist as a reviewer)
- [ ] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [ ] :zap: audited via [web.dev](https://web.dev/measure/) for performance and SEO
- [ ] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
