### PR TITLE
feat(tooltips): add tooltip component

### DIFF
--- a/src/components/MarkdownProvider/components/CodeExample/utils/retrieveCodesandboxParameters.ts
+++ b/src/components/MarkdownProvider/components/CodeExample/utils/retrieveCodesandboxParameters.ts
@@ -73,6 +73,7 @@ const packageJson = `
     "@zendeskgarden/react-tabs": "^8.x",
     "@zendeskgarden/react-tags": "^8.x",
     "@zendeskgarden/react-theming": "^8.x",
+    "@zendeskgarden/react-tooltips": "^8.x",
     "@zendeskgarden/react-typography": "^8.x",
     "@zendeskgarden/svg-icons": "^6.17.0"
   }

--- a/src/examples/tooltip/TooltipDefault.tsx
+++ b/src/examples/tooltip/TooltipDefault.tsx
@@ -1,0 +1,22 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import React from 'react';
+import { Tooltip } from '@zendeskgarden/react-tooltips';
+import { Row, Col } from '@zendeskgarden/react-grid';
+
+const Example = () => (
+  <Row>
+    <Col textAlign="center">
+      <Tooltip content={'Eat, drink and be rosemary'}>
+        <span>Hover for a tooltip</span>
+      </Tooltip>
+    </Col>
+  </Row>
+);
+
+export default Example;

--- a/src/examples/tooltip/TooltipDefault.tsx
+++ b/src/examples/tooltip/TooltipDefault.tsx
@@ -12,7 +12,7 @@ import { Row, Col } from '@zendeskgarden/react-grid';
 const Example = () => (
   <Row>
     <Col textAlign="center">
-      <Tooltip content={'Eat, drink and be rosemary'}>
+      <Tooltip content="Eat, drink, and be rosemary">
         <span>Hover for a tooltip</span>
       </Tooltip>
     </Col>

--- a/src/examples/tooltip/TooltipPlacement.tsx
+++ b/src/examples/tooltip/TooltipPlacement.tsx
@@ -29,7 +29,7 @@ const PLACEMENTS: Record<string, GARDEN_PLACEMENT> = {
 const Example = () => (
   <Row style={{ margin: 80 }}>
     <Col textAlign="center">
-      <Tooltip placement={PLACEMENTS.topStart} content={'Eat, drink and be rosemary'}>
+      <Tooltip placement={PLACEMENTS.topStart} content="Eat, drink, and be rosemary">
         <span>Hover for a tooltip</span>
       </Tooltip>
     </Col>

--- a/src/examples/tooltip/TooltipPlacement.tsx
+++ b/src/examples/tooltip/TooltipPlacement.tsx
@@ -1,0 +1,39 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import React from 'react';
+import { Tooltip } from '@zendeskgarden/react-tooltips';
+import { GARDEN_PLACEMENT } from '@zendeskgarden/react-dropdowns';
+import { Row, Col } from '@zendeskgarden/react-grid';
+
+const PLACEMENTS: Record<string, GARDEN_PLACEMENT> = {
+  auto: 'auto',
+  top: 'top',
+  topStart: 'top-start',
+  topEnd: 'top-end',
+  end: 'end',
+  endTop: 'end-top',
+  endBottom: 'end-bottom',
+  bottom: 'bottom',
+  bottomStart: 'bottom-start',
+  bottomEnd: 'bottom-end',
+  start: 'start',
+  startTop: 'start-top',
+  startBottom: 'start-bottom'
+};
+
+const Example = () => (
+  <Row style={{ margin: 80 }}>
+    <Col textAlign="center">
+      <Tooltip placement={PLACEMENTS.topStart} content={'Eat, drink and be rosemary'}>
+        <span>Hover for a tooltip</span>
+      </Tooltip>
+    </Col>
+  </Row>
+);
+
+export default Example;

--- a/src/examples/tooltip/TooltipSize.tsx
+++ b/src/examples/tooltip/TooltipSize.tsx
@@ -10,14 +10,14 @@ import { Tooltip, Title, Paragraph } from '@zendeskgarden/react-tooltips';
 import { Row, Col } from '@zendeskgarden/react-grid';
 
 const Example = () => (
-  <Row justifyContent="between">
+  <Row>
     <Col textAlign="center">
-      <Tooltip size="small" content={'Eat, drink and be rosemary'}>
+      <Tooltip size="small" content="Eat, drink, and be rosemary" placement="top-start">
         <span>Small</span>
       </Tooltip>
     </Col>
     <Col textAlign="center">
-      <Tooltip size="medium" content={'I want to start gardening, but I haven’t botany plants.'}>
+      <Tooltip size="medium" content="I want to start gardening, but I haven’t botany plants.">
         <span>Medium</span>
       </Tooltip>
     </Col>
@@ -42,12 +42,13 @@ const Example = () => (
       <Tooltip
         type="light"
         size="extra-large"
-        placement="auto"
+        placement="top-end"
+        zIndex={1}
         content={
           <>
             <Title>Garden advice</Title>
             <Paragraph>
-              I asked the staff at my local garden centre what to grow in my garden. They gave me
+              I asked the staff at my local garden center what to grow in my garden. They gave me
               some sage advice.
             </Paragraph>
           </>

--- a/src/examples/tooltip/TooltipSize.tsx
+++ b/src/examples/tooltip/TooltipSize.tsx
@@ -1,0 +1,62 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import React from 'react';
+import { Tooltip, Title, Paragraph } from '@zendeskgarden/react-tooltips';
+import { Row, Col } from '@zendeskgarden/react-grid';
+
+const Example = () => (
+  <Row justifyContent="between">
+    <Col textAlign="center">
+      <Tooltip size="small" content={'Eat, drink and be rosemary'}>
+        <span>Small</span>
+      </Tooltip>
+    </Col>
+    <Col textAlign="center">
+      <Tooltip size="medium" content={'I want to start gardening, but I haven’t botany plants.'}>
+        <span>Medium</span>
+      </Tooltip>
+    </Col>
+    <Col textAlign="center">
+      <Tooltip
+        type="light"
+        size="large"
+        content={
+          <>
+            <Title>Words of wisdom</Title>
+            <Paragraph>
+              I was offered a job as a gardener, but I didn’t take it because the celery was too
+              low.
+            </Paragraph>
+          </>
+        }
+      >
+        <span>Large</span>
+      </Tooltip>
+    </Col>
+    <Col textAlign="center">
+      <Tooltip
+        type="light"
+        size="extra-large"
+        placement="auto"
+        content={
+          <>
+            <Title>Garden advice</Title>
+            <Paragraph>
+              I asked the staff at my local garden centre what to grow in my garden. They gave me
+              some sage advice.
+            </Paragraph>
+          </>
+        }
+      >
+        <span>Extra large</span>
+      </Tooltip>
+    </Col>
+  </Row>
+);
+
+export default Example;

--- a/src/examples/tooltip/TooltipType.tsx
+++ b/src/examples/tooltip/TooltipType.tsx
@@ -12,7 +12,7 @@ import { Row, Col } from '@zendeskgarden/react-grid';
 const Example = () => (
   <Row>
     <Col textAlign="center">
-      <Tooltip type="dark" size="small" content={'Eat, drink and be rosemary'}>
+      <Tooltip type="dark" size="small" content="Eat, drink, and be rosemary">
         <span>Dark tooltip</span>
       </Tooltip>
     </Col>
@@ -20,11 +20,12 @@ const Example = () => (
       <Tooltip
         type="light"
         size="large"
+        placement="top-end"
         content={
           <>
             <Title>Words of wisdom</Title>
             <Paragraph>
-              I asked the staff at my local garden centre what to grow in my garden. They gave me
+              I asked the staff at my local garden center what to grow in my garden. They gave me
               some sage advice.
             </Paragraph>
           </>

--- a/src/examples/tooltip/TooltipType.tsx
+++ b/src/examples/tooltip/TooltipType.tsx
@@ -1,0 +1,39 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import React from 'react';
+import { Tooltip, Title, Paragraph } from '@zendeskgarden/react-tooltips';
+import { Row, Col } from '@zendeskgarden/react-grid';
+
+const Example = () => (
+  <Row>
+    <Col textAlign="center">
+      <Tooltip type="dark" size="small" content={'Eat, drink and be rosemary'}>
+        <span>Dark tooltip</span>
+      </Tooltip>
+    </Col>
+    <Col textAlign="center">
+      <Tooltip
+        type="light"
+        size="large"
+        content={
+          <>
+            <Title>Words of wisdom</Title>
+            <Paragraph>
+              I asked the staff at my local garden centre what to grow in my garden. They gave me
+              some sage advice.
+            </Paragraph>
+          </>
+        }
+      >
+        <span>Light tooltip</span>
+      </Tooltip>
+    </Col>
+  </Row>
+);
+
+export default Example;

--- a/src/nav/components.yml
+++ b/src/nav/components.yml
@@ -97,7 +97,7 @@
     - title: Tiles
       id: https://zendeskgarden.github.io/react-components/forms/#tiles
     - title: Tooltip
-      id: https://zendeskgarden.github.io/react-components/tooltips
+      id: /components/tooltip
     - title: Typography
       items:
         - title: Code

--- a/src/pages/components/tooltip.mdx
+++ b/src/pages/components/tooltip.mdx
@@ -1,10 +1,12 @@
 ---
 title: Tooltip
 description: >
-  Tooltips appear when a user hovers over an element. They provide contextual
+  Tooltips appear when a user hovers or focuses an element. They provide contextual
   information about the element they are paired with.
 package: '@zendeskgarden/react-tooltips'
 components:
+  - tooltips/src/elements/Paragraph.tsx
+  - tooltips/src/elements/Title.tsx
   - tooltips/src/elements/Tooltip.tsx
 ---
 
@@ -78,13 +80,13 @@ import TypeCode from '!!raw-loader!../../examples/tooltip/TooltipType.tsx';
 
 ## API
 
+### Paragraph
+
+### Title
+
 ### Tooltip
 
 <PropSheet components={props.data.mdx.components} componentName="tooltip" />
-
-#### Paragraph
-
-#### Title
 
 import { graphql } from 'gatsby';
 

--- a/src/pages/components/tooltip.mdx
+++ b/src/pages/components/tooltip.mdx
@@ -1,0 +1,95 @@
+---
+title: Tooltip
+description: >
+  Tooltips appear when a user hovers over an element. They provide contextual
+  information about the element they are paired with.
+package: '@zendeskgarden/react-tooltips'
+components:
+  - tooltips/src/elements/Tooltip.tsx
+---
+
+<Usage>
+  <Use>
+    <ul>
+      <li>To describe the function of an element when it might be ambiguous</li>
+      <li>To describe the function of unlabeled icons</li>
+    </ul>
+  </Use>
+  <Misuse>
+    <ul>
+      <li>To provide information a user needs to know or remember</li>
+      <li>To display truncated text, use a title attribute instead</li>
+    </ul>
+  </Misuse>
+</Usage>
+
+## How to use it
+
+### Default
+
+The default usage of a Tooltip component.
+
+import Default from '../../examples/tooltip/TooltipDefault.tsx';
+import DefaultCode from '!!raw-loader!../../examples/tooltip/TooltipDefault.tsx';
+
+<CodeExample code={DefaultCode}>
+  <Default />
+</CodeExample>
+
+### Placement
+
+There are 13 placement options. By default, the Tooltip occupies the top
+position. `auto` uses the placement with the most available space.
+
+import Placement from '../../examples/tooltip/TooltipPlacement.tsx';
+import PlacementCode from '!!raw-loader!../../examples/tooltip/TooltipPlacement.tsx';
+
+<CodeExample code={PlacementCode}>
+  <Placement />
+</CodeExample>
+
+### Size
+
+Tooltips can be small, medium, large, or extra-large. Only large and extra-large
+sizes can contain a Title.
+
+import Size from '../../examples/tooltip/TooltipSize.tsx';
+import SizeCode from '!!raw-loader!../../examples/tooltip/TooltipSize.tsx';
+
+<CodeExample code={SizeCode}>
+  <Size />
+</CodeExample>
+
+### Type
+
+Tooltips can be light or dark. Small and medium tooltips should default to dark.
+Large and extra-large tooltips should default to light.
+
+import Type from '../../examples/tooltip/TooltipType.tsx';
+import TypeCode from '!!raw-loader!../../examples/tooltip/TooltipType.tsx';
+
+<CodeExample code={TypeCode}>
+  <Type />
+</CodeExample>
+
+## Configuration
+
+<Configuration reactPackage={props.data.mdx.package} components={props.data.mdx.components} />
+
+## API
+
+### Tooltip
+
+<PropSheet components={props.data.mdx.components} componentName="tooltip" />
+
+#### Paragraph
+
+#### Title
+
+import { graphql } from 'gatsby';
+
+export const pageQuery = graphql`
+  query($fileAbsolutePath: String) {
+    ...SidebarPageFragment
+  }
+`;

--- a/src/pages/components/tooltip.mdx
+++ b/src/pages/components/tooltip.mdx
@@ -82,7 +82,11 @@ import TypeCode from '!!raw-loader!../../examples/tooltip/TooltipType.tsx';
 
 ### Paragraph
 
+<PropSheet components={props.data.mdx.components} componentName="paragraph" />
+
 ### Title
+
+<PropSheet components={props.data.mdx.components} componentName="title" />
 
 ### Tooltip
 


### PR DESCRIPTION
<!-- structure the Title above as the first line of a
  https://conventionalcommits.org/ message. example: "chore:
  add a new 'thing' component page". -->

## Description

This PR adds the Tooltip component to the website. 

## Detail

<!-- supporting details; screen shot, code, etc. -->

<!-- closes GITHUB_ISSUE -->

## Checklist

- [ ] :ok_hand: website updates are Garden Designer approved (add the designer as a reviewer)
- [ ] :black_nib: copy updates are approved (add the content strategist as a reviewer)
- [ ] :link: considered opportunities for adding cross-reference URLs (grep for keywords)
- [ ] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [ ] :zap: audited via [web.dev](https://web.dev/measure/) for performance and SEO
- [ ] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
