### PR TITLE
fix: prevent code block from overflowing rounded container borders

### DIFF
--- a/src/components/MarkdownProvider/components/CodeExample/index.tsx
+++ b/src/components/MarkdownProvider/components/CodeExample/index.tsx
@@ -38,6 +38,7 @@ export const CodeExample: React.FC<{ code: string }> = ({ children, code }) => {
         margin-bottom: ${p => p.theme.space.xl};
         border: ${p => p.theme.borders.sm} ${p => getColor('grey', 300, p.theme)};
         border-radius: ${p => p.theme.borderRadii.md};
+        overflow: hidden;
       `}
     >
       <ThemeProvider theme={exampleTheme} focusVisibleRef={focusVisibleRef}>


### PR DESCRIPTION
## Description

**Before**

<img width="300" alt="Screen Shot 2020-08-10 at 2 12 45 PM" src="https://user-images.githubusercontent.com/143773/89832005-a35f1300-db13-11ea-822d-2d0acffb057c.png">

**After**

<img width="300" alt="Screen Shot 2020-08-10 at 2 16 47 PM" src="https://user-images.githubusercontent.com/143773/89832431-297b5980-db14-11ea-954a-23631903da5e.png">

## Checklist

- [x] :ok_hand: website updates are Garden Designer approved (add the designer as a reviewer)
- [ ] :black_nib: ~copy updates are approved (add the content strategist as a reviewer)~
- [ ] :wheelchair: ~analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver~
- [ ] :zap: ~audited via [web.dev](https://web.dev/measure/) for performance and SEO~
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
