### PR TITLE
feat(content): Improve scannability with punctuation symbols in headings

### DIFF
--- a/src/pages/content/punctuation.mdx
+++ b/src/pages/content/punctuation.mdx
@@ -1,16 +1,18 @@
 ---
 title: Punctuation
+description: >
+  How to use punctuation at Zendesk.
 ---
 
-## Ampersand
+## Ampersand (&)
 
 Avoid ampersands in place of “and.” Don’t use “+” unless you’re opening a coffee shop in Portland.
 
-## Apostrophe
+## Apostrophe (&#39;)
 
 Use apostrophes to denote possession. Avoid apostrophes to denote plurals even for initialisms.
 
-## Colon
+## Colon (&#58;)
 
 In general, avoid using colons in product, especially when describing some attribute and its value.
 Use emphasis styling instead to distinguish between these two types of content.
@@ -29,20 +31,20 @@ sentence at the colon. This causes challenges for translation.
   </Dont>
 </BestPractice>
 
-## Comma
+## Comma (,)
 
 Always use the Oxford comma, also known as the serial comma, to precede the final item in a list.
 Don’t use commas in buttons.
 
-## Ellipse
+## Ellipse (...)
 
 Garden creates ellipses automatically when words are truncated. Don’t add them manually to the UI.
 
-## Exclamation point
+## Exclamation point (!)
 
 These are too loud for most of our brand tones. We tend not to use them at all.
 
-## Hyphens and dashes
+## Hyphens and dashes (- – —)
 
 Err on the side of fewer hyphens and dashes. Use en dashes with no spaces to communicate a range.
 Avoid using en or em dashes to communicate a break in your thoughts.
@@ -53,12 +55,12 @@ Avoid using en or em dashes to communicate a break in your thoughts.
   </Do>
 </BestPractice>
 
-## Parentheses
+## Parentheses ()
 
 Use sparingly. Use parentheses to introduce an acronym in product and never put crucial information
 in parentheses.
 
-## Period
+## Period (.)
 
 Use periods to end full sentences in body copy. Consult this handy chart to find out where we use
 periods.
@@ -76,7 +78,7 @@ periods.
 | Title                    | No                                                                                                                                                                                              |
 | Tooltip                  | No, unless it's more than one sentence.                                                                                                                                                         |
 
-## Quotation mark
+## Quotation mark (&ldquo; &rdquo;)
 
 Avoid using quote marks to indicate places and features in the UI. Use bold instead.
 
@@ -91,11 +93,11 @@ Avoid using quote marks to indicate places and features in the UI. Use bold inst
   </Dont>
 </BestPractice>
 
-## Semi-colon
+## Semi-colon (;)
 
 No semi-colons in product; that's the way it has to be.
 
-## Slash
+## Slash (&#47;)
 
 <!-- prettier-ignore -->
 Used when indicating URLs and as a date separator. You can also use slashes to mean “per,” but limit


### PR DESCRIPTION
## Description

This was a request by the localization team. I have added the punctuation symbol to each heading so it's more easily scanned. My initial impulse is to put the symbol in parentheses, but I am open to other design solutions!

## Checklist

- [x] :ok_hand: website updates are Garden Designer approved (add the designer as a reviewer)
- [x] :black_nib: copy updates are approved (add the content strategist as a reviewer)
