### PR TITLE
fix: gatsby-remark-images options

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -107,7 +107,9 @@ module.exports = {
           {
             resolve: 'gatsby-remark-images',
             options: {
-              maxWidth: 1000
+              maxWidth: 1000,
+              linkImagesToOriginal: false,
+              disableBgImageOnAlpha: true
             }
           },
           {


### PR DESCRIPTION
## Description

- turn `disableBgImageOnAlpha` on – per [gatsby](https://www.gatsbyjs.com/plugins/gatsby-remark-images/#options), images with transparent pixels result in blurry edges
- turn `linkImagesToOriginal` off – we don't want the ability to click-through to full-size images

## Detail

Fixes the background blur (and anchored image) seen here: https://garden.zendesk.com/content/voice-and-tone#mapping-tone

## Checklist

- [x] :ok_hand: website updates are Garden Designer approved (add the designer as a reviewer)
- [ ] :black_nib: ~copy updates are approved (add the content strategist as a reviewer)~
- [ ] :link: ~considered opportunities for adding cross-reference URLs (grep for keywords)~
- [ ] :wheelchair: ~analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver~
- [ ] :memo: ~tested in Chrome, Firefox, Safari, Edge, and IE11~
