### PR TITLE
fix(footer): improve footer link contrast on hover

### DIFF
--- a/src/layouts/Root/components/Footer.tsx
+++ b/src/layouts/Root/components/Footer.tsx
@@ -17,7 +17,8 @@ const StyledFooterItem = styled(Link)`
   margin-right: ${p => p.theme.space.lg};
   color: ${p => p.theme.palette.white};
 
-  &:hover {
+  &:hover,
+  &:focus {
     color: inherit;
   }
 `;

--- a/src/layouts/Root/components/Footer.tsx
+++ b/src/layouts/Root/components/Footer.tsx
@@ -16,6 +16,10 @@ import MaxWidthLayout from 'layouts/MaxWidth';
 const StyledFooterItem = styled(Link)`
   margin-right: ${p => p.theme.space.lg};
   color: ${p => p.theme.palette.white};
+
+  &:hover {
+    color: inherit;
+  }
 `;
 
 const Footer: React.FC = () => (


### PR DESCRIPTION
## Description

This PR fixes a failing contrast ratio for the footer links they are hovered by inheriting the white font color upon hover. 

## Checklist

- [ ] :ok_hand: website updates are Garden Designer approved (add the designer as a reviewer)
- [x] :black_nib: copy updates are approved (add the content strategist as a reviewer)
- [x] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [x] :zap: audited via [web.dev](https://web.dev/measure/) for performance and SEO
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
