### PR TITLE
fix(build): pin default Gatsby CPU count

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,6 +25,8 @@ references:
 jobs:
   build:
     <<: *executor
+    environment:
+      GATSBY_CPU_COUNT: 2
     steps:
       - checkout
       - restore_cache:


### PR DESCRIPTION
## Description

With us experiencing more frequent build failures in CircleCI, it appears that adjusting the [multi-core settings](https://www.gatsbyjs.com/docs/multi-core-builds/) helps us reliably build.

It looks like CircleCI is hyper-threading with a logical CPU count of `36`. This is causing the terser webpack plugin to run out of memory intermittently. By pinning the `GATSBY_CPU_COUNT` environment variable to match the physical cores (2) of the container this should help us going forward.

## Detail

I'm going to run this build a few times to make sure that it is passing consistently.

## Checklist

- [ ] ~:ok_hand: website updates are Garden Designer approved (add the designer as a reviewer)~
- [ ] ~:black_nib: copy updates are approved (add the content strategist as a reviewer)~
- [ ] ~:link: considered opportunities for adding cross-reference URLs (grep for keywords)~
- [ ] ~:wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver~
- [ ] ~:zap: audited via [web.dev](https://web.dev/measure/) for performance and SEO~
- [ ] ~:memo: tested in Chrome, Firefox, Safari, Edge, and IE11~
