### PR TITLE
feat: add inline loader component page

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "@zendeskgarden/react-dropdowns": "8.19.0",
     "@zendeskgarden/react-forms": "8.19.0",
     "@zendeskgarden/react-grid": "8.19.0",
+    "@zendeskgarden/react-loaders": "8.19.0",
     "@zendeskgarden/react-notifications": "8.19.0",
     "@zendeskgarden/react-tables": "8.19.0",
     "@zendeskgarden/react-tabs": "8.19.0",

--- a/src/examples/loaders/inline/InlineColor.tsx
+++ b/src/examples/loaders/inline/InlineColor.tsx
@@ -7,12 +7,19 @@
 
 import React from 'react';
 import { Row, Col } from '@zendeskgarden/react-grid';
+import { PALETTE } from '@zendeskgarden/react-theming';
 import { Inline } from '@zendeskgarden/react-loaders';
 
 const Example = () => (
   <Row>
     <Col textAlign="center">
-      <Inline />
+      <Inline size={32} color={PALETTE.grey[600]} />
+    </Col>
+    <Col textAlign="center">
+      <Inline size={32} color={PALETTE.blue[600]} />
+    </Col>
+    <Col textAlign="center">
+      <Inline size={32} color={PALETTE.green[600]} />
     </Col>
   </Row>
 );

--- a/src/examples/loaders/inline/InlineDefault.tsx
+++ b/src/examples/loaders/inline/InlineDefault.tsx
@@ -1,0 +1,13 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import React from 'react';
+import { Inline } from '@zendeskgarden/react-loaders';
+
+const Example = () => <Inline size={64} />;
+
+export default Example;

--- a/src/examples/loaders/inline/InlineSize.tsx
+++ b/src/examples/loaders/inline/InlineSize.tsx
@@ -10,9 +10,15 @@ import { Row, Col } from '@zendeskgarden/react-grid';
 import { Inline } from '@zendeskgarden/react-loaders';
 
 const Example = () => (
-  <Row>
+  <Row alignItems="center">
     <Col textAlign="center">
-      <Inline />
+      <Inline size={32} />
+    </Col>
+    <Col textAlign="center">
+      <Inline size={48} />
+    </Col>
+    <Col textAlign="center">
+      <Inline size={64} />
     </Col>
   </Row>
 );

--- a/src/nav/components.yml
+++ b/src/nav/components.yml
@@ -64,7 +64,7 @@
       items:
         - id: https://zendeskgarden.github.io/react-components/loaders
           title: Dots
-        - id: https://zendeskgarden.github.io/react-components/loaders
+        - id: /components/inline
           title: Inline
         - id: https://zendeskgarden.github.io/react-components/loaders
           title: Progress

--- a/src/pages/components/inline.mdx
+++ b/src/pages/components/inline.mdx
@@ -18,7 +18,7 @@ components:
     <ul>
       <li>
         <Markdown>
