### PR TITLE
fix: add react keys to overview links

### DIFF
--- a/src/components/MarkdownProvider/components/OverviewLinks.tsx
+++ b/src/components/MarkdownProvider/components/OverviewLinks.tsx
@@ -24,7 +24,7 @@ export const OverviewLinks: React.FC<{ nav: ISidebarSection[] }> = ({ nav }) => 
     /* skip past Overview link-to-self */
     if (index > 0) {
       return (
-        <>
+        <React.Fragment key={index}>
           <LG isBold tag="h2">
             {section.title}
           </LG>
@@ -54,11 +54,11 @@ export const OverviewLinks: React.FC<{ nav: ISidebarSection[] }> = ({ nav }) => 
               })}
             </StyledUnorderedList>
           )}
-        </>
+        </React.Fragment>
       );
     }
 
-    return <></>;
+    return null;
   });
 
   return <nav>{content}</nav>;


### PR DESCRIPTION
## Description

React keys were missing for the overview links which helps React identify changes in lists.

## Detail

This PR adds a `key` value for [list fragments](https://reactjs.org/docs/fragments.html#keyed-fragments) and removes empty fragments in favor of `null` (which tells React to render nothing).

## Screenshot

**Before:** Warning
<img width="882" alt="Screen Shot 2020-09-25 at 1 17 00 PM" src="https://user-images.githubusercontent.com/1811365/94312463-c746ae80-ff31-11ea-8db8-1481c6f9faaa.png">

**After:** No warning

<!-- supporting details; screen shot, code, etc. -->

<!-- closes GITHUB_ISSUE -->

## Checklist

- [x] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [x] :zap: audited via [web.dev](https://web.dev/measure/) for performance and SEO
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
