### PR TITLE
feat: add InputGroup documentation

### DIFF
--- a/src/examples/forms/input-group/ButtonPlacement.tsx
+++ b/src/examples/forms/input-group/ButtonPlacement.tsx
@@ -5,23 +5,62 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import React from 'react';
-import { Field, InputGroup, Input } from '@zendeskgarden/react-forms';
+import React, { useState } from 'react';
+import styled from 'styled-components';
+import { Field, Label, InputGroup, Input } from '@zendeskgarden/react-forms';
 import { Button } from '@zendeskgarden/react-buttons';
 import { Row, Col } from '@zendeskgarden/react-grid';
+import { Dropdown, Trigger, Menu, Item } from '@zendeskgarden/react-dropdowns';
+import { Span } from '@zendeskgarden/react-typography';
+import { ReactComponent as ChevronDownStroke } from '@zendeskgarden/svg-icons/src/16/chevron-down-stroke.svg';
 
-const Example = () => (
-  <Row justifyContent="center">
-    <Col sm={5}>
-      <Field>
-        <InputGroup>
-          <Button focusInset>Plant</Button>
-          <Input defaultValue="Soil" aria-label="Plant description" />
-          <Button focusInset>Copy</Button>
-        </InputGroup>
-      </Field>
-    </Col>
-  </Row>
-);
+/**
+ * The `react-dropdown` package includes a hidden input with the `Trigger` element.
+ * This element must be positioned outside of the `InputGroup`.
+ */
+const StyledInputGroup = styled(InputGroup)`
+  /* stylelint-disable-next-line */
+  & > input[aria-autocomplete='list'] {
+    position: absolute;
+  }
+`;
+
+const StyledSpanIcon = styled(Span.Icon)`
+  margin-left: ${p => p.theme.space.xs};
+`;
+
+const Example = () => {
+  const [selectedItem, setSelectedItem] = useState('Herb');
+
+  return (
+    <Row justifyContent="center">
+      <Col sm={5}>
+        <Field>
+          <Label>Plant name generator</Label>
+          <StyledInputGroup>
+            <Dropdown selectedItem={selectedItem} onSelect={item => setSelectedItem(item)}>
+              <Trigger>
+                <Button focusInset>
+                  <Span>
+                    {selectedItem}
+                    <StyledSpanIcon>
+                      <ChevronDownStroke />
+                    </StyledSpanIcon>
+                  </Span>
+                </Button>
+              </Trigger>
+              <Menu>
+                <Item value="Plant">Plant</Item>
+                <Item value="Herb">Herb</Item>
+                <Item value="Flower">Flower</Item>
+              </Menu>
+            </Dropdown>
+            <Input defaultValue="Bergamot" />
+          </StyledInputGroup>
+        </Field>
+      </Col>
+    </Row>
+  );
+};
 
 export default Example;

--- a/src/examples/forms/input-group/ButtonPlacement.tsx
+++ b/src/examples/forms/input-group/ButtonPlacement.tsx
@@ -1,0 +1,27 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import React from 'react';
+import { Field, InputGroup, Input } from '@zendeskgarden/react-forms';
+import { Button } from '@zendeskgarden/react-buttons';
+import { Row, Col } from '@zendeskgarden/react-grid';
+
+const Example = () => (
+  <Row justifyContent="center">
+    <Col sm={5}>
+      <Field>
+        <InputGroup>
+          <Button focusInset>Plant</Button>
+          <Input defaultValue="Soil" aria-label="Plant description" />
+          <Button focusInset>Copy</Button>
+        </InputGroup>
+      </Field>
+    </Col>
+  </Row>
+);
+
+export default Example;

--- a/src/examples/forms/input-group/ButtonPlacement.tsx
+++ b/src/examples/forms/input-group/ButtonPlacement.tsx
@@ -11,7 +11,6 @@ import { Field, Label, InputGroup, Input } from '@zendeskgarden/react-forms';
 import { Button } from '@zendeskgarden/react-buttons';
 import { Row, Col } from '@zendeskgarden/react-grid';
 import { Dropdown, Trigger, Menu, Item } from '@zendeskgarden/react-dropdowns';
