### PR TITLE
chore: add menu deps to dropdown

### DIFF
--- a/src/pages/components/autocomplete.mdx
+++ b/src/pages/components/autocomplete.mdx
@@ -5,13 +5,24 @@ description: >
   something quickly in a large list of options.
 package: '@zendeskgarden/react-dropdowns'
 components:
+  - dropdowns/src/elements/Menu/Items/AddItem.tsx
   - dropdowns/src/elements/Autocomplete/Autocomplete.tsx
   - dropdowns/src/elements/Dropdown/Dropdown.tsx
   - dropdowns/src/elements/Fields/Field.tsx
+  - dropdowns/src/elements/Menu/Items/HeaderIcon.tsx
+  - dropdowns/src/elements/Menu/Items/HeaderItem.tsx
   - dropdowns/src/elements/Fields/Hint.tsx
   - dropdowns/src/elements/Menu/Items/Item.tsx
+  - dropdowns/src/elements/Menu/Items/ItemMeta.tsx
   - dropdowns/src/elements/Fields/Label.tsx
+  - dropdowns/src/elements/Menu/Items/MediaBody.tsx
+  - dropdowns/src/elements/Menu/Items/MediaFigure.tsx
+  - dropdowns/src/elements/Menu/Items/MediaItem.tsx
   - dropdowns/src/elements/Menu/Menu.tsx
+  - dropdowns/src/elements/Menu/Items/NextItem.tsx
+  - dropdowns/src/elements/Menu/Items/PreviousItem.tsx
+  - dropdowns/src/elements/Menu/Separator.tsx
+  - dropdowns/src/elements/Trigger/Trigger.tsx
 ---
 
 <Usage>
@@ -86,6 +97,10 @@ import SizeCode from '!!raw-loader!../../examples/dropdowns/autocomplete/Size.ts
 
 ## API
 
+### AddItem
+
+<PropSheet components={props.data.mdx.components} componentName="addItem" />
+
 ### Autocomplete
 
 <PropSheet components={props.data.mdx.components} componentName="autocomplete" />
@@ -98,6 +113,14 @@ import SizeCode from '!!raw-loader!../../examples/dropdowns/autocomplete/Size.ts
 
 <PropSheet components={props.data.mdx.components} componentName="field" />
 
+### HeaderIcon
+
+<PropSheet components={props.data.mdx.components} componentName="headerIcon" />
+
+### HeaderItem
+
+<PropSheet components={props.data.mdx.components} componentName="headerItem" />
+
 ### Hint
 
 <PropSheet components={props.data.mdx.components} componentName="hint" />
@@ -106,13 +129,45 @@ import SizeCode from '!!raw-loader!../../examples/dropdowns/autocomplete/Size.ts
 
 <PropSheet components={props.data.mdx.components} componentName="item" />
 
+### ItemMeta
+
+<PropSheet components={props.data.mdx.components} componentName="itemMeta" />
+
 ### Label
 
 <PropSheet components={props.data.mdx.components} componentName="label" />
 
+### MediaBody
+
+<PropSheet components={props.data.mdx.components} componentName="mediaBody" />
+
+### MediaFigure
+
+<PropSheet components={props.data.mdx.components} componentName="mediaFigure" />
+
+### MediaItem
+
+<PropSheet components={props.data.mdx.components} componentName="mediaItem" />
+
 ### Menu
 
 <PropSheet components={props.data.mdx.components} componentName="menu" />
+
+### NextItem
+
+<PropSheet components={props.data.mdx.components} componentName="nextItem" />
+
+### PreviousItem
+
+<PropSheet components={props.data.mdx.components} componentName="previousItem" />
+
+### Separator
+
+<PropSheet components={props.data.mdx.components} componentName="separator" />
+
+### Trigger
+
+<PropSheet components={props.data.mdx.components} componentName="trigger" />
 
 import { graphql } from 'gatsby';
 

--- a/src/pages/components/multiselect.mdx
+++ b/src/pages/components/multiselect.mdx
@@ -5,12 +5,24 @@ description: >
   user types in the input field and their selections appear as tags in the input field.
 package: '@zendeskgarden/react-dropdowns'
 components:
