### PR TITLE
feat: new FileUpload documentation page

### DIFF
--- a/package.json
+++ b/package.json
@@ -113,6 +113,7 @@
     "react-beautiful-dnd": "13.0.0",
     "react-docgen-typescript": "1.20.5",
     "react-dom": "16.13.1",
+    "react-dropzone": "11.2.3",
     "react-helmet": "6.1.0",
     "react-syntax-highlighter": "13.5.3",
     "react-window": "1.8.5",

--- a/src/components/MarkdownProvider/components/CodeExample/utils/retrieveCodesandboxParameters.ts
+++ b/src/components/MarkdownProvider/components/CodeExample/utils/retrieveCodesandboxParameters.ts
@@ -59,6 +59,7 @@ const packageJson = `
     "react-dom": "latest",
     "styled-components": "latest",
     "lodash.debounce": "latest",
+    "react-dropzone": "latest",
     "react-window": "latest",
     "@zendeskgarden/container-utilities": "^0.5.4",
     "@zendeskgarden/css-bedrock": "^8.x",

--- a/src/examples/forms/file-upload/Disabled.tsx
+++ b/src/examples/forms/file-upload/Disabled.tsx
@@ -1,0 +1,46 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import React from 'react';
+import { useDropzone } from 'react-dropzone';
+import { Field, Label, Hint, Input, FileUpload } from '@zendeskgarden/react-forms';
+import { Row, Col } from '@zendeskgarden/react-grid';
+
+const Example = () => {
+  const onDrop = React.useCallback((acceptedFiles: File[]) => {
+    alert(`${acceptedFiles.length} files accepted for upload`);
+  }, []);
+
+  const { getRootProps, getInputProps, isDragActive } = useDropzone({
+    accept: ['image/jpeg', 'image/png', 'image/gif'],
+    disabled: true,
+    onDrop
+  });
+
+  return (
+    <Row>
+      <Col>
+        <Field>
+          <Label>Upload a photo of your ailing cactus</Label>
+          <Hint>
+            Include the entire plant in your photo. Acceptable formats are JPG, PNG, and GIF.
+          </Hint>
+          <FileUpload {...getRootProps()} isDragging={isDragActive} disabled={true}>
+            {isDragActive ? (
+              <span>Drop files here</span>
+            ) : (
+              <span>Choose a file of drag and drop here</span>
+            )}
+            <Input {...getInputProps()} disabled={true} />
+          </FileUpload>
+        </Field>
+      </Col>
+    </Row>
+  );
+};
+
+export default Example;

--- a/src/examples/forms/file-upload/FileUpload.tsx
+++ b/src/examples/forms/file-upload/FileUpload.tsx
@@ -1,0 +1,45 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import React from 'react';
+import { useDropzone } from 'react-dropzone';
+import { Field, Label, Hint, Input, FileUpload } from '@zendeskgarden/react-forms';
+import { Row, Col } from '@zendeskgarden/react-grid';
+
+const Example = () => {
+  const onDrop = React.useCallback((acceptedFiles: File[]) => {
+    alert(`${acceptedFiles.length} files accepted for upload`);
+  }, []);
+
+  const { getRootProps, getInputProps, isDragActive } = useDropzone({
+    accept: ['image/jpeg', 'image/png', 'image/gif'],
+    onDrop
+  });
+
+  return (
+    <Row>
+      <Col>
+        <Field>
+          <Label>Upload a photo of your ailing cactus</Label>
+          <Hint>
+            Include the entire plant in your photo. Acceptable formats are JPG, PNG, and GIF.
+          </Hint>
+          <FileUpload {...getRootProps()} isDragging={isDragActive}>
+            {isDragActive ? (
+              <span>Drop files here</span>
+            ) : (
+              <span>Choose a file of drag and drop here</span>
+            )}
+            <Input {...getInputProps()} />
+          </FileUpload>
+        </Field>
+      </Col>
+    </Row>
+  );
+};
+
+export default Example;

--- a/src/examples/forms/file-upload/Size.tsx
+++ b/src/examples/forms/file-upload/Size.tsx
@@ -1,0 +1,72 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import React from 'react';
+import styled from 'styled-components';
+import { useDropzone } from 'react-dropzone';
+import { mediaQuery } from '@zendeskgarden/react-theming';
+import { Field, Label, Input, FileUpload } from '@zendeskgarden/react-forms';
+import { Row, Col } from '@zendeskgarden/react-grid';
+
+const StyledCol = styled(Col)`
+  ${p => mediaQuery('down', 'xs', p.theme)} {
+    margin-top: ${p => p.theme.space.sm};
+  }
+`;
+
+const Example = () => {
+  const onDrop = React.useCallback((acceptedFiles: File[]) => {
+    alert(`${acceptedFiles.length} files accepted for upload`);
+  }, []);
+
+  const defaultDropzone = useDropzone({
+    accept: ['image/jpeg', 'image/png', 'image/gif'],
+    onDrop
+  });
+
+  const compactDropzone = useDropzone({
+    accept: ['image/jpeg', 'image/png', 'image/gif'],
+    onDrop
+  });
+
+  return (
+    <Row justifyContent="center">
+      <Col sm={5}>
+        <Field>
+          <Label>Upload a photo of your ailing cactus</Label>
+          <FileUpload {...defaultDropzone.getRootProps()} isDragging={defaultDropzone.isDragActive}>
+            {defaultDropzone.isDragActive ? (
+              <span>Drop files here</span>
+            ) : (
+              <span>Choose a file of drag and drop here</span>
+            )}
+            <Input {...defaultDropzone.getInputProps()} />
+          </FileUpload>
+        </Field>
+      </Col>
+      <StyledCol sm={5}>
+        <Field>
+          <Label>Upload a photo of your ailing cactus</Label>
+          <FileUpload
+            {...compactDropzone.getRootProps()}
+            isDragging={compactDropzone.isDragActive}
+            isCompact
+          >
+            {compactDropzone.isDragActive ? (
+              <span>Drop files here</span>
+            ) : (
+              <span>Choose a file of drag and drop here</span>
+            )}
+            <Input {...compactDropzone.getInputProps()} />
+          </FileUpload>
+        </Field>
+      </StyledCol>
+    </Row>
+  );
+};
+
+export default Example;

--- a/src/nav/components.yml
+++ b/src/nav/components.yml
@@ -62,6 +62,8 @@
           title: Input
         - id: /components/input-group
           title: Input group
+        - id: /components/file-upload
+          title: File upload
         - id: /components/multi-thumb-range
           title: Multi-thumb range
         - id: /components/radio

--- a/src/nav/components.yml
+++ b/src/nav/components.yml
@@ -58,12 +58,12 @@
       items:
         - id: /components/checkbox
           title: Checkbox
+        - id: /components/file-upload
+          title: File upload
         - id: /components/input
           title: Input
         - id: /components/input-group
           title: Input group
-        - id: /components/file-upload
-          title: File upload
         - id: /components/multi-thumb-range
           title: Multi-thumb range
         - id: /components/radio

--- a/src/pages/components/file-upload.mdx
+++ b/src/pages/components/file-upload.mdx
@@ -51,6 +51,18 @@ import SizeCode from '!!raw-loader!../../examples/forms/file-upload/Size.tsx';
   <Size />
 </CodeExample>
 
+## How to use it well
+
+### Put file requirements in hints
+
+<BestPractice>
+  <Do imageSource={props.data.fileUploadRequirements.childFile.childImageSharp.fluid} imageIsSquare>
+    <p>
+      <Markdown>Use `Hint` to describe image requirements and restrictions</Markdown>
+    </p>
+  </Do>
+</BestPractice>
+
 ## Configuration
 
 <Configuration reactPackage={props.data.mdx.package} components={props.data.mdx.components} />
@@ -69,5 +81,16 @@ import { graphql } from 'gatsby';
 export const pageQuery = graphql`
   query($fileAbsolutePath: String) {
     ...SidebarPageFragment
+    fileUploadRequirements: abstractAsset(
+      layerName: { eq: "components-forms-fileupload-file-requirements" }
+    ) {
+      childFile {
+        childImageSharp {
+          fluid(maxHeight: 200) {
+            ...GatsbyImageSharpFluid
+          }
+        }
+      }
+    }
   }
 `;

--- a/src/pages/components/file-upload.mdx
+++ b/src/pages/components/file-upload.mdx
@@ -55,7 +55,7 @@ import SizeCode from '!!raw-loader!../../examples/forms/file-upload/Size.tsx';
 
 <Configuration reactPackage={props.data.mdx.package} components={props.data.mdx.components} />
 
-The `FileUpload` component is a styled <div> which can be used with 3rd-party file upload libraries
+The `FileUpload` component is a styled `div` which can be used with 3rd-party file upload libraries
 like [react-dropzone](https://github.com/react-dropzone/react-dropzone/).
 
 ## API

--- a/src/pages/components/file-upload.mdx
+++ b/src/pages/components/file-upload.mdx
@@ -51,28 +51,16 @@ import SizeCode from '!!raw-loader!../../examples/forms/file-upload/Size.tsx';
   <Size />
 </CodeExample>
 
-## How to use it well
-
-### Put file requirements in hints
-
-<BestPractice>
-  <Do imageSource={props.data.fileUploadRequirements.childFile.childImageSharp.fluid} imageIsSquare>
-    <p>
-      <Markdown>Use `Hint` to describe image requirements and restrictions</Markdown>
-    </p>
-  </Do>
-</BestPractice>
-
 ## Configuration
 
 <Configuration reactPackage={props.data.mdx.package} components={props.data.mdx.components} />
 
-The `FileUpload` component is a styled `div` which can be used with 3rd-party file upload libraries
-like [react-dropzone](https://github.com/react-dropzone/react-dropzone/).
-
 ## API
 
 ### FileUpload
+
+The `FileUpload` component is a styled `div` which can be used with 3rd-party file upload libraries
+like [react-dropzone](https://github.com/react-dropzone/react-dropzone/).
 
 <PropSheet components={props.data.mdx.components} componentName="fileUpload" />
 
@@ -81,16 +69,5 @@ import { graphql } from 'gatsby';
 export const pageQuery = graphql`
   query($fileAbsolutePath: String) {
     ...SidebarPageFragment
-    fileUploadRequirements: abstractAsset(
-      layerName: { eq: "components-forms-fileupload-file-requirements" }
-    ) {
-      childFile {
-        childImageSharp {
-          fluid(maxHeight: 200) {
-            ...GatsbyImageSharpFluid
-          }
-        }
-      }
-    }
   }
 `;

--- a/src/pages/components/file-upload.mdx
+++ b/src/pages/components/file-upload.mdx
@@ -1,0 +1,73 @@
+---
+title: File upload
+description: >
+  File upload lets users select and upload files.
+package: '@zendeskgarden/react-forms'
+components:
+  - forms/src/elements/FileUpload.tsx
+---
+
+<Usage>
+  <Use>
+    <ul>
+      <li>To let users attach a file or image to something else</li>
+      <li>To let users add images to their avatars</li>
+    </ul>
+  </Use>
+</Usage>
+
+## How to use it
+
+### Default
+
+Users drag and drop files on to the target or click to select which files to upload.
+
+import Default from '../../examples/forms/file-upload/FileUpload.tsx';
+import DefaultCode from '!!raw-loader!../../examples/forms/file-upload/FileUpload.tsx';
+
+<CodeExample code={DefaultCode}>
+  <Default />
+</CodeExample>
+
+### Disabled
+
+A disabled File upload prevents user interaction. It doesn’t appear in the tab order and can’t receive focus.
+
+import Disabled from '../../examples/forms/file-upload/Disabled.tsx';
+import DisabledCode from '!!raw-loader!../../examples/forms/file-upload/Disabled.tsx';
+
+<CodeExample code={DisabledCode}>
+  <Disabled />
+</CodeExample>
+
+### Size
+
+File upload can be default or compact. Size affects spacing between the label/description and the touch target.
+
+import Size from '../../examples/forms/file-upload/Size.tsx';
+import SizeCode from '!!raw-loader!../../examples/forms/file-upload/Size.tsx';
+
+<CodeExample code={SizeCode}>
+  <Size />
+</CodeExample>
+
+## Configuration
+
+<Configuration reactPackage={props.data.mdx.package} components={props.data.mdx.components} />
+
+The `FileUpload` component is a styled <div> which can be used with 3rd-party file upload libraries
+like [react-dropzone](https://github.com/react-dropzone/react-dropzone/).
+
+## API
+
+### FileUpload
+
+<PropSheet components={props.data.mdx.components} componentName="fileUpload" />
+
+import { graphql } from 'gatsby';
+
+export const pageQuery = graphql`
+  query($fileAbsolutePath: String) {
+    ...SidebarPageFragment
+  }
+`;

--- a/yarn.lock
+++ b/yarn.lock
@@ -4526,6 +4526,11 @@ atob@^2.1.2:
   resolved "https://registry.yarnpkg.com/atob/-/atob-2.1.2.tgz#6d9517eb9e030d2436666651e86bd9f6f13533c9"
   integrity sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==
 
+attr-accept@^2.2.1:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/attr-accept/-/attr-accept-2.2.2.tgz#646613809660110749e92f2c10833b70968d929b"
+  integrity sha512-7prDjvt9HmqiZ0cl5CRjtS84sEyhsHP2coDkaZKRKVfCDo9s7iw7ChVmar78Gu9pC4SoR/28wFu/G5JJhTnqEg==
+
 author-regex@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/author-regex/-/author-regex-1.0.0.tgz#d08885be6b9bbf9439fe087c76287245f0a81450"
@@ -8789,6 +8794,13 @@ file-name@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/file-name/-/file-name-0.1.0.tgz#12b122f120f9c34dbc176c1ab81a548aced6def7"
   integrity sha1-ErEi8SD5w028F2wauBpUis7W3vc=
+
+file-selector@^0.2.2:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/file-selector/-/file-selector-0.2.2.tgz#76186ac94ea01a18262a1e9ee36a8815911bc0b4"
+  integrity sha512-tMZc0lkFzhOGlZUAkQ5iljPORvDX+nWEI+9C5nj9KT7Ax8bAUUtI/GYM8JFIjyKfKlQkJRC84D0UgxwDqRGvRQ==
+  dependencies:
+    tslib "^2.0.3"
 
 file-type@5.2.0, file-type@^5.2.0:
   version "5.2.0"
@@ -16268,6 +16280,15 @@ react-dom@16.13.1:
     prop-types "^15.6.2"
     scheduler "^0.19.1"
 
+react-dropzone@11.2.3:
+  version "11.2.3"
+  resolved "https://registry.yarnpkg.com/react-dropzone/-/react-dropzone-11.2.3.tgz#8a49e9fc7ab75eaccf748c382a790092c035cef1"
+  integrity sha512-D99BhHm7H1h7ztUH/FLDo4wDy7VzXMbHoS/tUZHtoaY37Y55uadq0kUKqoaJ8PXl+niqdb5t6GankuEaAL6Vwg==
+  dependencies:
+    attr-accept "^2.2.1"
+    file-selector "^0.2.2"
+    prop-types "^15.7.2"
+
 react-error-overlay@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/react-error-overlay/-/react-error-overlay-3.0.0.tgz#c2bc8f4d91f1375b3dad6d75265d51cd5eeaf655"
@@ -19270,6 +19291,11 @@ tslib@^2.0.0, tslib@~2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.0.0.tgz#18d13fc2dce04051e20f074cc8387fd8089ce4f3"
   integrity sha512-lTqkx847PI7xEDYJntxZH89L2/aXInsyF2luSafe/+0fHOMjlBNXdH6th7f70qxLDhul7KZK0zC8V5ZIyHl0/g==
+
+tslib@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.0.3.tgz#8e0741ac45fc0c226e58a17bfc3e64b9bc6ca61c"
+  integrity sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ==
 
 tsutils@^3.17.1:
   version "3.17.1"


### PR DESCRIPTION
## Description

This PR adds the documentation for the `FileUpload` component. The DO/DONT layer isn't merged into abstract yet, but that will be added once available.

## Checklist

- [x] :ok_hand: website updates are Garden Designer approved (add the designer as a reviewer)
- [x] :black_nib: copy updates are approved (add the content strategist as a reviewer)
- [x] :link: considered opportunities for adding cross-reference URLs (grep for keywords)
- [x] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
