### PR TITLE
feat: add Design / Color documentation

### DIFF
--- a/src/components/MarkdownProvider/components/Color.tsx
+++ b/src/components/MarkdownProvider/components/Color.tsx
@@ -1,0 +1,88 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import React from 'react';
+import styled from 'styled-components';
+import { readableColor } from 'polished';
+import { PALETTE } from '@zendeskgarden/react-theming';
+import { Row, Col } from '@zendeskgarden/react-grid';
+
+const StyledColorHex = styled.figcaption`
+  margin-left: auto;
+  font-size: ${p => p.theme.fontSizes.sm};
+`;
+
+const StyledColorSwatch = styled.figure<{ color: string }>`
+  display: flex;
+  align-items: center;
+  background-color: ${p => p.color};
+  padding: ${p => p.theme.space.xs} ${p => p.theme.space.sm};
+  color: ${p => readableColor(p.color, p.theme.colors.foreground, p.theme.colors.background)};
+
+  &:first-child {
+    border-top-left-radius: ${p => p.theme.space.sm};
+    border-top-right-radius: ${p => p.theme.space.sm};
+  }
+
+  &:last-child {
+    border-bottom-left-radius: ${p => p.theme.space.sm};
+    border-bottom-right-radius: ${p => p.theme.space.sm};
+  }
+`;
+
+const StyledColorTitle = styled.b`
+  font-size: ${p => p.theme.fontSizes.md};
+  font-weight: ${p => p.theme.fontWeights.semibold};
+`;
+
+const Color: React.FC<{ hue: string }> = ({ hue }) => {
+  const colors = (PALETTE as any)[hue];
+
+  return (
+    <>
+      {Object.keys(colors).map(shade => {
+        const color = colors[shade];
+
+        return (
+          <StyledColorSwatch color={color} key={shade}>
+            <StyledColorTitle>{shade}</StyledColorTitle>
+            <StyledColorHex>{color}</StyledColorHex>
+          </StyledColorSwatch>
+        );
+      })}
+    </>
+  );
+};
+
+export const ColorPalette: React.FC = () => (
+  <>
+    <Row>
+      <Col>
+        <Color hue="grey" />
+      </Col>
+      <Col>
+        <Color hue="kale" />
+      </Col>
+    </Row>
+    <Row>
+      <Col>
+        <Color hue="blue" />
+      </Col>
+      <Col>
+        <Color hue="green" />
+      </Col>
+    </Row>
+    <Row>
+      <Col>
+        <Color hue="yellow" />
+      </Col>
+      <Col>
+        <Color hue="red" />
+      </Col>
+    </Row>
+  </>
+);

--- a/src/components/MarkdownProvider/components/ColorPalette.tsx
+++ b/src/components/MarkdownProvider/components/ColorPalette.tsx
@@ -16,6 +16,11 @@ const StyledColorHex = styled.figcaption`
   font-size: ${p => p.theme.fontSizes.sm};
 `;
 
+const StyledColorPalette = styled.div`
+  margin-top: ${p => p.theme.space.md};
+  margin-bottom: ${p => p.theme.space.xl};
+`;
+
 const StyledColorSwatch = styled.figure<{ color: string }>`
   display: flex;
   align-items: center;
@@ -35,21 +40,32 @@ const StyledColorSwatch = styled.figure<{ color: string }>`
 `;
 
 const StyledColorTitle = styled.b`