+  - dropdowns/src/elements/Menu/Items/AddItem.tsx
   - dropdowns/src/elements/Dropdown/Dropdown.tsx
   - dropdowns/src/elements/Fields/Field.tsx
+  - dropdowns/src/elements/Menu/Items/HeaderIcon.tsx
+  - dropdowns/src/elements/Menu/Items/HeaderItem.tsx
   - dropdowns/src/elements/Fields/Hint.tsx
   - dropdowns/src/elements/Menu/Items/Item.tsx
+  - dropdowns/src/elements/Menu/Items/ItemMeta.tsx
   - dropdowns/src/elements/Fields/Label.tsx
+  - dropdowns/src/elements/Menu/Items/MediaBody.tsx
+  - dropdowns/src/elements/Menu/Items/MediaFigure.tsx
+  - dropdowns/src/elements/Menu/Items/MediaItem.tsx
+  - dropdowns/src/elements/Menu/Menu.tsx
   - dropdowns/src/elements/Multiselect/Multiselect.tsx
+  - dropdowns/src/elements/Menu/Items/NextItem.tsx
+  - dropdowns/src/elements/Menu/Items/PreviousItem.tsx
+  - dropdowns/src/elements/Menu/Separator.tsx
+  - dropdowns/src/elements/Trigger/Trigger.tsx
 ---
 
 <Usage>
@@ -63,9 +75,21 @@ import MultiselectSizeCode from '!!raw-loader!../../examples/dropdowns/multisele
 
 ## API
 
+### AddItem
+
+<PropSheet components={props.data.mdx.components} componentName="addItem" />
+
 ### Dropdown
 
 <PropSheet components={props.data.mdx.components} componentName="dropdown" />
+
+### HeaderIcon
+
+<PropSheet components={props.data.mdx.components} componentName="headerIcon" />
+
+### HeaderItem
+
+<PropSheet components={props.data.mdx.components} componentName="headerItem" />
 
 ### Field
 
@@ -79,13 +103,49 @@ import MultiselectSizeCode from '!!raw-loader!../../examples/dropdowns/multisele
 
 <PropSheet components={props.data.mdx.components} componentName="item" />
 
+### ItemMeta
+
+<PropSheet components={props.data.mdx.components} componentName="itemMeta" />
+
 ### Label
 
 <PropSheet components={props.data.mdx.components} componentName="label" />
 
+### MediaBody
+
+<PropSheet components={props.data.mdx.components} componentName="mediaBody" />
+
+### MediaFigure
+
+<PropSheet components={props.data.mdx.components} componentName="mediaFigure" />
+
+### MediaItem
+
+<PropSheet components={props.data.mdx.components} componentName="mediaItem" />
+
+### Menu
+
+<PropSheet components={props.data.mdx.components} componentName="menu" />
+
 ### Multiselect
 
 <PropSheet components={props.data.mdx.components} componentName="multiselect" />
+
+### NextItem
+
+<PropSheet components={props.data.mdx.components} componentName="nextItem" />
+
+### PreviousItem
+
+<PropSheet components={props.data.mdx.components} componentName="previousItem" />
+
+### Separator
+
+<PropSheet components={props.data.mdx.components} componentName="separator" />
+
+### Trigger
+
+<PropSheet components={props.data.mdx.components} componentName="trigger" />
 
 import { graphql } from 'gatsby';
 

--- a/src/pages/components/select.mdx
+++ b/src/pages/components/select.mdx
@@ -5,12 +5,25 @@ description: >
   This helps simplify the UI when space is limited.
 package: '@zendeskgarden/react-dropdowns'
 components:
+  - dropdowns/src/elements/Menu/Items/AddItem.tsx
   - dropdowns/src/elements/Dropdown/Dropdown.tsx
   - dropdowns/src/elements/Fields/Field.tsx
