### PR TITLE
feat(typography): add code-block component page

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -19,5 +19,4 @@
 - [ ] :black_nib: copy updates are approved (add the content strategist as a reviewer)
 - [ ] :link: considered opportunities for adding cross-reference URLs (grep for keywords)
 - [ ] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
-- [ ] :zap: audited via [web.dev](https://web.dev/measure/) for performance and SEO
 - [ ] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11

--- a/src/examples/typography/code-block/Default.tsx
+++ b/src/examples/typography/code-block/Default.tsx
@@ -1,0 +1,33 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import React from 'react';
+import { CodeBlock } from '@zendeskgarden/react-typography';
+
+const Example = () => (
+  <CodeBlock>{`
+/**
+ * Copy the given value to the clipboard.
+ *
+ * @param {string} value The value to copy
+ */
+const copy = (value: string) => {
+  const element = document.createElement('textarea');
+
+  element.readOnly = true;
+  element.style.position = 'absolute';
+  element.style.left = '-9999px';
+  document.body.appendChild(element);
+  element.value = value;
+  element.select();
+  document.execCommand('copy');
+  element.remove();
+};
+  `}</CodeBlock>
+);
+
+export default Example;

--- a/src/examples/typography/code-block/Language.tsx
+++ b/src/examples/typography/code-block/Language.tsx
@@ -1,0 +1,28 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import React from 'react';
+import { CodeBlock } from '@zendeskgarden/react-typography';
+
+const Example = () => (
+  <CodeBlock language="css">{`
+/* CSS utility for making hidden content accessible to screen readers */
+.sr-only {
+  position: absolute;
+  margin: -1px;
+  border-width: 0;
+  clip: rect(0, 0, 0, 0);
+  padding: 0;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  white-space: nowrap;
+}
+  `}</CodeBlock>
+);
+
+export default Example;

--- a/src/examples/typography/code-block/Light.tsx
+++ b/src/examples/typography/code-block/Light.tsx
@@ -1,0 +1,33 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import React from 'react';
+import { CodeBlock } from '@zendeskgarden/react-typography';
+
+const Example = () => (
+  <CodeBlock isLight>{`
+/**
+ * Copy the given value to the clipboard.
+ *
+ * @param {string} value The value to copy
+ */
+const copy = (value: string) => {
+  const element = document.createElement('textarea');
+
+  element.readOnly = true;
+  element.style.position = 'absolute';
+  element.style.left = '-9999px';
+  document.body.appendChild(element);
+  element.value = value;
+  element.select();
+  document.execCommand('copy');
+  element.remove();
+};
+  `}</CodeBlock>
+);
+
+export default Example;

--- a/src/examples/typography/code-block/Numbered.tsx
+++ b/src/examples/typography/code-block/Numbered.tsx
@@ -1,0 +1,55 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import React from 'react';
+import { CodeBlock } from '@zendeskgarden/react-typography';
+
+const Example = () => (
+  <CodeBlock isNumbered>{`
+import React from 'react';
+import styled from 'styled-components';
+import { Row, Col } from '@zendeskgarden/react-grid';
+import { mediaQuery } from '@zendeskgarden/react-theming';
+import { Field, Label, Input, Message } from '@zendeskgarden/react-forms';
+
+const StyledCol = styled(Col)\`
+  \${p => mediaQuery('down', 'xs', p.theme)} {
+    margin-top: \${p => p.theme.space.sm};
+  }
+\`;
+
+const Example = () => (
+  <Row>
+    <Col sm={4}>
+      <Field>
+        <Label>Plant</Label>
+        <Input validation="success" />
+        <Message validation="success">A cactus is a beautiful plant</Message>
+      </Field>
+    </Col>
+    <StyledCol sm={4}>
+      <Field>
+        <Label>Plant</Label>
+        <Input validation="warning" />
+        <Message validation="warning">A cactus has thorns</Message>
+      </Field>
+    </StyledCol>
+    <StyledCol sm={4}>
+      <Field>
+        <Label>Plant</Label>
+        <Input validation="error" />
+        <Message validation="error">A cactus belongs in the desert</Message>
+      </Field>
+    </StyledCol>
+  </Row>
+);
+
+export default Example;
+`}</CodeBlock>
+);
+
+export default Example;

--- a/src/examples/typography/code-block/Size.tsx
+++ b/src/examples/typography/code-block/Size.tsx
@@ -1,0 +1,37 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import React from 'react';
+import { CodeBlock, Paragraph } from '@zendeskgarden/react-typography';
+
+const Example = () => (
+  <>
+    <Paragraph>
+      <CodeBlock size="small">{`
+const perrenial = '  Daylily (Hemerocallis)  ';
+
+console.log(\`🌱 \${perrenial.trim()} 🌱\`);
+      `}</CodeBlock>
+    </Paragraph>
+    <Paragraph>
+      <CodeBlock size="medium">{`
+const perrenial = '  Daylily (Hemerocallis)  ';
+
+console.log(\`🌱 \${perrenial.trim()} 🌱\`);
+      `}</CodeBlock>
+    </Paragraph>
+    <Paragraph>
+      <CodeBlock size="large">{`
+const perrenial = '  Daylily (Hemerocallis)  ';
+
+console.log(\`🌱 \${perrenial.trim()} 🌱\`);
+      `}</CodeBlock>
+    </Paragraph>
+  </>
+);
+
+export default Example;

--- a/src/nav/components.yml
+++ b/src/nav/components.yml
@@ -112,6 +112,8 @@
       items:
         - title: Code
           id: /components/code
+        - title: Code block
+          id: /components/code-block
         - title: Lists
           id: /components/lists
         - title: Paragraph

--- a/src/pages/components/code-block.mdx
+++ b/src/pages/components/code-block.mdx
@@ -17,7 +17,7 @@ components:
   </Use>
   <Misuse>
     <ul>
-      <li>For editing code. Code snippets are read-only.</li>
+      <li>For editing code</li>
       <li>
         <Markdown>
           For simple, single-line usage, use the [Code](/components/code) component

--- a/src/pages/components/code-block.mdx
+++ b/src/pages/components/code-block.mdx
@@ -64,7 +64,7 @@ import LanguageCode from '!!raw-loader!../../examples/typography/code-block/Lang
 
 ### Line numbers
 
-Code block supports line numbers, improving the ability to reference lines of code.
+Code block supports line numbers. This improves the ability to reference lines of code.
 
 import Numbered from '../../examples/typography/code-block/Numbered.tsx';
 import NumberedCode from '!!raw-loader!../../examples/typography/code-block/Numbered.tsx';

--- a/src/pages/components/code-block.mdx
+++ b/src/pages/components/code-block.mdx
@@ -1,0 +1,103 @@
+---
+title: Code block
+description: >
+  Code block is used to display text with code formatting. It uses syntax
+  highlighting to make code more legible.
+package: '@zendeskgarden/react-typography'
+components:
+  - typography/src/elements/CodeBlock.tsx
+---
+
+<Usage>
+  <Use>
+    <ul>
+      <li>To display read-only text with code formatting</li>
+      <li>To display code snippets for users to copy</li>
+    </ul>
+  </Use>
+  <Misuse>
+    <ul>
+      <li>For editing code. Code snippets are read-only.</li>
+      <li>
+        <Markdown>
+          For simple, single-line usage, use the [Code](/components/code) component
+        </Markdown>
+      </li>
+    </ul>
+  </Misuse>
+</Usage>
+
+## How to use it
+
+### Default
+
+Code block renders code with syntax highlighting.
+
+import Default from '../../examples/typography/code-block/Default.tsx';
+import DefaultCode from '!!raw-loader!../../examples/typography/code-block/Default.tsx';
+
+<CodeExample code={DefaultCode}>
+  <Default />
+</CodeExample>
+
+### Light mode
+
+By default, Code block is dark. Shed some light on it using `isLight`.
+
+import Light from '../../examples/typography/code-block/Light.tsx';
+import LightCode from '!!raw-loader!../../examples/typography/code-block/Light.tsx';
+
+<CodeExample code={LightCode}>
+  <Light />
+</CodeExample>
+
+### Language
+
+Use the `language` prop to determine the syntax highlighting language. Default is `tsx`.
+
+import Language from '../../examples/typography/code-block/Language.tsx';
+import LanguageCode from '!!raw-loader!../../examples/typography/code-block/Language.tsx';
+
+<CodeExample code={LanguageCode}>
+  <Language />
+</CodeExample>
+
+### Line numbers
+
+Code block supports line numbers, improving the ability to reference lines of code.
+
+import Numbered from '../../examples/typography/code-block/Numbered.tsx';
+import NumberedCode from '!!raw-loader!../../examples/typography/code-block/Numbered.tsx';
+
+<CodeExample code={NumberedCode}>
+  <Numbered />
+</CodeExample>
+
+### Size
+
+By default, Code block text is medium-sized, but it can also be small or large.
+
+import Size from '../../examples/typography/code-block/Size.tsx';
+import SizeCode from '!!raw-loader!../../examples/typography/code-block/Size.tsx';
+
+<CodeExample code={SizeCode}>
+  <Size />
+</CodeExample>
+
+## Configuration
+
+<Configuration reactPackage={props.data.mdx.package} components={props.data.mdx.components} />
+
+## API
+
+### CodeBlock
+
+<PropSheet components={props.data.mdx.components} componentName="codeBlock" />
+
+import { graphql } from 'gatsby';
+
+export const pageQuery = graphql`
+  query($fileAbsolutePath: String) {
+    ...SidebarPageFragment
+  }
+`;

--- a/src/pages/components/code-block.mdx
+++ b/src/pages/components/code-block.mdx
@@ -53,7 +53,7 @@ import LightCode from '!!raw-loader!../../examples/typography/code-block/Light.t
 
 ### Language
 
-Use the `language` prop to determine the syntax highlighting language. Default is `tsx`.
+Use the `language` prop to specify the syntax highlighting language. Default is `tsx`.
 
 import Language from '../../examples/typography/code-block/Language.tsx';
 import LanguageCode from '!!raw-loader!../../examples/typography/code-block/Language.tsx';
@@ -64,7 +64,8 @@ import LanguageCode from '!!raw-loader!../../examples/typography/code-block/Lang
 
 ### Line numbers
 
-Code block supports line numbers. This improves the ability to reference lines of code.
+Line numbers make it easier to reference specific lines of code. You can turn
+this on with the `isNumbered` prop.
 
 import Numbered from '../../examples/typography/code-block/Numbered.tsx';
 import NumberedCode from '!!raw-loader!../../examples/typography/code-block/Numbered.tsx';


### PR DESCRIPTION
## Description

Adds a new `Typography / Code block` component page.

## Detail

@steue I winged it on the examples and several copy modifications. Please review with a critical eye.

## Checklist

- [x] :ok_hand: website updates are Garden Designer approved (add the designer as a reviewer)
- [x] :black_nib: copy updates are approved (add the content strategist as a reviewer)
- [x] :link: considered opportunities for adding cross-reference URLs (grep for keywords)
- [x] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [ ] :zap: ~audited via [web.dev](https://web.dev/measure/) for performance and SEO~
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
