### PR TITLE
fix(dropdowns): fix nested menu to highlight correct item

### DIFF
--- a/src/examples/dropdowns/menu/Nested.tsx
+++ b/src/examples/dropdowns/menu/Nested.tsx
@@ -47,12 +47,7 @@ const Example = () => {
 
             if (Object.prototype.hasOwnProperty.call(changes, 'selectedItem')) {
               updatedState.tempSelectedItem = changes.selectedItem;
-
-              if (updatedState.tempSelectedItem === 'flowers') {
-                stateAndHelpers.setHighlightedIndex(1);
-              } else if (updatedState.tempSelectedItem === 'fruits') {
-                stateAndHelpers.setHighlightedIndex(3);
-              }
+              stateAndHelpers.setHighlightedIndex(1);
             }
 
             if (Object.keys(updatedState).length > 0) {


### PR DESCRIPTION
## Description

It looks like the nested menu example has a regression from how it [previously behaved](https://garden-v7.netlify.app/dropdowns/#!/Menu%20usage/7) in the v7 example. The problem is that when a user switches between menus no item is highlighted.

## Detail

The `onStateChange` callback has some incorrect logic which this PR fixes. When navigating between the parent and nested menus, the menu item at index 1 should be highlighted. Also, `'flowers'` is not an item that exists in the example so that has been removed.

## Screenshots

**Before**: The user switches between menus no item is highlighted

<img width="500" src="https://user-images.githubusercontent.com/1811365/97604911-4284ff80-19cb-11eb-8c4a-de9d0940db60.gif" />

--------

**After**: The user switches between menus and the first item (or the previous parent item) is highlighted.

<img width="500" src="https://user-images.githubusercontent.com/1811365/97604901-4022a580-19cb-11eb-8e5b-4a7a27a4f07c.gif" />

## Checklist

- [x] :ok_hand: website updates are Garden Designer approved (add the designer as a reviewer)
- [x] :black_nib: copy updates are approved (add the content strategist as a reviewer)
- [x] :link: considered opportunities for adding cross-reference URLs (grep for keywords)
- [x] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