-import { Span } from '@zendeskgarden/react-typography';
 import { ReactComponent as ChevronDownStroke } from '@zendeskgarden/svg-icons/src/16/chevron-down-stroke.svg';
 
 /**
@@ -25,12 +24,9 @@ const StyledInputGroup = styled(InputGroup)`
   }
 `;
 
-const StyledSpanIcon = styled(Span.Icon)`
-  margin-left: ${p => p.theme.space.xs};
-`;
-
 const Example = () => {
   const [selectedItem, setSelectedItem] = useState('Herb');
+  const [isOpen, setIsOpen] = useState(false);
 
   return (
     <Row justifyContent="center">
@@ -38,15 +34,22 @@ const Example = () => {
         <Field>
           <Label>Plant name generator</Label>
           <StyledInputGroup>
-            <Dropdown selectedItem={selectedItem} onSelect={item => setSelectedItem(item)}>
+            <Dropdown
+              isOpen={isOpen}
+              selectedItem={selectedItem}
+              onSelect={item => setSelectedItem(item)}
+              onStateChange={state => {
+                if (state.isOpen !== undefined) {
+                  setIsOpen(state.isOpen);
+                }
+              }}
+            >
               <Trigger>
                 <Button focusInset>
-                  <Span>
-                    {selectedItem}
-                    <StyledSpanIcon>
-                      <ChevronDownStroke />
-                    </StyledSpanIcon>
-                  </Span>
+                  {selectedItem}
+                  <Button.EndIcon isRotated={isOpen}>
+                    <ChevronDownStroke />
+                  </Button.EndIcon>
                 </Button>
               </Trigger>
               <Menu>

--- a/src/examples/forms/input-group/Disabled.tsx
+++ b/src/examples/forms/input-group/Disabled.tsx
@@ -14,10 +14,10 @@ const Example = () => (
   <Row justifyContent="center">
     <Col sm={5}>
       <Field>
-        <Label>Plant</Label>
+        <Label>Plant name generator</Label>
         <InputGroup>
-          <Input value="Soil" disabled />
-          <Button disabled>Copy</Button>
+          <Input value="Sheepberry" disabled />
+          <Button disabled>Germinate</Button>
         </InputGroup>
       </Field>
     </Col>

--- a/src/examples/forms/input-group/Disabled.tsx
+++ b/src/examples/forms/input-group/Disabled.tsx
@@ -1,0 +1,27 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import React from 'react';
+import { Field, Label, InputGroup, Input } from '@zendeskgarden/react-forms';
+import { Button } from '@zendeskgarden/react-buttons';
+import { Row, Col } from '@zendeskgarden/react-grid';
+
+const Example = () => (
+  <Row justifyContent="center">
+    <Col sm={5}>
+      <Field>
+        <Label>Plant</Label>
+        <InputGroup>
+          <Input value="Soil" disabled />
+          <Button disabled>Copy</Button>
+        </InputGroup>
+      </Field>
+    </Col>
+  </Row>
+);
+
+export default Example;

--- a/src/examples/forms/input-group/InputGroup.tsx
+++ b/src/examples/forms/input-group/InputGroup.tsx
@@ -14,10 +14,10 @@ const Example = () => (
   <Row justifyContent="center">
     <Col sm={5}>
       <Field>
-        <Label>Plant</Label>
+        <Label>Plant name generator</Label>
         <InputGroup>
-          <Input defaultValue="Soil" />
-          <Button focusInset>Copy</Button>
+          <Input defaultValue="Sheepberry" />
+          <Button focusInset>Germinate</Button>
         </InputGroup>
       </Field>
     </Col>

--- a/src/examples/forms/input-group/InputGroup.tsx
+++ b/src/examples/forms/input-group/InputGroup.tsx
@@ -1,0 +1,27 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import React from 'react';
+import { Field, Label, InputGroup, Input } from '@zendeskgarden/react-forms';
+import { Button } from '@zendeskgarden/react-buttons';
+import { Row, Col } from '@zendeskgarden/react-grid';
+
+const Example = () => (
+  <Row justifyContent="center">
+    <Col sm={5}>
+      <Field>
+        <Label>Plant</Label>
+        <InputGroup>
+          <Input defaultValue="Soil" />
+          <Button focusInset>Copy</Button>
+        </InputGroup>
+      </Field>
+    </Col>
+  </Row>
+);
+
+export default Example;

--- a/src/examples/forms/input-group/Readonly.tsx
+++ b/src/examples/forms/input-group/Readonly.tsx
@@ -1,0 +1,27 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import React from 'react';
+import { Field, Label, InputGroup, Input } from '@zendeskgarden/react-forms';
+import { Button } from '@zendeskgarden/react-buttons';
+import { Row, Col } from '@zendeskgarden/react-grid';
+
+const Example = () => (
+  <Row justifyContent="center">
+    <Col sm={5}>
+      <Field>
+        <Label>Plant</Label>
+        <InputGroup>
+          <Input value="Soil" readOnly />
+          <Button focusInset>Copy</Button>
+        </InputGroup>
+      </Field>
+    </Col>
+  </Row>
+);
+
+export default Example;

--- a/src/examples/forms/input-group/Readonly.tsx
+++ b/src/examples/forms/input-group/Readonly.tsx
@@ -14,9 +14,9 @@ const Example = () => (
   <Row justifyContent="center">
     <Col sm={5}>
       <Field>
-        <Label>Plant</Label>
+        <Label>Invoice number</Label>
         <InputGroup>
-          <Input value="Soil" readOnly />
+          <Input value="GDN10136H74NK-0011" readOnly />
           <Button focusInset>Copy</Button>
         </InputGroup>
       </Field>

--- a/src/examples/forms/input-group/Size.tsx
+++ b/src/examples/forms/input-group/Size.tsx
@@ -22,20 +22,20 @@ const Example = () => (
   <Row justifyContent="center">
     <Col sm={5}>
       <Field>
-        <Label>Default</Label>
+        <Label>Plant name generator</Label>
         <InputGroup>
-          <Input />
-          <Button focusInset>Copy</Button>
+          <Input defaultValue="Sheepberry" />
+          <Button focusInset>Germinate</Button>
         </InputGroup>
       </Field>
     </Col>
     <StyledCol sm={5}>
       <Field>
-        <Label>Compact</Label>
+        <Label>Plant name generator</Label>
         <InputGroup isCompact>
-          <Input isCompact />
+          <Input isCompact defaultValue="Sheepberry" />
           <Button size="small" focusInset>
-            Copy
+            Germinate
           </Button>
         </InputGroup>
       </Field>

--- a/src/examples/forms/input-group/Size.tsx
+++ b/src/examples/forms/input-group/Size.tsx
@@ -1,0 +1,54 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import React, { useCallback, useState } from 'react';
+import styled from 'styled-components';
+import { Row, Col } from '@zendeskgarden/react-grid';
+import { mediaQuery } from '@zendeskgarden/react-theming';
+import { Field, Label, Input, InputGroup } from '@zendeskgarden/react-forms';
+import { Button } from '@zendeskgarden/react-buttons';
+
+const StyledCol = styled(Col)`
+  ${p => mediaQuery('down', 'xs', p.theme)} {
+    margin-top: ${p => p.theme.space.sm};
+  }
+`;
+
+const Example = () => {
+  const [value, setValue] = useState('Soil');
+
+  const onChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+    setValue(e.target.value);
+  }, []);
+
+  return (
+    <Row justifyContent="center">
+      <Col sm={5}>
+        <Field>
+          <Label>Default</Label>
+          <InputGroup>
+            <Input value={value} onChange={onChange} />
+            <Button focusInset>Copy</Button>
+          </InputGroup>
+        </Field>
+      </Col>
+      <StyledCol sm={5}>
+        <Field>
+          <Label>Compact</Label>
+          <InputGroup isCompact>
+            <Input isCompact value={value} onChange={onChange} />
+            <Button size="small" focusInset>
+              Copy
+            </Button>
+          </InputGroup>
+        </Field>
+      </StyledCol>
+    </Row>
+  );
+};
+
+export default Example;

--- a/src/examples/forms/input-group/Size.tsx
+++ b/src/examples/forms/input-group/Size.tsx
@@ -5,7 +5,7 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import React, { useCallback, useState } from 'react';
+import React from 'react';
 import styled from 'styled-components';
 import { Row, Col } from '@zendeskgarden/react-grid';
 import { mediaQuery } from '@zendeskgarden/react-theming';
@@ -18,37 +18,29 @@ const StyledCol = styled(Col)`
   }
 `;
 
-const Example = () => {
-  const [value, setValue] = useState('Soil');
-
-  const onChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
-    setValue(e.target.value);
-  }, []);
-
-  return (
-    <Row justifyContent="center">
-      <Col sm={5}>
-        <Field>
-          <Label>Default</Label>
-          <InputGroup>
-            <Input value={value} onChange={onChange} />
-            <Button focusInset>Copy</Button>
-          </InputGroup>
-        </Field>
-      </Col>
-      <StyledCol sm={5}>
-        <Field>
-          <Label>Compact</Label>
-          <InputGroup isCompact>
-            <Input isCompact value={value} onChange={onChange} />
-            <Button size="small" focusInset>
-              Copy
-            </Button>
-          </InputGroup>
-        </Field>
-      </StyledCol>
-    </Row>
-  );
-};
+const Example = () => (
+  <Row justifyContent="center">
+    <Col sm={5}>
+      <Field>
+        <Label>Default</Label>
+        <InputGroup>
+          <Input />
+          <Button focusInset>Copy</Button>
+        </InputGroup>
+      </Field>
+    </Col>
+    <StyledCol sm={5}>
+      <Field>
+        <Label>Compact</Label>
+        <InputGroup isCompact>
+          <Input isCompact />
+          <Button size="small" focusInset>
+            Copy
+          </Button>
+        </InputGroup>
+      </Field>
+    </StyledCol>
+  </Row>
+);
 
 export default Example;

--- a/src/nav/components.yml
+++ b/src/nav/components.yml
@@ -60,6 +60,8 @@
           title: Checkbox
         - id: /components/input
           title: Input
+        - id: /components/input-group
+          title: Input group
         - id: /components/multi-thumb-range
           title: Multi-thumb range
         - id: /components/radio

--- a/src/pages/components/input-group.mdx
+++ b/src/pages/components/input-group.mdx
@@ -1,8 +1,8 @@
 ---
 title: Input group
 description: >
-  An Input group is a field with buttons on either side. This allows users to
-  better understand or take action on entered information.
+  An Input group combines two components, a Button and an Input,
+  to let users take quick action on entered information.
 package: '@zendeskgarden/react-forms'
 components:
   - forms/src/elements/input-group/InputGroup.tsx
@@ -11,16 +11,16 @@ components:
 <Usage>
   <Use>
     <ul>
-      <li>To take action on specific data in a field (for example, country code selection)</li>
-      <li>To copy data inside a field</li>
+      <li>To let users select data in a field</li>
+      <li>To let users copy data in a field</li>
     </ul>
   </Use>
   <Misuse>
     <ul>
       <li>
         <Markdown>
-          For form submission, use separate [Inputs](/components/input) and
-          [Buttons](/components/button) instead
+          To submit a form, separate your [Buttons](/components/button) from your
+          [Inputs](/components/input).
         </Markdown>
       </li>
     </ul>
@@ -42,7 +42,7 @@ import InputGroupCode from '!!raw-loader!../../examples/forms/input-group/InputG
 
 ### Read-only
 
-Field content can be read-only.
+Field content can be made read-only.
 
 import Readonly from '../../examples/forms/input-group/Readonly.tsx';
 import ReadonlyCode from '!!raw-loader!../../examples/forms/input-group/Readonly.tsx';
@@ -64,7 +64,7 @@ import DisabledCode from '!!raw-loader!../../examples/forms/input-group/Disabled
 
 ### Size
 
-Input group comes in two sizes: regular (default) and compact.
+Input group comes in two sizes: default and compact.
 
 import Size from '../../examples/forms/input-group/Size.tsx';
 import SizeCode from '!!raw-loader!../../examples/forms/input-group/Size.tsx';

--- a/src/pages/components/input-group.mdx
+++ b/src/pages/components/input-group.mdx
@@ -1,7 +1,7 @@
 ---
-title: Input Group
+title: Input group
 description: >
-  An Input Group is a field with buttons on either side. This allows users to
+  An Input group is a field with buttons on either side. This allows users to
   better understand or take action on entered information.
 package: '@zendeskgarden/react-forms'
 components:
@@ -31,7 +31,7 @@ components:
 
 ### Default
 
-The basic usage of an Input Group component.
+The basic usage of an Input group component.
 
 import InputGroup from '../../examples/forms/input-group/InputGroup.tsx';
 import InputGroupCode from '!!raw-loader!../../examples/forms/input-group/InputGroup.tsx';
@@ -53,7 +53,7 @@ import ReadonlyCode from '!!raw-loader!../../examples/forms/input-group/Readonly
 
 ### Disabled
 
-A disabled Input Group prevents user interaction.
+A disabled Input group prevents user interaction.
 
 import Disabled from '../../examples/forms/input-group/Disabled.tsx';
 import DisabledCode from '!!raw-loader!../../examples/forms/input-group/Disabled.tsx';
@@ -64,7 +64,7 @@ import DisabledCode from '!!raw-loader!../../examples/forms/input-group/Disabled
 
 ### Size
 
-Input Group comes in two sizes: regular (default) and compact.
+Input group comes in two sizes: regular (default) and compact.
 
 import Size from '../../examples/forms/input-group/Size.tsx';
 import SizeCode from '!!raw-loader!../../examples/forms/input-group/Size.tsx';

--- a/src/pages/components/input-group.mdx
+++ b/src/pages/components/input-group.mdx
@@ -1,0 +1,103 @@
+---
+title: Input Group
+description: >
+  An Input Group is a field with buttons on either side. This allows users to
+  better understand or take action on entered information.
+package: '@zendeskgarden/react-forms'
+components:
+  - forms/src/elements/input-group/InputGroup.tsx
+---
+
+<Usage>
+  <Use>
+    <ul>
+      <li>To take action on specific data in a field (for example, country code selection)</li>
+      <li>To copy data inside a field</li>
+    </ul>
+  </Use>
+  <Misuse>
+    <ul>
+      <li>
+        <Markdown>
+          For form submission, use separate [Inputs](/components/input) and
+          [Buttons](/components/button) instead
+        </Markdown>
+      </li>
+    </ul>
+  </Misuse>
+</Usage>
+
+## How to use it
+
+### Default
+
+The basic usage of an Input Group component.
+
+import InputGroup from '../../examples/forms/input-group/InputGroup.tsx';
+import InputGroupCode from '!!raw-loader!../../examples/forms/input-group/InputGroup.tsx';
+
+<CodeExample code={InputGroupCode}>
+  <InputGroup />
+</CodeExample>
+
+### Read-only
+
+Field content can be read-only.
+
+import Readonly from '../../examples/forms/input-group/Readonly.tsx';
+import ReadonlyCode from '!!raw-loader!../../examples/forms/input-group/Readonly.tsx';
+
+<CodeExample code={ReadonlyCode}>
+  <Readonly />
+</CodeExample>
+
+### Disabled
+
+A disabled Input Group prevents user interaction.
+
+import Disabled from '../../examples/forms/input-group/Disabled.tsx';
+import DisabledCode from '!!raw-loader!../../examples/forms/input-group/Disabled.tsx';
+
+<CodeExample code={DisabledCode}>
+  <Disabled />
+</CodeExample>
+
+### Size
+
+Input Group comes in two sizes: regular (default) and compact.
+
+import Size from '../../examples/forms/input-group/Size.tsx';
+import SizeCode from '!!raw-loader!../../examples/forms/input-group/Size.tsx';
+
+<CodeExample code={SizeCode}>
+  <Size />
+</CodeExample>
+
+### Button placement
+
+Buttons can be placed before or after the input.
+
+import ButtonPlacement from '../../examples/forms/input-group/ButtonPlacement.tsx';
+import ButtonPlacementCode from '!!raw-loader!../../examples/forms/input-group/ButtonPlacement.tsx';
+
+<CodeExample code={ButtonPlacementCode}>
+  <ButtonPlacement />
+</CodeExample>
+
+## Configuration
+
+<Configuration reactPackage={props.data.mdx.package} components={props.data.mdx.components} />
+
+## API
+
+### InputGroup
+
+<PropSheet components={props.data.mdx.components} componentName="InputGroup" />
+
+import { graphql } from 'gatsby';
+
+export const pageQuery = graphql`
+  query($fileAbsolutePath: String) {
+    ...SidebarPageFragment
+  }
+`;


### PR DESCRIPTION
## Description

This PR introduces the documentation for the [InputGroup](https://zendeskgarden.github.io/react-components/forms/#input-group) component.

## Checklist

- [x] :ok_hand: website updates are Garden Designer approved (add the designer as a reviewer)
- [x] :black_nib: copy updates are approved (add the content strategist as a reviewer)
- [x] :link: considered opportunities for adding cross-reference URLs (grep for keywords)
- [x] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [x] :zap: audited via [web.dev](https://web.dev/measure/) for performance and SEO
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
