### PR TITLE
chore: restructure colors and icons for search indexing

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "@zendeskgarden/react-typography": "8.28.0",
     "@zendeskgarden/scripts": "0.1.11",
     "@zendeskgarden/stylelint-config": "14.0.0",
-    "@zendeskgarden/svg-icons": "6.26.0",
+    "@zendeskgarden/svg-icons": "6.27.0",
     "abstract-sdk": "8.1.0",
     "babel-eslint": "10.1.0",
     "babel-plugin-styled-components": "1.12.0",

--- a/src/components/MarkdownProvider/components/ColorPalette.tsx
+++ b/src/components/MarkdownProvider/components/ColorPalette.tsx
@@ -27,16 +27,6 @@ const StyledColorSwatch = styled.figure<{ color: string }>`
   background-color: ${p => p.color};
   padding: ${p => p.theme.space.sm};
   color: ${p => readableColor(p.color, p.theme.colors.foreground, p.theme.colors.background)};
-
-  &:first-child {
-    border-top-left-radius: ${p => p.theme.space.sm};
-    border-top-right-radius: ${p => p.theme.space.sm};
-  }
-
-  &:last-child {
-    border-bottom-left-radius: ${p => p.theme.space.sm};
-    border-bottom-right-radius: ${p => p.theme.space.sm};
-  }
 `;
 
 const StyledColorTitle = styled.b`
@@ -57,6 +47,18 @@ const StyledRow = styled(Row)`
   }
 `;
 
+const StyledList = styled.ul`
+  & > li:first-child ${StyledColorSwatch} {
+    border-top-left-radius: ${p => p.theme.space.sm};
+    border-top-right-radius: ${p => p.theme.space.sm};
+  }
+
+  & > li:last-child ${StyledColorSwatch} {
+    border-bottom-left-radius: ${p => p.theme.space.sm};
+    border-bottom-right-radius: ${p => p.theme.space.sm};
+  }
+`;
+
 const Hue: React.FC<{ hue: string }> = ({ hue }) => {
   const colors = (PALETTE as any)[hue];
 
@@ -64,19 +66,21 @@ const Hue: React.FC<{ hue: string }> = ({ hue }) => {
   delete colors.connect;
 
   return (
-    <>
+    <StyledList>
       {Object.keys(colors).map(shade => {
         const color = colors[shade];
         const title = hue === 'product' ? shade : `${hue}-${shade}`;
 
         return (
-          <StyledColorSwatch color={color} key={shade}>
-            <StyledColorTitle>{title}</StyledColorTitle>
-            <StyledColorHex>{color}</StyledColorHex>
-          </StyledColorSwatch>
+          <li key={shade}>
+            <StyledColorSwatch color={color}>
+              <StyledColorTitle>{title}</StyledColorTitle>
+              <StyledColorHex>{color}</StyledColorHex>
+            </StyledColorSwatch>
+          </li>
         );
       })}
-    </>
+    </StyledList>
   );
 };
 

--- a/src/examples/design/icons/SvgSearch.tsx
+++ b/src/examples/design/icons/SvgSearch.tsx
@@ -52,6 +52,10 @@ export const SvgSearch: React.FC<{
     updatedDebouncedInputValue(inputValue);
   }, [inputValue, updatedDebouncedInputValue]);
 
+  const StyledCol = styled(Col).attrs({ forwardedAs: 'li' })``;
+
+  const StyledRow = styled(Row).attrs({ forwardedAs: 'ul' })``;
+
   const icons = useMemo(() => {
     return data.edges
       .filter(edge => {
@@ -64,7 +68,7 @@ export const SvgSearch: React.FC<{
         return edge.node.name.trim().toLowerCase().includes(formattedSearchValue);
       })
       .map(edge => (
-        <Col key={edge.node.name} lg={3} md={4} xs={6}>
+        <StyledCol key={edge.node.name} lg={3} md={4} xs={6}>
           <StyledIconWrapper>
             <StyledSvgWrapper
               isAnswerBot={edge.node.name === 'answer-bot'}
@@ -75,9 +79,9 @@ export const SvgSearch: React.FC<{
               {edge.node.name}
             </Code>
           </StyledIconWrapper>
-        </Col>
+        </StyledCol>
       ));
-  }, [data, debouncedInputValue]);
+  }, [data, debouncedInputValue, StyledCol]);
 
   return (
     <div>
@@ -96,18 +100,14 @@ export const SvgSearch: React.FC<{
         </Field>
       )}
       <Grid>
-        <Row>
+        <StyledRow>
           {icons}
           {icons.length === 0 && (
-            <Col
-              css={`
-                text-align: center;
-              `}
-            >
+            <StyledCol textAlign="center">
               <XL>No icons found</XL>
-            </Col>
+            </StyledCol>
           )}
-        </Row>
+        </StyledRow>
       </Grid>
     </div>
   );

--- a/yarn.lock
+++ b/yarn.lock
@@ -3390,10 +3390,10 @@
   resolved "https://registry.yarnpkg.com/@zendeskgarden/stylelint-config/-/stylelint-config-14.0.0.tgz#521db96f65bd7e8a5f084fad8a38fb0235ffe420"
   integrity sha512-jFFXLRxdK+oO0GfuoeEORqg377ofKCPaAQ0rUa7MWaDgEw+2ERAzTXuzXjkIgRxM4ZMo0t8g87bWjdMIA5M4XQ==
 
-"@zendeskgarden/svg-icons@6.26.0":
-  version "6.26.0"
-  resolved "https://registry.yarnpkg.com/@zendeskgarden/svg-icons/-/svg-icons-6.26.0.tgz#461deddf3ac0040fe2fd717d61a380afb319c1d9"
-  integrity sha512-qOXGrkIeabAy08gpYVJwqtcBHX1Hv6uM+YjA+YRO04vFfmNkWWDitOtrJCgIzPOEDppjGrvmnKpjNPJn/Zp8gg==
+"@zendeskgarden/svg-icons@6.27.0":
+  version "6.27.0"
+  resolved "https://registry.yarnpkg.com/@zendeskgarden/svg-icons/-/svg-icons-6.27.0.tgz#1f63ecee9bb182252792e38aaafef26828b9ad87"
+  integrity sha512-Kx4uOI8jXjBIxrK+iv8VV43Ce5+urqj6b85RqIRqyQQ8Ywuk7jQNkDdNE+kaIogFUu7J57Oy9IdfcsWdqUiNgA==
 
 abstract-sdk@8.1.0:
   version "8.1.0"


### PR DESCRIPTION
## Description

From the following config, we can see that paragraphs and list items are eligible for DocSearch indexing.

https://github.com/algolia/docsearch-configs/blob/master/configs/garden_zendesk.json

This PR restructures the DOM for colors and icons in order to facilitate indexing. We won't know until 24 hours (crawler lag time) after merge whether these changes succeed or not.
