### PR TITLE
chore: best practice styles

### DIFF
--- a/src/components/MarkdownProvider/components/BestPractice.tsx
+++ b/src/components/MarkdownProvider/components/BestPractice.tsx
@@ -117,7 +117,6 @@ interface ISectionProps extends ICaptionProps {
   imageAlt?: string;
   imageHeight?: number;
   imageWidth?: number;
-  imageIsSquare?: boolean;
 }
 
 export const Section: React.FC<ISectionProps> = props => {
@@ -125,8 +124,7 @@ export const Section: React.FC<ISectionProps> = props => {
     const imageStyles = {
       width: props.imageWidth,
       height: props.imageHeight,
-      maxWidth: props.imageIsSquare ? 160 : undefined,
-      maxHeight: 160
+      maxWidth: 320
     };
 
     return (

--- a/src/pages/components/autocomplete.mdx
+++ b/src/pages/components/autocomplete.mdx
@@ -72,7 +72,7 @@ import SizeCode from '!!raw-loader!../../examples/dropdowns/autocomplete/Size.ts
 ### Use Autocomplete to narrow down options
 
 <BestPractice>
-  <Do imageSource={props.data.dropdownSelectionDo.childFile.childImageSharp.fluid} imageIsSquare>
+  <Do imageSource={props.data.dropdownSelectionDo.childFile.childImageSharp.fluid}>
     <p>
       Autocomplete is useful for lists that are too long to read in full (for example, company
       employees) or that accumulate items over time (for example, an inventory).

--- a/src/pages/components/icon-button.mdx
+++ b/src/pages/components/icon-button.mdx
@@ -101,7 +101,7 @@ import IconButtonTypesCode from '!!raw-loader!../../examples/button/IconButtonTy
 ### Don't leave users in the dark
 
 <BestPractice>
-  <Do imageSource={props.data.iconButtonTooltipDo.childFile.childImageSharp.fluid} imageIsSquare>
+  <Do imageSource={props.data.iconButtonTooltipDo.childFile.childImageSharp.fluid}>
     <p>
       <Markdown>
         Include a [Tooltip](/components/tooltip) to help any users who may be unfamiliar with the

--- a/src/pages/components/toggle-icon-button.mdx
+++ b/src/pages/components/toggle-icon-button.mdx
@@ -111,10 +111,7 @@ import ToggleIconButtonTypesCode from '!!raw-loader!../../examples/button/Toggle
 ### Don’t leave users in the dark
 
 <BestPractice>
-  <Do
-    imageSource={props.data.toggleIconButtonTooltipDo.childFile.childImageSharp.fluid}
-    imageIsSquare
-  >
+  <Do imageSource={props.data.toggleIconButtonTooltipDo.childFile.childImageSharp.fluid}>
     <p>
       <Markdown>
         Include a [Tooltip](/components/tooltip) to help any users who may be unfamiliar with the


### PR DESCRIPTION
<!-- structure the Title above as the first line of a
  https://conventionalcommits.org/ message. example: "chore:
  add a new 'thing' component page". -->

## Description

This PR temporarily addresses the poor formatting the site is experiencing in relation to the static images in the best practices section. I think the styling of that component in general needs a larger design investigation, but I think this fix would allow the images to format more pleasantly in full width and half width scenarios. 

This is compared against master but the changes reflected on #205  would go [from this](https://share.getcloudapp.com/z8uYRod0) to [this.](https://share.getcloudapp.com/YEuybww4) 

The pages with static content to view this change are:

- Avatar
- Autocomplete
- Checkbox
- Icon button
- Toggle icon button

## Detail

<!-- supporting details; screen shot, code, etc. -->

<!-- closes GITHUB_ISSUE -->

## Checklist

- [ ] :ok_hand: website updates are Garden Designer approved (add the designer as a reviewer)
- [ ] :black_nib: copy updates are approved (add the content strategist as a reviewer)
- [ ] :link: considered opportunities for adding cross-reference URLs (grep for keywords)
- [ ] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [ ] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
