### PR TITLE
feat: add split button examples

### DIFF
--- a/src/examples/button/SplitButtonDanger.tsx
+++ b/src/examples/button/SplitButtonDanger.tsx
@@ -11,7 +11,7 @@ import { SplitButton, Button, ChevronButton } from '@zendeskgarden/react-buttons
 import { Dropdown, Trigger, Menu, Item } from '@zendeskgarden/react-dropdowns';
 
 const Example = () => {
-  const [rotated, setRotated] = useState<boolean | undefined>();
+  const [rotated, setRotated] = useState<boolean>();
 
   return (
     <Row>

--- a/src/examples/button/SplitButtonDanger.tsx
+++ b/src/examples/button/SplitButtonDanger.tsx
@@ -1,0 +1,41 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import React, { useState } from 'react';
+import { Row, Col } from '@zendeskgarden/react-grid';
+import { SplitButton, Button, ChevronButton } from '@zendeskgarden/react-buttons';
+import { Dropdown, Trigger, Menu, Item } from '@zendeskgarden/react-dropdowns';
+
+const Example = () => {
+  const [rotated, setRotated] = useState<boolean | undefined>();
+
+  return (
+    <Row>
+      <Col textAlign="center">
+        <SplitButton>
+          <Button isDanger>Harvest</Button>
+          <Dropdown
+            onStateChange={options =>
+              Object.prototype.hasOwnProperty.call(options, 'isOpen') && setRotated(options.isOpen)
+            }
+          >
+            <Trigger>
+              <ChevronButton aria-label="other actions" isRotated={rotated} isDanger />
+            </Trigger>
+            <Menu placement="bottom-end">
+              <Item value="prune">Prune</Item>
+              <Item value="water">Water</Item>
+              <Item value="fertilize">Fertilize</Item>
+            </Menu>
+          </Dropdown>
+        </SplitButton>
+      </Col>
+    </Row>
+  );
+};
+
+export default Example;

--- a/src/examples/button/SplitButtonDefault.tsx
+++ b/src/examples/button/SplitButtonDefault.tsx
@@ -1,0 +1,41 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import React, { useState } from 'react';
+import { Row, Col } from '@zendeskgarden/react-grid';
+import { SplitButton, Button, ChevronButton } from '@zendeskgarden/react-buttons';
+import { Dropdown, Trigger, Menu, Item } from '@zendeskgarden/react-dropdowns';
+
+const Example = () => {
+  const [rotated, setRotated] = useState<boolean | undefined>();
+
+  return (
+    <Row>
+      <Col textAlign="center">
+        <SplitButton>
+          <Button>Harvest</Button>
+          <Dropdown
+            onStateChange={options =>
+              Object.prototype.hasOwnProperty.call(options, 'isOpen') && setRotated(options.isOpen)
+            }
+          >
+            <Trigger>
+              <ChevronButton aria-label="other actions" isRotated={rotated} />
+            </Trigger>
+            <Menu placement="bottom-end">
+              <Item value="prune">Prune</Item>
+              <Item value="water">Water</Item>
+              <Item value="fertilize">Fertilize</Item>
+            </Menu>
+          </Dropdown>
+        </SplitButton>
+      </Col>
+    </Row>
+  );
+};
+
+export default Example;

--- a/src/examples/button/SplitButtonDefault.tsx
+++ b/src/examples/button/SplitButtonDefault.tsx
@@ -11,7 +11,7 @@ import { SplitButton, Button, ChevronButton } from '@zendeskgarden/react-buttons
 import { Dropdown, Trigger, Menu, Item } from '@zendeskgarden/react-dropdowns';
 
 const Example = () => {
-  const [rotated, setRotated] = useState<boolean | undefined>();
+  const [rotated, setRotated] = useState<boolean>();
 
   return (
     <Row>

--- a/src/examples/button/SplitButtonDisabled.tsx
+++ b/src/examples/button/SplitButtonDisabled.tsx
@@ -1,0 +1,48 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import React, { useState } from 'react';
+import { Row, Col } from '@zendeskgarden/react-grid';
+import { SplitButton, Button, ChevronButton } from '@zendeskgarden/react-buttons';
+import { Dropdown, Trigger, Menu, Item } from '@zendeskgarden/react-dropdowns';
+
+const Example = () => {
+  const [rotated, setRotated] = useState<boolean | undefined>();
+
+  return (
+    <Row>
+      <Col textAlign="center">
+        <SplitButton>
+          <Button disabled aria-disabled="true">
+            Harvest
+          </Button>
+          <Dropdown
+            onStateChange={options =>
+              Object.prototype.hasOwnProperty.call(options, 'isOpen') && setRotated(options.isOpen)
+            }
+          >
+            <Trigger>
+              <ChevronButton
+                aria-label="other actions"
+                isRotated={rotated}
+                disabled
+                aria-disabled="true"
+              />
+            </Trigger>
+            <Menu placement="bottom-end">
+              <Item value="prune">Prune</Item>
+              <Item value="water">Water</Item>
+              <Item value="fertilize">Fertilize</Item>
+            </Menu>
+          </Dropdown>
+        </SplitButton>
+      </Col>
+    </Row>
+  );
+};
+
+export default Example;

--- a/src/examples/button/SplitButtonDisabled.tsx
+++ b/src/examples/button/SplitButtonDisabled.tsx
@@ -11,7 +11,7 @@ import { SplitButton, Button, ChevronButton } from '@zendeskgarden/react-buttons
 import { Dropdown, Trigger, Menu, Item } from '@zendeskgarden/react-dropdowns';
 
 const Example = () => {
-  const [rotated, setRotated] = useState<boolean | undefined>();
+  const [rotated, setRotated] = useState<boolean>();
 
   return (
     <Row>

--- a/src/examples/button/SplitButtonDisabled.tsx
+++ b/src/examples/button/SplitButtonDisabled.tsx
@@ -17,21 +17,14 @@ const Example = () => {
     <Row>
       <Col textAlign="center">
         <SplitButton>
-          <Button disabled aria-disabled="true">
-            Harvest
-          </Button>
+          <Button disabled>Harvest</Button>
           <Dropdown
             onStateChange={options =>
               Object.prototype.hasOwnProperty.call(options, 'isOpen') && setRotated(options.isOpen)
             }
           >
             <Trigger>
-              <ChevronButton
-                aria-label="other actions"
-                isRotated={rotated}
-                disabled
-                aria-disabled="true"
-              />
+              <ChevronButton aria-label="other actions" isRotated={rotated} disabled />
             </Trigger>
             <Menu placement="bottom-end">
               <Item value="prune">Prune</Item>

--- a/src/examples/button/SplitButtonSizes.tsx
+++ b/src/examples/button/SplitButtonSizes.tsx
@@ -19,9 +19,9 @@ const StyledCol = styled(Col)`
 `;
 
 const Example = () => {
-  const [smallRotated, setSmallRotated] = useState<boolean | undefined>();
-  const [mediumRotated, setMediumRotated] = useState<boolean | undefined>();
-  const [largeRotated, setLargeRotated] = useState<boolean | undefined>();
+  const [smallRotated, setSmallRotated] = useState<boolean>();
+  const [mediumRotated, setMediumRotated] = useState<boolean>();
+  const [largeRotated, setLargeRotated] = useState<boolean>();
 
   return (
     <Row alignItems="center">

--- a/src/examples/button/SplitButtonTypes.tsx
+++ b/src/examples/button/SplitButtonTypes.tsx
@@ -11,8 +11,8 @@ import { SplitButton, Button, ChevronButton } from '@zendeskgarden/react-buttons
 import { Dropdown, Trigger, Menu, Item } from '@zendeskgarden/react-dropdowns';
 
 const Example = () => {
-  const [defaultRotated, setDefaultRotated] = useState<boolean | undefined>();
-  const [primaryRotated, setPrimaryRotated] = useState<boolean | undefined>();
+  const [defaultRotated, setDefaultRotated] = useState<boolean>();
+  const [primaryRotated, setPrimaryRotated] = useState<boolean>();
 
   return (
     <Row>

--- a/src/pages/components/checkbox.mdx
+++ b/src/pages/components/checkbox.mdx
@@ -52,7 +52,7 @@ import DefaultCode from '!!raw-loader!../../examples/forms/checkbox/Default.tsx'
 ### Disabled
 
 A disabled Checkbox prevents user interaction. It doesn’t appear in the tab order, can’t receive focus, and may not
-read aloud by a screenreader.
+be read aloud by a screenreader.
 
 import Disabled from '../../examples/forms/checkbox/Disabled.tsx';
 import DisabledCode from '!!raw-loader!../../examples/forms/checkbox/Disabled.tsx';

--- a/src/pages/components/icon-button.mdx
+++ b/src/pages/components/icon-button.mdx
@@ -54,7 +54,7 @@ import IconButtonDangerCode from '!!raw-loader!../../examples/button/IconButtonD
 ### Disabled
 
 A disabled Icon Button prevents user interaction. It doesn’t appear in the tab order, can’t receive focus, and may not
-read aloud by a screenreader.
+be read aloud by a screenreader.
 
 import IconButtonDisabled from '../../examples/button/IconButtonDisabled.tsx';
 import IconButtonDisabledCode from '!!raw-loader!../../examples/button/IconButtonDisabled.tsx';

--- a/src/pages/components/split-button.mdx
+++ b/src/pages/components/split-button.mdx
@@ -64,7 +64,7 @@ import SplitButtonDangerCode from '!!raw-loader!../../examples/button/SplitButto
 ### Disabled
 
 A disabled Split Button prevents user interaction. It doesn’t appear in the tab order,
-can’t receive focus, and may not read aloud by a screenreader.
+can’t receive focus, and may not be read aloud by a screenreader.
 
 import SplitButtonDisabled from '../../examples/button/SplitButtonDisabled.tsx';
 import SplitButtonDisabledCode from '!!raw-loader!../../examples/button/SplitButtonDisabled.tsx';

--- a/src/pages/components/split-button.mdx
+++ b/src/pages/components/split-button.mdx
@@ -39,6 +39,40 @@ components:
 
 ## How to use it
 
+### Default
+
+The typical usage of a Split Button component.
+
+import SplitButtonDefault from '../../examples/button/SplitButtonDefault.tsx';
+import SplitButtonDefaultCode from '!!raw-loader!../../examples/button/SplitButtonDefault.tsx';
+
+<CodeExample code={SplitButtonDefaultCode}>
+  <SplitButtonDefault />
+</CodeExample>
+
+### Danger
+
+Use danger styling for Split Buttons that enable destructive action.
+
+import SplitButtonDanger from '../../examples/button/SplitButtonDanger.tsx';
+import SplitButtonDangerCode from '!!raw-loader!../../examples/button/SplitButtonDanger.tsx';
+
+<CodeExample code={SplitButtonDangerCode}>
+  <SplitButtonDanger />
+</CodeExample>
+
+### Disabled
+
+A disabled Split Button prevents user interaction. It doesn’t appear in the tab order,
+can’t receive focus, and may not read aloud by a screenreader.
+
+import SplitButtonDisabled from '../../examples/button/SplitButtonDisabled.tsx';
+import SplitButtonDisabledCode from '!!raw-loader!../../examples/button/SplitButtonDisabled.tsx';
+
+<CodeExample code={SplitButtonDisabledCode}>
+  <SplitButtonDisabled />
+</CodeExample>
+
 ### Size
 
 Split Buttons can be small, medium, or large. The default size is medium.


### PR DESCRIPTION
<!-- structure the Title above as the first line of a
  https://conventionalcommits.org/ message. example: "chore:
  add a new 'thing' component page". -->

## Description

**Fixes Jira [GARDEN-1401]**
Adds default, danger and disabled examples to the Split Button component page using other Button page copy syntax as a template for the text. 

## Detail

<!-- supporting details; screen shot, code, etc. -->

<!-- closes GITHUB_ISSUE -->

## Checklist

- [ ] :ok_hand: website updates are Garden Designer approved (add the designer as a reviewer)
- [ ] :black_nib: copy updates are approved (add the content strategist as a reviewer)
- [ ] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [ ] :zap: audited via [web.dev](https://web.dev/measure/) for performance and SEO
- [ ] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