+  white-space: nowrap;
   font-size: ${p => p.theme.fontSizes.md};
   font-weight: ${p => p.theme.fontWeights.semibold};
 `;
 
-const Color: React.FC<{ hue: string }> = ({ hue }) => {
+const StyledRow = styled(Row)`
+  & + & {
+    margin-top: ${p => p.theme.space.md};
+  }
+`;
+
+const Hue: React.FC<{ hue: string }> = ({ hue }) => {
   const colors = (PALETTE as any)[hue];
+
+  // Remove EOL product
+  delete colors.connect;
 
   return (
     <>
       {Object.keys(colors).map(shade => {
         const color = colors[shade];
+        const title = hue === 'product' ? shade : `${hue}-${shade.toLowerCase()}`;
 
         return (
           <StyledColorSwatch color={color} key={shade}>
-            <StyledColorTitle>{shade}</StyledColorTitle>
+            <StyledColorTitle>{title}</StyledColorTitle>
             <StyledColorHex>{color}</StyledColorHex>
           </StyledColorSwatch>
         );
@@ -58,31 +74,33 @@ const Color: React.FC<{ hue: string }> = ({ hue }) => {
   );
 };
 
-export const ColorPalette: React.FC = () => (
-  <>
-    <Row>
-      <Col>
-        <Color hue="grey" />
-      </Col>
-      <Col>
-        <Color hue="kale" />
-      </Col>
-    </Row>
-    <Row>
-      <Col>
-        <Color hue="blue" />
-      </Col>
-      <Col>
-        <Color hue="green" />
-      </Col>
-    </Row>
-    <Row>
-      <Col>
-        <Color hue="yellow" />
-      </Col>
-      <Col>
-        <Color hue="red" />
-      </Col>
-    </Row>
-  </>
-);
+export const ColorPalette: React.FC<{ hues: Array<string> }> = ({ hues }) => {
+  // Convert the given list of `hues` to column pairs
+  const rows = hues.reduce((retVal: Array<Array<string>>, currentValue, index, array) => {
+    if (index % 2 === 0) {
+      const pair: Array<string> = array.slice(index, index + 2);
+
+      retVal.push(pair);
+    }
+
+    return retVal;
+  }, []);
+
+  return (
+    <StyledColorPalette>
+      {rows.map((row, index) => {
+        const hue1 = row[0];
+        const hue2 = row[1];
+
+        return (
+          <StyledRow key={index}>
+            <Col sm>
+              <Hue hue={hue1} />
+            </Col>
+            {hue1 !== 'product' && <Col sm>{hue2 && <Hue hue={hue2} />}</Col>}
+          </StyledRow>
+        );
+      })}
+    </StyledColorPalette>
+  );
+};

--- a/src/components/MarkdownProvider/components/ColorPalette.tsx
+++ b/src/components/MarkdownProvider/components/ColorPalette.tsx
@@ -8,7 +8,7 @@
 import React from 'react';
 import styled from 'styled-components';
 import { readableColor } from 'polished';
-import { PALETTE } from '@zendeskgarden/react-theming';
+import { mediaQuery, PALETTE } from '@zendeskgarden/react-theming';
 import { Row, Col } from '@zendeskgarden/react-grid';
 
 const StyledColorHex = styled.figcaption`
