### PR TITLE
fix: ensure scrollable table handle unique scrollbar sizes

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "comment-parser": "0.7.6",
     "core-js": "2.6.11",
     "date-fns": "2.16.1",
+    "dom-helpers": "5.2.0",
     "dotenv": "8.2.0",
     "envalid": "6.0.2",
     "eslint": "7.10.0",

--- a/src/components/MarkdownProvider/components/CodeExample/utils/retrieveCodesandboxParameters.ts
+++ b/src/components/MarkdownProvider/components/CodeExample/utils/retrieveCodesandboxParameters.ts
@@ -53,6 +53,7 @@ const packageJson = `
 {
   "dependencies": {
     "date-fns": "latest",
+    "dom-helpers": "latest",
     "react-beautiful-dnd": "latest",
     "react-scripts": "latest",
     "react": "latest",

--- a/src/examples/table/TableScroll.tsx
+++ b/src/examples/table/TableScroll.tsx
@@ -6,7 +6,16 @@
  */
 
 import React from 'react';
+import styled from 'styled-components';
+import getScrollbarSize from 'dom-helpers/scrollbarSize';
 import { Body, Cell, Head, HeaderCell, HeaderRow, Row, Table } from '@zendeskgarden/react-tables';
+
+const SCROLLBAR_SIZE = getScrollbarSize();
+
+const StyledSpacerCell = styled(HeaderCell)`
+  padding: 0;
+  width: ${SCROLLBAR_SIZE}px;
+`;
 
 interface IRow {
   index: number;
@@ -30,6 +39,7 @@ const Example = () => (
           <HeaderCell>Fruit</HeaderCell>
           <HeaderCell>Sun exposure</HeaderCell>
           <HeaderCell>Soil type</HeaderCell>
+          <StyledSpacerCell aria-hidden={true} />
         </HeaderRow>
       </Head>
     </Table>

--- a/src/examples/table/TableVirtualized.tsx
+++ b/src/examples/table/TableVirtualized.tsx
@@ -7,8 +7,16 @@
 
 import React from 'react';
 import styled from 'styled-components';
+import getScrollbarSize from 'dom-helpers/scrollbarSize';
 import { FixedSizeList } from 'react-window';
 import { Table, Head, HeaderRow, HeaderCell, Body, Row, Cell } from '@zendeskgarden/react-tables';
+
+const SCROLLBAR_SIZE = getScrollbarSize();
+
+const StyledSpacerCell = styled(HeaderCell)`
+  padding: 0;
+  width: ${SCROLLBAR_SIZE}px;
+`;
 
 interface IRow {
   id: number;
@@ -63,6 +71,7 @@ const Example = () => (
           <ScrollableHeaderCell>Fruit</ScrollableHeaderCell>
           <ScrollableHeaderCell>Sun exposure</ScrollableHeaderCell>
           <ScrollableHeaderCell>Soil type</ScrollableHeaderCell>
+          <StyledSpacerCell aria-hidden={true} />
         </ScrollableHeaderRow>
       </ScrollableHead>
     </ScrollableTable>

--- a/yarn.lock
+++ b/yarn.lock
@@ -7524,20 +7524,20 @@ dom-converter@^0.2:
   dependencies:
     utila "~0.4"
 
-dom-helpers@^3.4.0:
-  version "3.4.0"
-  resolved "https://registry.yarnpkg.com/dom-helpers/-/dom-helpers-3.4.0.tgz#e9b369700f959f62ecde5a6babde4bccd9169af8"
-  integrity sha512-LnuPJ+dwqKDIyotW1VzmOZ5TONUN7CwkCR5hrgawTUbkBGYdeoNLZo6nNfGkCrjtE1nXXaj7iMMpDa8/d9WoIA==
-  dependencies:
-    "@babel/runtime" "^7.1.2"
-
-dom-helpers@^5.0.1:
+dom-helpers@5.2.0, dom-helpers@^5.0.1:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/dom-helpers/-/dom-helpers-5.2.0.tgz#57fd054c5f8f34c52a3eeffdb7e7e93cd357d95b"
   integrity sha512-Ru5o9+V8CpunKnz5LGgWXkmrH/20cGKwcHwS4m73zIvs54CN9epEmT/HLqFJW3kXpakAFkEdzgy1hzlJe3E4OQ==
   dependencies:
     "@babel/runtime" "^7.8.7"
     csstype "^3.0.2"
+
+dom-helpers@^3.4.0:
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/dom-helpers/-/dom-helpers-3.4.0.tgz#e9b369700f959f62ecde5a6babde4bccd9169af8"
+  integrity sha512-LnuPJ+dwqKDIyotW1VzmOZ5TONUN7CwkCR5hrgawTUbkBGYdeoNLZo6nNfGkCrjtE1nXXaj7iMMpDa8/d9WoIA==
+  dependencies:
+    "@babel/runtime" "^7.1.2"
 
 dom-helpers@^5.1.0:
   version "5.1.4"


### PR DESCRIPTION
## Description

Depending on the OS, browser, and system preferences users may see different scrollbar styling for the scroll and virtualized table examples.

This PR adds additional logic to ensure that table headers align with body columns.

## Detail

Native tables are hard to style sometimes. The same reasons that makes scrollable tables a custom implementation, padding/margin limitations, require us to include a hidden cell rather than styling the `<tr>` directly.

## Checklist

- [ ] :ok_hand: website updates are Garden Designer approved (add the designer as a reviewer)
- [ ] ~:black_nib: copy updates are approved (add the content strategist as a reviewer)~
- [x] :link: considered opportunities for adding cross-reference URLs (grep for keywords)
- [x] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
