### PR TITLE
fix: remove unnecessary global height styles

### DIFF
--- a/src/layouts/Root/index.tsx
+++ b/src/layouts/Root/index.tsx
@@ -19,15 +19,6 @@ import '@zendeskgarden/css-bedrock/dist/index.css';
  * Ensure Gatsby wrapping nodes are full height
  */
 const GlobalStyling = createGlobalStyle`
-  /* stylelint-disable-next-line selector-max-id, selector-max-specificity */
-  html,
-  body,
-  #___gatsby,
-  #___gatsby > div,
-  #gatsby-focus-wrapper {
-    height: 100%;
-  }
-
   * {
     -ms-overflow-style: -ms-autohiding-scrollbar;
   }


### PR DESCRIPTION
## Description

Applying `height: 100%` to the `<html>` element [causes](https://github.com/willmcpo/body-scroll-lock/issues/182#issuecomment-699714361) the browser to scroll to the top when `overflow: hidden` is applied to the `body`. To see this problem, visit `Modal` [documentation](https://garden.zendesk.com/components/modal#size), scroll the page, select "Open Large Modal" and **the browser automatically scrolls the page to the top**. This problem is more apparent with the current `DrawerModal` as outlined here: https://github.com/zendeskgarden/website/pull/188#pullrequestreview-500559432.

## Detail

It looks like the `height` styles in question were used to make [the footer stick to the bottom](https://dev.to/hzburki/100-height-to-all-divs-gatsby-33nd). However, I think these styles might be unnecessary because [using flexbox](https://codepen.io/hzhu/pen/zYqVRxv) should be sufficient. 

To verify that removing these styles didn't break the header/footer layout, I removed the styles, some DOM nodes. The header/footer layout remains spaced and the footer stickied to the bottom:
<img width="1033" alt="Screen Shot 2020-10-01 at 12 56 05 PM" src="https://user-images.githubusercontent.com/1811365/94859294-28b2c580-03e9-11eb-8cab-f1b771591981.png">


@austin94 since you added the original styles I'd love to get your review on this.

<!-- supporting details; screen shot, code, etc. -->

<!-- closes GITHUB_ISSUE -->

## Checklist

- [x] :ok_hand: website updates are Garden Designer approved (add the designer as a reviewer)
- [x] :black_nib: copy updates are approved (add the content strategist as a reviewer)
- [x] :link: considered opportunities for adding cross-reference URLs (grep for keywords)
- [x] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [x] :zap: audited via [web.dev](https://web.dev/measure/) for performance and SEO
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