+  - dropdowns/src/elements/Menu/Items/HeaderIcon.tsx
+  - dropdowns/src/elements/Menu/Items/HeaderItem.tsx
   - dropdowns/src/elements/Fields/Hint.tsx
+  - dropdowns/src/elements/Menu/Items/Item.tsx
+  - dropdowns/src/elements/Menu/Items/ItemMeta.tsx
   - dropdowns/src/elements/Fields/Label.tsx
+  - dropdowns/src/elements/Menu/Items/MediaBody.tsx
+  - dropdowns/src/elements/Menu/Items/MediaFigure.tsx
+  - dropdowns/src/elements/Menu/Items/MediaItem.tsx
+  - dropdowns/src/elements/Menu/Menu.tsx
   - dropdowns/src/elements/Fields/Message.tsx
+  - dropdowns/src/elements/Menu/Items/NextItem.tsx
+  - dropdowns/src/elements/Menu/Items/PreviousItem.tsx
   - dropdowns/src/elements/Select/Select.tsx
+  - dropdowns/src/elements/Menu/Separator.tsx
+  - dropdowns/src/elements/Trigger/Trigger.tsx
 ---
 
 <Usage>
@@ -100,6 +113,10 @@ import SelectValidationCode from '!!raw-loader!../../examples/dropdowns/select/V
 
 ## API
 
+### AddItem
+
+<PropSheet components={props.data.mdx.components} componentName="addItem" />
+
 ### Dropdown
 
 <PropSheet components={props.data.mdx.components} componentName="dropdown" />
@@ -108,21 +125,69 @@ import SelectValidationCode from '!!raw-loader!../../examples/dropdowns/select/V
 
 <PropSheet components={props.data.mdx.components} componentName="field" />
 
+### HeaderIcon
+
+<PropSheet components={props.data.mdx.components} componentName="headerIcon" />
+
+### HeaderItem
+
+<PropSheet components={props.data.mdx.components} componentName="headerItem" />
+
 ### Hint
 
 <PropSheet components={props.data.mdx.components} componentName="hint" />
+
+### Item
+
+<PropSheet components={props.data.mdx.components} componentName="item" />
+
+### ItemMeta
+
+<PropSheet components={props.data.mdx.components} componentName="itemMeta" />
 
 ### Label
 
 <PropSheet components={props.data.mdx.components} componentName="label" />
 
+### MediaBody
+
+<PropSheet components={props.data.mdx.components} componentName="mediaBody" />
+
+### MediaFigure
+
+<PropSheet components={props.data.mdx.components} componentName="mediaFigure" />
+
+### MediaItem
+
+<PropSheet components={props.data.mdx.components} componentName="mediaItem" />
+
 ### Message
 
 <PropSheet components={props.data.mdx.components} componentName="message" />
 
+### Menu
+
+<PropSheet components={props.data.mdx.components} componentName="menu" />
+
+### NextItem
+
+<PropSheet components={props.data.mdx.components} componentName="nextItem" />
+
+### PreviousItem
+
+<PropSheet components={props.data.mdx.components} componentName="previousItem" />
+
 ### Select
 
 <PropSheet components={props.data.mdx.components} componentName="select" />
+
+### Separator
+
+<PropSheet components={props.data.mdx.components} componentName="separator" />
+
+### Trigger
+
+<PropSheet components={props.data.mdx.components} componentName="trigger" />
 
 import { graphql } from 'gatsby';
 


### PR DESCRIPTION
<!-- structure the Title above as the first line of a
  https://conventionalcommits.org/ message. example: "chore:
  add a new 'thing' component page". -->

## Description

**Fix Jira [GARDEN]1377**
All "Dropdown" pages now include the same available Menu/Item exports 

## Detail

<!-- supporting details; screen shot, code, etc. -->

<!-- closes GITHUB_ISSUE -->

## Checklist

- [ ] :ok_hand: website updates are Garden Designer approved (add the designer as a reviewer)
- [ ] :black_nib: copy updates are approved (add the content strategist as a reviewer)
- [ ] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [ ] :zap: audited via [web.dev](https://web.dev/measure/) for performance and SEO
- [ ] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