-          To communicate an action is being processed, use the
+          To show a loading state, use the
           [Dots](https://zendeskgarden.github.io/react-components/loaders/#dots-1) loader instead
         </Markdown>
       </li>
@@ -30,13 +30,37 @@ components:
 
 ### Default
 
-The typical usage of an Inline component.
+The Inline loader is used to represent someone typing.
 
 import Default from '../../examples/loaders/inline/InlineDefault.tsx';
 import DefaultCode from '!!raw-loader!../../examples/loaders/inline/InlineDefault.tsx';
 
 <CodeExample code={DefaultCode}>
   <Default />
+</CodeExample>
+
+### Color
+
+By default the color will be inherited from the parent element’s color. Can be
+explicitly set.
+
+import Color from '../../examples/loaders/inline/InlineColor.tsx';
+import ColorCode from '!!raw-loader!../../examples/loaders/inline/InlineColor.tsx';
+
+<CodeExample code={ColorCode}>
+  <Color />
+</CodeExample>
+
+### Size
+
+Can be explicitly set. By default, the size will be inherited from the font-size
+of the parent element.
+
+import Size from '../../examples/loaders/inline/InlineSize.tsx';
+import SizeCode from '!!raw-loader!../../examples/loaders/inline/InlineSize.tsx';
+
+<CodeExample code={SizeCode}>
+  <Size />
 </CodeExample>
 
 ## Configuration

--- a/src/pages/components/inline.mdx
+++ b/src/pages/components/inline.mdx
@@ -1,0 +1,58 @@
+---
+title: Inline
+description: >
+  The Inline loader is used as a typing indicator. This signals the other party
+  is present and preparing a reply.
+package: '@zendeskgarden/react-loaders'
+components:
+  - loaders/src/elements/Inline.tsx
+---
+
+<Usage>
+  <Use>
+    <ul>
+      <li>As a typing indicator</li>
+    </ul>
+  </Use>
+  <Misuse>
+    <ul>
+      <li>
+        <Markdown>
+          To communicate an action is being processed, use the
+          [Dots](https://zendeskgarden.github.io/react-components/loaders/#dots-1) loader instead
+        </Markdown>
+      </li>
+    </ul>
+  </Misuse>
+</Usage>
+
+## How to use it
+
+### Default
+
+The typical usage of an Inline component.
+
+import Default from '../../examples/loaders/inline/InlineDefault.tsx';
+import DefaultCode from '!!raw-loader!../../examples/loaders/inline/InlineDefault.tsx';
+
+<CodeExample code={DefaultCode}>
+  <Default />
+</CodeExample>
+
+## Configuration
+
+<Configuration reactPackage={props.data.mdx.package} components={props.data.mdx.components} />
+
+## API
+
+### Inline
+
+<PropSheet components={props.data.mdx.components} componentName="inline" />
+
+import { graphql } from 'gatsby';
+
+export const pageQuery = graphql`
+  query($fileAbsolutePath: String) {
+    ...SidebarPageFragment
+  }
+`;

--- a/yarn.lock
+++ b/yarn.lock
@@ -3522,6 +3522,13 @@
     "@babel/runtime" "^7.8.4"
     "@zendeskgarden/container-utilities" "^0.5.3"
 
+"@zendeskgarden/container-schedule@^1.3.1":
+  version "1.3.5"
+  resolved "https://registry.yarnpkg.com/@zendeskgarden/container-schedule/-/container-schedule-1.3.5.tgz#284e58b2f572c0af9e0e06cdaa48ec4f791eb6b2"
+  integrity sha512-2/nOtHpuChXovVqJLhjmyiifUNNEY9AVnW23xAUZ3cXTpiOQuLcaXDr8tFmrK8CrmWL05mJCK3eY95CXoSMdRA==
+  dependencies:
+    "@babel/runtime" "^7.8.4"
+
 "@zendeskgarden/container-selection@^1.3.1", "@zendeskgarden/container-selection@^1.3.5":
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/@zendeskgarden/container-selection/-/container-selection-1.3.5.tgz#72d88e62796665ef08d6c0de779a66f91ed9c8b6"
@@ -3638,6 +3645,14 @@
   resolved "https://registry.yarnpkg.com/@zendeskgarden/react-grid/-/react-grid-8.19.0.tgz#64d9a274a9a24852606246dc240b9cfcb828271f"
   integrity sha512-Z526LJ6Kg0CALSfl856FqzeihohfdnLiVWKBlRhTB5LGD5cPgayPt0dQarWScdBTI18RkIRuiNT1STranPvL9A==
   dependencies:
+    polished "^3.5.1"
+
+"@zendeskgarden/react-loaders@8.19.0":
+  version "8.19.0"
+  resolved "https://registry.yarnpkg.com/@zendeskgarden/react-loaders/-/react-loaders-8.19.0.tgz#caa1d240b3ddd0d18893173d8efa6701e13862a3"
+  integrity sha512-/5wUs69mmBMVGj1UeS0SkmD3qYFqkME3DtauvjDJ/bV40i+sDROxqx0LdkjqgGhI6QdzcI3E6lvSx5AoIckuMQ==
+  dependencies:
+    "@zendeskgarden/container-schedule" "^1.3.1"
     polished "^3.5.1"
 
 "@zendeskgarden/react-notifications@8.19.0":


### PR DESCRIPTION
<!-- structure the Title above as the first line of a
  https://conventionalcommits.org/ message. example: "chore:
  add a new 'thing' component page". -->

## Description

This PR adds the Inline loader component page to the website. For the moment, you will need to access it from the Overview Page link as our root navigation automatically navigates to the old site. 

## Detail

<!-- supporting details; screen shot, code, etc. -->

<!-- closes GITHUB_ISSUE -->

## Checklist

- [x] :ok_hand: website updates are Garden Designer approved (add the designer as a reviewer)
- [x] :black_nib: copy updates are approved (add the content strategist as a reviewer)
- [x] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [x] :zap: audited via [web.dev](https://web.dev/measure/) for performance and SEO
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
