### PR TITLE
fix: allow overflow in code example

### DIFF
--- a/src/components/MarkdownProvider/components/CodeExample/index.tsx
+++ b/src/components/MarkdownProvider/components/CodeExample/index.tsx
@@ -6,6 +6,7 @@
  */
 
 import React, { useRef, useState, useMemo } from 'react';
+import { math } from 'polished';
 import styled, { css, DefaultTheme } from 'styled-components';
 import { ThemeProvider, DEFAULT_THEME, getColor } from '@zendeskgarden/react-theming';
 import { Tooltip } from '@zendeskgarden/react-tooltips';
@@ -19,8 +20,8 @@ import { retrieveCodesandboxParameters } from './utils/retrieveCodesandboxParame
 import { copyToClipboard } from './utils/copyToClipboard';
 
 const StyledCodeBlock = styled(CodeBlock)`
-  border-bottom-left-radius: ${props => props.theme.space.base}px;
-  border-bottom-right-radius: ${props => props.theme.space.base}px;
+  border-bottom-left-radius: ${props => math(`${props.theme.borderRadii.md} - 1px`)};
+  border-bottom-right-radius: ${props => math(`${props.theme.borderRadii.md} - 1px`)};
 `;
 
 export const CodeExample: React.FC<{ code: string }> = ({ children, code }) => {

--- a/src/components/MarkdownProvider/components/CodeExample/index.tsx
+++ b/src/components/MarkdownProvider/components/CodeExample/index.tsx
@@ -6,7 +6,7 @@
  */
 
 import React, { useRef, useState, useMemo } from 'react';
-import { css, DefaultTheme } from 'styled-components';
+import styled, { css, DefaultTheme } from 'styled-components';
 import { ThemeProvider, DEFAULT_THEME, getColor } from '@zendeskgarden/react-theming';
 import { Tooltip } from '@zendeskgarden/react-tooltips';
 import { CodeBlock } from '@zendeskgarden/react-typography';
@@ -17,6 +17,11 @@ import { ReactComponent as DirectionRtlStroke } from '@zendeskgarden/svg-icons/s
 import { ReactComponent as CodeSandboxIcon } from './assets/codesandbox-icon.svg';
 import { retrieveCodesandboxParameters } from './utils/retrieveCodesandboxParameters';
 import { copyToClipboard } from './utils/copyToClipboard';
+
+const StyledCodeBlock = styled(CodeBlock)`
+  border-bottom-left-radius: ${props => props.theme.space.base}px;
+  border-bottom-right-radius: ${props => props.theme.space.base}px;
+`;
 
 export const CodeExample: React.FC<{ code: string }> = ({ children, code }) => {
   const [isRtl, setIsRtl] = useState(false);
@@ -38,7 +43,6 @@ export const CodeExample: React.FC<{ code: string }> = ({ children, code }) => {
         margin-bottom: ${p => p.theme.space.xl};
         border: ${p => p.theme.borders.sm} ${p => getColor('grey', 300, p.theme)};
         border-radius: ${p => p.theme.borderRadii.md};
-        overflow: hidden;
       `}
     >
       <ThemeProvider theme={exampleTheme} focusVisibleRef={focusVisibleRef}>
@@ -114,7 +118,7 @@ export const CodeExample: React.FC<{ code: string }> = ({ children, code }) => {
           </ToggleIconButton>
         </Tooltip>
       </div>
-      {isCodeVisible && <CodeBlock>{code.replace(COPYRIGHT_REGEXP, '')}</CodeBlock>}
+      {isCodeVisible && <StyledCodeBlock>{code.replace(COPYRIGHT_REGEXP, '')}</StyledCodeBlock>}
     </div>
   );
 };


### PR DESCRIPTION
## Description

This PR proposes to allow overflow for code examples which would allow `SplitButton` to overflow rather than to be clipped.

## Detail

It looks like originally `overflow: hidden;` was applied to `CodeExample` to prevent code block from overflowing rounded container borders. To address both the `SplitButton` and the original rounded border overflow issue, I've removed `overflow: hidden;` and applied rounded borders to the `CodeBlock` component.

## Screenshots

**Before:** overflowed menus were clipped
<img src="https://user-images.githubusercontent.com/1811365/95621295-4f46b100-0a26-11eb-9009-e52ad6c0cf79.gif" data-canonical-src="https://user-images.githubusercontent.com/1811365/95621295-4f46b100-0a26-11eb-9009-e52ad6c0cf79.gif" height="600" />

--------

**After:** overflowed menus are no longer clipped
<img src="https://user-images.githubusercontent.com/1811365/95621280-48b83980-0a26-11eb-8598-c9708338254b.gif" data-canonical-src="https://user-images.githubusercontent.com/1811365/95621280-48b83980-0a26-11eb-8598-c9708338254b.gif" height="600" />

<!-- supporting details; screen shot, code, etc. -->

<!-- closes GITHUB_ISSUE -->

## Checklist

- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
