### PR TITLE
chore(docs): add TailwindCSS plugin link

### DIFF
--- a/src/nav/components.yml
+++ b/src/nav/components.yml
@@ -6,6 +6,8 @@
   items:
     - id: https://zendeskgarden.github.io/css-components/bedrock/
       title: Bedrock CSS
+    - id: https://github.com/zendeskgarden/tailwindcss
+      title: Tailwind CSS Plugin
     - id: https://zendeskgarden.github.io/react-containers
       title: Containers
     - id: https://zendeskgarden.github.io/react-components/theming


### PR DESCRIPTION
## Description

This PR adds the Garden Tailwind CSS plugin to the components sidebar.

## Detail

I've gone with `Tailwind CSS Plugin` for the naming since we already have `Bedrock CSS`. Open to any changes that you all think is best.

Originally went with "Design Tokens", but I'm not sure that's descriptive enough.

## Checklist

- [ ] :ok_hand: website updates are Garden Designer approved (add the designer as a reviewer)
- [ ] :black_nib: copy updates are approved (add the content strategist as a reviewer)
- [ ] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [ ] :zap: audited via [web.dev](https://web.dev/measure/) for performance and SEO
- [ ] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
