### PR TITLE
fix: amend component overflow style

### DIFF
--- a/src/components/MarkdownProvider/components/CodeExample/index.tsx
+++ b/src/components/MarkdownProvider/components/CodeExample/index.tsx
@@ -46,7 +46,6 @@ export const CodeExample: React.FC<{ code: string }> = ({ children, code }) => {
           css={css`
             padding: ${p => p.theme.space.md};
             direction: ${p => p.theme.rtl && 'rtl'};
-            overflow: auto;
           `}
         >
           {typeof window === 'undefined' /* isSSR */ ? undefined : children}

--- a/src/examples/table/TableCaption.tsx
+++ b/src/examples/table/TableCaption.tsx
@@ -19,7 +19,7 @@ import {
 } from '@zendeskgarden/react-tables';
 
 const Example = () => (
-  <div style={{ overflow: 'auto' }}>
+  <div style={{ overflowX: 'auto' }}>
     <Table style={{ minWidth: 500 }}>
       <Caption>
         <XL>Garden details</XL>

--- a/src/examples/table/TableCaption.tsx
+++ b/src/examples/table/TableCaption.tsx
@@ -19,8 +19,8 @@ import {
 } from '@zendeskgarden/react-tables';
 
 const Example = () => (
-  <div style={{ minWidth: 500 }}>
-    <Table>
+  <div style={{ overflow: 'auto' }}>
+    <Table style={{ minWidth: 500 }}>
       <Caption>
         <XL>Garden details</XL>
       </Caption>

--- a/src/examples/table/TableDefault.tsx
+++ b/src/examples/table/TableDefault.tsx
@@ -9,7 +9,7 @@ import React from 'react';
 import { Body, Cell, Head, HeaderCell, HeaderRow, Row, Table } from '@zendeskgarden/react-tables';
 
 const Example = () => (
-  <div style={{ overflow: 'auto' }}>
+  <div style={{ overflowX: 'auto' }}>
     <Table style={{ minWidth: 500 }}>
       <Head>
         <HeaderRow>

--- a/src/examples/table/TableDefault.tsx
+++ b/src/examples/table/TableDefault.tsx
@@ -9,8 +9,8 @@ import React from 'react';
 import { Body, Cell, Head, HeaderCell, HeaderRow, Row, Table } from '@zendeskgarden/react-tables';
 
 const Example = () => (
-  <div style={{ minWidth: 500 }}>
-    <Table>
+  <div style={{ overflow: 'auto' }}>
+    <Table style={{ minWidth: 500 }}>
       <Head>
         <HeaderRow>
           <HeaderCell>Fruit</HeaderCell>

--- a/src/examples/table/TableGroupedRows.tsx
+++ b/src/examples/table/TableGroupedRows.tsx
@@ -18,8 +18,8 @@ import {
 } from '@zendeskgarden/react-tables';
 
 const Example = () => (
-  <div style={{ minWidth: 500 }}>
-    <Table>
+  <div style={{ overflow: 'auto' }}>
+    <Table style={{ minWidth: 500 }}>
       <Head>
         <HeaderRow>
           <HeaderCell>Type</HeaderCell>

--- a/src/examples/table/TableGroupedRows.tsx
+++ b/src/examples/table/TableGroupedRows.tsx
@@ -18,7 +18,7 @@ import {
 } from '@zendeskgarden/react-tables';
 
 const Example = () => (
-  <div style={{ overflow: 'auto' }}>
+  <div style={{ overflowX: 'auto' }}>
     <Table style={{ minWidth: 500 }}>
       <Head>
         <HeaderRow>

--- a/src/examples/table/TableOverflow.tsx
+++ b/src/examples/table/TableOverflow.tsx
@@ -51,7 +51,7 @@ const OverflowMenu = () => (
 );
 
 const Example = () => (
-  <div style={{ overflow: 'auto' }}>
+  <div style={{ overflowX: 'auto' }}>
     <Table style={{ minWidth: 500 }}>
       <Head>
         <HeaderRow>

--- a/src/examples/table/TableOverflow.tsx
+++ b/src/examples/table/TableOverflow.tsx
@@ -51,8 +51,8 @@ const OverflowMenu = () => (
 );
 
 const Example = () => (
-  <div style={{ minWidth: 500 }}>
-    <Table>
+  <div style={{ overflow: 'auto' }}>
+    <Table style={{ minWidth: 500 }}>
       <Head>
         <HeaderRow>
           <HeaderCell>Fruit</HeaderCell>

--- a/src/examples/table/TablePagination.tsx
+++ b/src/examples/table/TablePagination.tsx
@@ -40,7 +40,7 @@ const Example = () => {
   const [currentPage, setCurrentPage] = useState(1);
 
   return (
-    <div style={{ overflow: 'auto' }}>
+    <div style={{ overflowX: 'auto' }}>
       <StyledTable>
         <Head>
           <HeaderRow>

--- a/src/examples/table/TablePagination.tsx
+++ b/src/examples/table/TablePagination.tsx
@@ -12,6 +12,7 @@ import { Pagination } from '@zendeskgarden/react-pagination';
 
 const StyledTable = styled(Table)`
   margin-bottom: ${p => p.theme.space.md};
+  min-width: 500px;
 `;
 
 interface IRow {
@@ -39,7 +40,7 @@ const Example = () => {
   const [currentPage, setCurrentPage] = useState(1);
 
   return (
-    <div style={{ minWidth: 500 }}>
+    <div style={{ overflow: 'auto' }}>
       <StyledTable>
         <Head>
           <HeaderRow>

--- a/src/examples/table/TableScroll.tsx
+++ b/src/examples/table/TableScroll.tsx
@@ -23,8 +23,8 @@ const rowData: IRow[] = Array.from(Array(100)).map((row, index) => ({
 }));
 
 const Example = () => (
-  <div style={{ minWidth: 500 }}>
-    <Table>
+  <div style={{ overflow: 'auto' }}>
+    <Table style={{ minWidth: 500 }}>
       <Head>
         <HeaderRow>
           <HeaderCell>Fruit</HeaderCell>

--- a/src/examples/table/TableScroll.tsx
+++ b/src/examples/table/TableScroll.tsx
@@ -23,7 +23,7 @@ const rowData: IRow[] = Array.from(Array(100)).map((row, index) => ({
 }));
 
 const Example = () => (
-  <div style={{ overflow: 'auto' }}>
+  <div style={{ overflowX: 'auto' }}>
     <Table style={{ minWidth: 500 }}>
       <Head>
         <HeaderRow>

--- a/src/examples/table/TableSelectRows.tsx
+++ b/src/examples/table/TableSelectRows.tsx
@@ -46,8 +46,8 @@ const Example = () => {
   const [focusedRowIndex, setFocusedRowIndex] = useState<number | undefined>(undefined);
 
   return (
-    <div style={{ minWidth: 500 }}>
-      <Table>
+    <div style={{ overflow: 'auto' }}>
+      <Table style={{ minWidth: 500 }}>
         <Head>
           <HeaderRow>
             <HeaderCell isMinimum>

--- a/src/examples/table/TableSelectRows.tsx
+++ b/src/examples/table/TableSelectRows.tsx
@@ -46,7 +46,7 @@ const Example = () => {
   const [focusedRowIndex, setFocusedRowIndex] = useState<number | undefined>(undefined);
 
   return (
-    <div style={{ overflow: 'auto' }}>
+    <div style={{ overflowX: 'auto' }}>
       <Table style={{ minWidth: 500 }}>
         <Head>
           <HeaderRow>

--- a/src/examples/table/TableSize.tsx
+++ b/src/examples/table/TableSize.tsx
@@ -25,7 +25,7 @@ const StyledContainer = styled.div`
 `;
 
 const Example = () => (
-  <div style={{ overflow: 'auto' }}>
+  <div style={{ overflowX: 'auto' }}>
     <StyledContainer>
       <Table size="small">
         <Caption>

--- a/src/examples/table/TableSize.tsx
+++ b/src/examples/table/TableSize.tsx
@@ -21,10 +21,11 @@ import { LG } from '@zendeskgarden/react-typography';
 
 const StyledContainer = styled.div`
   margin-bottom: ${p => p.theme.space.xl};
+  min-width: 500px;
 `;
 
 const Example = () => (
-  <div style={{ minWidth: 500 }}>
+  <div style={{ overflow: 'auto' }}>
     <StyledContainer>
       <Table size="small">
         <Caption>

--- a/src/examples/table/TableSort.tsx
+++ b/src/examples/table/TableSort.tsx
@@ -69,8 +69,8 @@ const Example = () => {
   const [typeSort, setTypeSort] = useState<Direction>();
 
   return (
-    <div style={{ minWidth: 500 }}>
-      <Table>
+    <div style={{ overflow: 'auto' }}>
+      <Table style={{ minWidth: 500 }}>
         <Head>
           <HeaderRow>
             <HeaderCell>Subject</HeaderCell>

--- a/src/examples/table/TableSort.tsx
+++ b/src/examples/table/TableSort.tsx
@@ -69,7 +69,7 @@ const Example = () => {
   const [typeSort, setTypeSort] = useState<Direction>();
 
   return (
-    <div style={{ overflow: 'auto' }}>
+    <div style={{ overflowX: 'auto' }}>
       <Table style={{ minWidth: 500 }}>
         <Head>
           <HeaderRow>

--- a/src/examples/table/TableStripedRows.tsx
+++ b/src/examples/table/TableStripedRows.tsx
@@ -23,8 +23,8 @@ const rowData: IRow[] = Array.from(Array(10)).map((row, index) => ({
 }));
 
 const Example = () => (
-  <div style={{ minWidth: 500 }}>
-    <Table>
+  <div style={{ overflow: 'auto' }}>
+    <Table style={{ minWidth: 500 }}>
       <Head>
         <HeaderRow>
           <HeaderCell>Fruit</HeaderCell>

--- a/src/examples/table/TableStripedRows.tsx
+++ b/src/examples/table/TableStripedRows.tsx
@@ -23,7 +23,7 @@ const rowData: IRow[] = Array.from(Array(10)).map((row, index) => ({
 }));
 
 const Example = () => (
-  <div style={{ overflow: 'auto' }}>
+  <div style={{ overflowX: 'auto' }}>
     <Table style={{ minWidth: 500 }}>
       <Head>
         <HeaderRow>

--- a/src/examples/table/TableTruncate.tsx
+++ b/src/examples/table/TableTruncate.tsx
@@ -12,8 +12,8 @@ const content = `Lorem ipsum dolor sit amet, consectetur adipiscing elit,
 sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.`;
 
 const Example = () => (
-  <div style={{ minWidth: 500 }}>
-    <Table>
+  <div style={{ overflow: 'auto' }}>
+    <Table style={{ minWidth: 500 }}>
       <Head>
         <HeaderRow>
           <HeaderCell>Wrapping content</HeaderCell>

--- a/src/examples/table/TableTruncate.tsx
+++ b/src/examples/table/TableTruncate.tsx
@@ -12,7 +12,7 @@ const content = `Lorem ipsum dolor sit amet, consectetur adipiscing elit,
 sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.`;
 
 const Example = () => (
-  <div style={{ overflow: 'auto' }}>
+  <div style={{ overflowX: 'auto' }}>
     <Table style={{ minWidth: 500 }}>
       <Head>
         <HeaderRow>


### PR DESCRIPTION
<!-- structure the Title above as the first line of a
  https://conventionalcommits.org/ message. example: "chore:
  add a new 'thing' component page". -->

## Description

The `overflow: auto` styling added to the component example wrapper in the latest Table PR brought with it some undesirable behavior on other examples. This PR addresses that problems and handles the overflow behavior for the Tables in the Table example code instead. 

## Detail

<!-- supporting details; screen shot, code, etc. -->

<!-- closes GITHUB_ISSUE -->

## Checklist

- [ ] :ok_hand: website updates are Garden Designer approved (add the designer as a reviewer)
- [ ] :black_nib: copy updates are approved (add the content strategist as a reviewer)
- [ ] :link: considered opportunities for adding cross-reference URLs (grep for keywords)
- [ ] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [ ] :zap: audited via [web.dev](https://web.dev/measure/) for performance and SEO
- [ ] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