@@ -25,7 +25,7 @@ const StyledColorSwatch = styled.figure<{ color: string }>`
   display: flex;
   align-items: center;
   background-color: ${p => p.color};
-  padding: ${p => p.theme.space.xs} ${p => p.theme.space.sm};
+  padding: ${p => p.theme.space.sm};
   color: ${p => readableColor(p.color, p.theme.colors.foreground, p.theme.colors.background)};
 
   &:first-child {
@@ -45,6 +45,12 @@ const StyledColorTitle = styled.b`
   font-weight: ${p => p.theme.fontWeights.semibold};
 `;
 
+const StyledCol = styled(Col)`
+  ${p => mediaQuery('down', 'xs', p.theme)} {
+    margin-top: ${p => p.theme.space.md};
+  }
+`;
+
 const StyledRow = styled(Row)`
   & + & {
     margin-top: ${p => p.theme.space.md};
@@ -61,7 +67,7 @@ const Hue: React.FC<{ hue: string }> = ({ hue }) => {
     <>
       {Object.keys(colors).map(shade => {
         const color = colors[shade];
-        const title = hue === 'product' ? shade : `${hue}-${shade.toLowerCase()}`;
+        const title = hue === 'product' ? shade : `${hue}-${shade}`;
 
         return (
           <StyledColorSwatch color={color} key={shade}>
@@ -97,7 +103,7 @@ export const ColorPalette: React.FC<{ hues: Array<string> }> = ({ hues }) => {
             <Col sm>
               <Hue hue={hue1} />
             </Col>
-            {hue1 !== 'product' && <Col sm>{hue2 && <Hue hue={hue2} />}</Col>}
+            {hue1 !== 'product' && <StyledCol sm>{hue2 && <Hue hue={hue2} />}</StyledCol>}
           </StyledRow>
         );
       })}

--- a/src/components/MarkdownProvider/index.tsx
+++ b/src/components/MarkdownProvider/index.tsx
@@ -10,7 +10,7 @@ import { MDXProvider } from '@mdx-js/react';
 import { Code } from '@zendeskgarden/react-typography';
 import { CodeExample } from './components/CodeExample';
 import { StyledCodeBlock as CodeBlock } from './components/CodeBlock';
-import { ColorPalette } from './components/Color';
+import { ColorPalette } from './components/ColorPalette';
 import { Component } from './components/Component';
 import { Configuration } from './components/Configuration';
 import { ObjectBlock } from './components/ObjectBlock';

--- a/src/components/MarkdownProvider/index.tsx
+++ b/src/components/MarkdownProvider/index.tsx
@@ -10,6 +10,7 @@ import { MDXProvider } from '@mdx-js/react';
 import { Code } from '@zendeskgarden/react-typography';
 import { CodeExample } from './components/CodeExample';
 import { StyledCodeBlock as CodeBlock } from './components/CodeBlock';
+import { ColorPalette } from './components/Color';
 import { Component } from './components/Component';
 import { Configuration } from './components/Configuration';
 import { ObjectBlock } from './components/ObjectBlock';
@@ -33,6 +34,7 @@ export const MarkdownProvider: React.FC = ({ children }) => (
          * Helper components
          */
         CodeExample,
+        ColorPalette,
         Component,
         Configuration,
         ObjectBlock,

--- a/src/nav/design.yml
+++ b/src/nav/design.yml
@@ -4,8 +4,8 @@
       title: Overview
 - title: Foundations
   items:
-    - title: Color
-      id: https://zendeskgarden.github.io/react-components/theming/#!/PALETTE
+    - id: /design/color
+      title: Color
     - title: Icons
       items:
         - id: /design/icons/installation

--- a/src/pages/design/color.mdx
+++ b/src/pages/design/color.mdx
@@ -1,0 +1,48 @@
+---
+title: Color
+description: >
+  The Zendesk Garden color system is a set of purposeful colors designed with
+  brand personality, usability, and accessibility in mind. The system is
+  broken down into two core palettes: UI and brand.
+---
+
+## UI colors
+
+The UI colors are used when creating interface elements. Each color has been
+designed to meet accessibility requirements.
+
+### Primary colors
+
+Primary colors are used for the structure of interfaces, actionable items,
+and validation. Colors in the 600, 700, and 800 ranges have a [WCAG
+AA](https://www.w3.org/TR/UNDERSTANDING-WCAG20/visual-audio-contrast-contrast.html)
+ratio above 4.5:1 against white or 100 backgrounds. The 800 color range
+(excluding yellow) has AAA contrast ratios above 7:1 against white and 100
+backgrounds.
+
+### Secondary colors
+
+Secondary colors are used in supplementary UI elements such as icons, tags,
+status badges, and illustrations. Each color has a light and dark hue with a
+default and muted variant. Muted colors are denoted by an "M" prefix, like
+M400.
+
+The default color variants should be used for small UI elements when the
+design requires a vibrant color. The muted variants are for applications with
+larger floods of color like data visualization and infographics. Colors in
+the 400 range meet a minimum contrast of 3:1 on white backgrounds. Colors in
+the 600 range meet a 4.5:1 contrast ratio on white backgrounds.
+
+## Brand colors
+
+The brand color palette contains the primary brand colors of Zendesk’s
+product suite. These colors are reserved to denote elements in the UI related
+to Zendesk products.
+
+import { graphql } from 'gatsby';
+
+export const pageQuery = graphql`
+  query($fileAbsolutePath: String) {
+    ...SidebarPageFragment
+  }
+`;

--- a/src/pages/design/color.mdx
+++ b/src/pages/design/color.mdx
@@ -14,11 +14,11 @@ designed to meet accessibility requirements.
 ### Primary colors
 
 Primary colors are used for the structure of interfaces, actionable items,
-and validation. Colors in the 600, 700, and 800 ranges have a [WCAG
+and validation. Colors in the `600`, `700`, and `800` ranges have a [WCAG
 AA](https://www.w3.org/TR/UNDERSTANDING-WCAG20/visual-audio-contrast-contrast.html)
-ratio above 4.5:1 against white or 100 backgrounds. The 800 color range
-(excluding yellow) has AAA contrast ratios above 7:1 against white and 100
-backgrounds.
+ratio above 4.5:1 against white or `100` backgrounds (excluding
+`yellow-600`). The `800` color range has AAA contrast ratios above 7:1
+against white and `100` backgrounds.
 
 <ColorPalette hues={['grey', 'kale', 'blue', 'green', 'red', 'yellow']} />
 
@@ -26,14 +26,15 @@ backgrounds.
 
 Secondary colors are used in supplementary UI elements such as icons, tags,
 status badges, and illustrations. Each color has a light and dark hue with a
-default and muted variant. Muted colors are denoted by an "M" prefix, like
-M400.
+default and muted variant. Muted colors are denoted by an `M` prefix, like
+`M400`.
 
 The default color variants should be used for small UI elements when the
 design requires a vibrant color. The muted variants are for applications with
 larger floods of color like data visualization and infographics. Colors in
-the 400 range meet a minimum contrast of 3:1 on white backgrounds. Colors in
-the 600 range meet a 4.5:1 contrast ratio on white backgrounds.
+the `400` range meet a minimum contrast of 3:1 on white backgrounds
+(excluding `lemon` and `lime-400`). Colors in the `600` range meet a 4.5:1
+contrast ratio on white backgrounds (excluding `lemon`).
 
 <ColorPalette
   hues={[

--- a/src/pages/design/color.mdx
+++ b/src/pages/design/color.mdx
@@ -20,6 +20,8 @@ ratio above 4.5:1 against white or 100 backgrounds. The 800 color range
 (excluding yellow) has AAA contrast ratios above 7:1 against white and 100
 backgrounds.
 
+<ColorPalette />
+
 ### Secondary colors
 
 Secondary colors are used in supplementary UI elements such as icons, tags,

--- a/src/pages/design/color.mdx
+++ b/src/pages/design/color.mdx
@@ -20,7 +20,7 @@ ratio above 4.5:1 against white or 100 backgrounds. The 800 color range
 (excluding yellow) has AAA contrast ratios above 7:1 against white and 100
 backgrounds.
 
-<ColorPalette />
+<ColorPalette hues={['grey', 'kale', 'blue', 'green', 'red', 'yellow']} />
 
 ### Secondary colors
 
@@ -35,11 +35,29 @@ larger floods of color like data visualization and infographics. Colors in
 the 400 range meet a minimum contrast of 3:1 on white backgrounds. Colors in
 the 600 range meet a 4.5:1 contrast ratio on white backgrounds.
 
+<ColorPalette
+  hues={[
+    'fuschia',
+    'pink',
+    'crimson',
+    'orange',
+    'lemon',
+    'lime',
+    'mint',
+    'teal',
+    'azure',
+    'royal',
+    'purple'
+  ]}
+/>
+
 ## Brand colors
 
 The brand color palette contains the primary brand colors of Zendesk’s
 product suite. These colors are reserved to denote elements in the UI related
 to Zendesk products.
+
+<ColorPalette hues={['product']} />
 
 import { graphql } from 'gatsby';
 

--- a/src/pages/design/color.mdx
+++ b/src/pages/design/color.mdx
@@ -38,17 +38,17 @@ contrast ratio on white backgrounds (excluding `lemon`).
 
 <ColorPalette
   hues={[
-    'fuschia',
-    'pink',
-    'crimson',
-    'orange',
-    'lemon',
-    'lime',
-    'mint',
-    'teal',
-    'azure',
+    'purple',
     'royal',
-    'purple'
+    'fuschia',
+    'azure',
+    'pink',
+    'teal',
+    'crimson',
+    'mint',
+    'orange',
+    'lime',
+    'lemon'
   ]}
 />
 


### PR DESCRIPTION
## Description

Find the new page under the `/design/color` URL.

## Detail

- the palette component uses Polished [readableColor](https://polished.js.org/docs/#readablecolor) to determine light-on-dark text
- the `ColorPalette` component makes it easy to rearrange hues within a palette on the `website`; rearranging shades within a hue will require adjustments to `react-components` source code (cc @allisonacs, it will be good to get your :eyes: on the current 🌈  ordering)
- I made some guesses about vertical spacing (20px top; 40px bottom) based on other components such as `CodeExample`

## Checklist

- [x] :ok_hand: website updates are Garden Designer approved (add the designer as a reviewer)
- [x] :black_nib: copy updates are approved (add the content strategist as a reviewer)
- [x] :link: considered opportunities for adding cross-reference URLs (grep for keywords)
- [x] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
