### PR TITLE
fix: refine table of contents overflow

### DIFF
--- a/src/layouts/Titled/components/TOC.tsx
+++ b/src/layouts/Titled/components/TOC.tsx
@@ -124,7 +124,7 @@ export const TOC: React.FC<{ data: IHeading[] }> = ({ data }) => {
         margin-left: ${p => p.theme.space.base * 15}px;
         padding-right: ${p => p.theme.space.md};
         max-height: calc(100vh - ${p => math(`${p.theme.space.lg} * 2`)});
-        overflow-y: scroll;
+        overflow-y: auto;
       `}
     >
       <StyledSectionHeader


### PR DESCRIPTION
<!-- structure the Title above as the first line of a
  https://conventionalcommits.org/ message. example: "chore:
  add a new 'thing' component page". -->

## Description
Closes Jira [GARDEN-1453]

This PR refines the overflow behavior of the Table of Contents so we don't have a persistent scroll bar shell in places where it isn't necessary. 

## Detail

<img width="720" alt="Screen Shot 2020-08-05 at 1 01 57 PM" src="https://user-images.githubusercontent.com/29072694/89458447-e25c2580-d71b-11ea-9b61-4dc1aade95f7.png">

## Checklist

- [ ] :ok_hand: website updates are Garden Designer approved (add the designer as a reviewer)
- [ ] :black_nib: copy updates are approved (add the content strategist as a reviewer)
- [ ] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [ ] :zap: audited via [web.dev](https://web.dev/measure/) for performance and SEO
- [ ] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
