### PR TITLE
chore: update home alignment

### DIFF
--- a/src/layouts/Home/components/News.tsx
+++ b/src/layouts/Home/components/News.tsx
@@ -47,7 +47,6 @@ export const News: React.FC = () => {
         <Grid gutters="lg">
           <Row>
             <Col
-              size={12}
               css={css`
                 padding-top: ${p => p.theme.space.xxl};
                 padding-bottom: ${p => p.theme.space.xxl};

--- a/src/layouts/Home/components/News.tsx
+++ b/src/layouts/Home/components/News.tsx
@@ -47,8 +47,10 @@ export const News: React.FC = () => {
         <Grid gutters="lg">
           <Row>
             <Col
+              size={12}
               css={css`
-                padding: ${p => p.theme.space.xxl};
+                padding-top: ${p => p.theme.space.xxl};
+                padding-bottom: ${p => p.theme.space.xxl};
               `}
             >
               <StyledSectionHeader>News and Articles</StyledSectionHeader>

--- a/src/layouts/Home/components/Search.tsx
+++ b/src/layouts/Home/components/Search.tsx
@@ -57,7 +57,7 @@ export const Search: React.FC = () => {
       `}
     >
       <MaxWidthLayout>
-        <Grid>
+        <Grid gutters="lg">
           <Row alignItems="center">
             <Col
               md={6}
@@ -85,10 +85,8 @@ export const Search: React.FC = () => {
             <Col
               md={6}
               css={css`
-                padding: ${p => p.theme.space.xxl};
-
                 ${p => mediaQuery('down', 'md', p.theme)} {
-                  padding: ${p => p.theme.space.lg};
+                  padding-top: ${p => p.theme.space.lg};
                   padding-bottom: 0;
                 }
               `}

--- a/src/layouts/Root/components/Header.tsx
+++ b/src/layouts/Root/components/Header.tsx
@@ -39,7 +39,7 @@ const StyledHeader = styled.header.attrs({ role: 'banner' })`
       `${p.theme.space.base * 6}px`,
       getColor('grey', 800, p.theme, 0.05)!
     )};
-  padding: 0 ${p => p.theme.space.md};
+  padding: 0 ${p => p.theme.space.base * 4}px;
   height: ${p => p.theme.space.base * 20}px;
 
   &[data-show-navigation='true'] {


### PR DESCRIPTION
<!-- structure the Title above as the first line of a
  https://conventionalcommits.org/ message. example: "chore:
  add a new 'thing' component page". -->

## Description

**Fix Jira [GARDEN-1404]**
Revises the news section alignment to vertically fall in line with section above it. 

## Detail

<img width="666" alt="Screen Shot 2020-08-04 at 4 04 58 PM" src="https://user-images.githubusercontent.com/29072694/89353918-5212d780-d66c-11ea-8df7-930ec4617680.png">


<!-- closes GITHUB_ISSUE -->

## Checklist

- [ ] :ok_hand: website updates are Garden Designer approved (add the designer as a reviewer)
- [ ] :black_nib: copy updates are approved (add the content strategist as a reviewer)
- [ ] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [ ] :zap: audited via [web.dev](https://web.dev/measure/) for performance and SEO
- [ ] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
