### PR TITLE
fix(content): update tense example

### DIFF
--- a/src/pages/content/grammar.mdx
+++ b/src/pages/content/grammar.mdx
@@ -138,11 +138,22 @@ display both cases at once.
 The present tense is what’s happening now. It’s friendlier and easier to read. Stick to one tense
 per component. Don’t move from past to present tense—we’re not time travelers.
 
-| Tense          | Do this       | Not this              |
-| -------------- | ------------- | --------------------- |
-| Present        | Message sent  | Message has been sent |
-| Simple past    | Chat ended    | Chat has ended        |
-| Simple present | Chat will end | Chat will have ended  |
+<BestPractice>
+  <Do>
+    <ul>
+      <li>Message sent</li>
+      <li>Chat ended</li>
+      <li>Chat will end</li>
+    </ul>
+  </Do>
+  <Dont>
+    <ul>
+      <li>Message has been sent</li>
+      <li>Chat has ended</li>
+      <li>Chat will have ended</li>
+    </ul>
+  </Dont>
+</BestPractice>
 
 import { graphql } from 'gatsby';
 


### PR DESCRIPTION
<!-- structure the Title above as the first line of a
  https://conventionalcommits.org/ message. example: "chore:
  add a new 'thing' component page". -->

## Description

As part of the bug bash, it was noted that the table examples in the "Tense" example of the content section would be better suited in Do this/Not this examples as opposed to a table. This PR proposes that update. 

## Detail

<!-- supporting details; screen shot, code, etc. -->

<!-- closes GITHUB_ISSUE -->

## Checklist

- [ ] :ok_hand: website updates are Garden Designer approved (add the designer as a reviewer)
- [ ] :black_nib: copy updates are approved (add the content strategist as a reviewer)
- [ ] :link: considered opportunities for adding cross-reference URLs (grep for keywords)
- [ ] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [ ] :zap: audited via [web.dev](https://web.dev/measure/) for performance and SEO
- [ ] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
