### PR TITLE
fix: amend button size strings

### DIFF
--- a/src/pages/components/button-group.mdx
+++ b/src/pages/components/button-group.mdx
@@ -33,7 +33,7 @@ recommend the use of Button Groups.
 
 ### Size
 
-Button Groups can be small, default, or large.
+Button Groups can be small, medium, or large. The default size is medium.
 
 import ButtonGroupSize from '../../examples/button/ButtonGroupSize.tsx';
 import ButtonGroupSizeCode from '!!raw-loader!../../examples/button/ButtonGroupSize.tsx';

--- a/src/pages/components/button.mdx
+++ b/src/pages/components/button.mdx
@@ -79,7 +79,7 @@ import ButtonMediaCode from '!!raw-loader!../../examples/button/ButtonMedia.tsx'
 
 ### Size
 
-Buttons come in small, default, and large.
+Buttons come in small, medium, and large. The default size is medium.
 
 import ButtonSizes from '../../examples/button/ButtonSizes.tsx';
 import ButtonSizesCode from '!!raw-loader!../../examples/button/ButtonSizes.tsx';

--- a/src/pages/components/split-button.mdx
+++ b/src/pages/components/split-button.mdx
@@ -41,7 +41,7 @@ components:
 
 ### Size
 
-Split Buttons can be small, default, or large.
+Split Buttons can be small, medium, or large. The default size is medium.
 
 import SplitButtonSizes from '../../examples/button/SplitButtonSizes.tsx';
 import SplitButtonSizesCode from '!!raw-loader!../../examples/button/SplitButtonSizes.tsx';


### PR DESCRIPTION
<!-- structure the Title above as the first line of a
  https://conventionalcommits.org/ message. example: "chore:
  add a new 'thing' component page". -->

## Description

**Fixes Jira [GARDEN-1400]**

This PR aligns the way we refer to button sizes for the pages:
- `Button`
- `Icon Button`
- `Button Group`
- `Split Button`

## Detail

<!-- supporting details; screen shot, code, etc. -->

<!-- closes GITHUB_ISSUE -->

## Checklist

- [ ] :ok_hand: website updates are Garden Designer approved (add the designer as a reviewer)
- [ ] :black_nib: copy updates are approved (add the content strategist as a reviewer)
- [ ] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [ ] :zap: audited via [web.dev](https://web.dev/measure/) for performance and SEO
- [ ] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
