### PR TITLE
fix: anchor link focus styling

### DIFF
--- a/src/components/MarkdownProvider/components/Anchor.ts
+++ b/src/components/MarkdownProvider/components/Anchor.ts
@@ -5,34 +5,44 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import styled from 'styled-components';
-import { mediaQuery } from '@zendeskgarden/react-theming';
+import styled, { DefaultTheme } from 'styled-components';
+import { getColor, mediaQuery } from '@zendeskgarden/react-theming';
 import { Anchor } from '@zendeskgarden/react-buttons';
-import { math } from 'polished';
+import { math, rgba } from 'polished';
+
+const boxShadow = (theme: DefaultTheme) => {
+  const color = getColor('primaryHue', 600, theme);
+  const shadow = rgba(color as string, 0.35);
+
+  return `inset ${theme.shadows.sm(shadow)}`;
+};
 
 export const StyledAnchor = styled(Anchor).attrs(props => ({
   /* eslint-disable-next-line prefer-named-capture-group */
   isExternal: props.href && !/^(#|\/(?!\/))/u.test(props.href)
 }))`
   &.anchor.before {
+    position: relative;
     margin-left: -${p => math(`${p.theme.space.xs} * 2 + ${p.theme.iconSizes.md}`)};
-    padding: 0 ${p => p.theme.space.xs};
+    border-radius: ${p => p.theme.borderRadii.md};
+    padding: 0 ${p => p.theme.iconSizes.md};
     color: transparent;
 
     /* stylelint-disable selector-max-specificity */
     ${p => mediaQuery('down', 'md', p.theme)} {
       margin-left: -${p => math(`${p.theme.space.xxs} * 2 + ${p.theme.iconSizes.md}`)};
-      padding: 0 ${p => p.theme.space.xxs};
+      padding: 0 ${p => p.theme.space.sm};
     }
 
     &[data-garden-focus-visible] {
+      box-shadow: ${p => boxShadow(p.theme)};
       color: inherit;
     }
 
     & > svg {
-      position: relative;
-      top: -1px;
-      vertical-align: middle;
+      position: absolute;
+      top: 50%;
+      transform: translate(-50%, -50%);
     }
   }
 `;


### PR DESCRIPTION
## Description

Added focus styling to anchor links.

## Detail

Following similar styling seen on https://www.gatsbyjs.com/plugins/gatsby-image/.

## Checklist

- [x] :ok_hand: website updates are Garden Designer approved (add the designer as a reviewer)
- [ ] :black_nib: ~copy updates are approved (add the content strategist as a reviewer)~
- [ ] :link: ~considered opportunities for adding cross-reference URLs (grep for keywords)~
- [x] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
