### PR TITLE
feat(content): add empty state to period standard

### DIFF
--- a/src/pages/content/punctuation.mdx
+++ b/src/pages/content/punctuation.mdx
@@ -69,6 +69,7 @@ periods.
 | Bullets (in a list)      | No. Bullets should be sentence fragments. If a bullet has more than one sentence, use closing punctuation on each. If a bullet has more than two sentences, it should be a description instead. |
 | Button                   | No                                                                                                                                                                                              |
 | Description              | Yes, at the end of every full sentence.                                                                                                                                                         |
+| Empty state              | Yes, at the end of every full sentence.                                                                                                                                                         |
 | Headings and subheadings | No                                                                                                                                                                                              |
 | Labels                   | No                                                                                                                                                                                              |
 | System messages          | No, unless it's more than one sentence.                                                                                                                                                         |


### PR DESCRIPTION
## Description

Publishing new standard for empty states and periods in punctuation

## Checklist

- [x] :ok_hand: website updates are Garden Designer approved (add the designer as a reviewer)
- [x] :black_nib: copy updates are approved (add the content strategist as a reviewer)
- [ ] ~:link: considered opportunities for adding cross-reference URLs (grep for keywords)~
- [ ] ~:wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver~
- [ ] ~:zap: audited via [web.dev](https://web.dev/measure/) for performance and SEO~
- [ ] ~:memo: tested in Chrome, Firefox, Safari, Edge, and IE11~
