### PR TITLE
fix(icons): remove example reference

### DIFF
--- a/src/pages/design/icons/installation.mdx
+++ b/src/pages/design/icons/installation.mdx
@@ -17,8 +17,7 @@ View the [zendeskgarden/svg-icons](https://github.com/zendeskgarden/svg-icons) r
 
 Garden SVGs come in two flavors – monochrome and two-tone. The primary fill/stroke will always
 be specified as `currentColor`. This means CSS text color style will cascade to the icon. Two-tone
-icons can receive a secondary color via the `fill` style property. In the following example,
-the top arrow of the "sort" icon will be blue; the bottom arrow will be red.
+icons can receive a secondary color via the `fill` style property.
 
 Once installed, SVG icons may be accessed in a variety of ways. The following list demonstrates
 several possibilities, however usage will vary depending on the particular needs of your application.


### PR DESCRIPTION
<!-- structure the Title above as the first line of a
  https://conventionalcommits.org/ message. example: "chore:
  add a new 'thing' component page". -->

## Description

As part of the bug bash, it was noted the copy references an example that doesn't exist on the icons page. This removes that reference.

## Detail

<!-- supporting details; screen shot, code, etc. -->

<!-- closes GITHUB_ISSUE -->

## Checklist

- [ ] :ok_hand: website updates are Garden Designer approved (add the designer as a reviewer)
- [ ] :black_nib: copy updates are approved (add the content strategist as a reviewer)
- [ ] :link: considered opportunities for adding cross-reference URLs (grep for keywords)
- [ ] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [ ] :zap: audited via [web.dev](https://web.dev/measure/) for performance and SEO
- [ ] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
