### PR TITLE
fix: clean up some copy and anchor bugs

### DIFF
--- a/plugins/gatsby-source-react-packages/gatsby-node.js
+++ b/plugins/gatsby-source-react-packages/gatsby-node.js
@@ -36,8 +36,6 @@ const parseComponents = filePaths => {
   const components = PARSER.parse(filePaths);
 
   return components.map(component => {
-    const data = parse(`/** ${component.description} */`)[0];
-    const extendsTag = data ? data.tags.find(tag => tag.tag === 'extends') : null;
     const props = {};
 
     Object.keys(component.props)
@@ -79,8 +77,8 @@ const parseComponents = filePaths => {
 
     return {
       name: component.displayName,
-      description: data ? data.description : '',
-      extends: extendsTag ? extendsTag.name : '',
+      description: component.description,
+      extends: component.tags ? component.tags.extends : '',
       props
     };
   });

--- a/src/components/MarkdownProvider/components/Configuration.tsx
+++ b/src/components/MarkdownProvider/components/Configuration.tsx
@@ -8,9 +8,9 @@
 import React from 'react';
 import styled from 'styled-components';
 import { UnorderedList, Span } from '@zendeskgarden/react-typography';
-import { Anchor } from '@zendeskgarden/react-buttons';
 import { getColor } from '@zendeskgarden/react-theming';
 import { IComponentData } from 'src/templates/types';
+import { StyledAnchor } from './Anchor';
 
 interface IPackage {
   version: string;
@@ -55,17 +55,17 @@ export const Configuration: React.FC<{
       <StyledListItemLabel isBold>Name</StyledListItemLabel>
       {reactPackage.version}
       <StyledDot>•</StyledDot>
-      <Anchor
+      <StyledAnchor
         href={`https://github.com/zendeskgarden/react-components/tree/main/packages/${reactPackage.packageName}`}
       >
         View source
-      </Anchor>
+      </StyledAnchor>
       <StyledDot>•</StyledDot>
-      <Anchor
+      <StyledAnchor
         href={`https://www.npmjs.com/package/@zendeskgarden/react-${reactPackage.packageName}`}
       >
         View on npm
-      </Anchor>
+      </StyledAnchor>
     </StyledListItem>
     <StyledListItem>
       <StyledListItemLabel isBold>Install</StyledListItemLabel>

--- a/src/pages/components/checkbox.mdx
+++ b/src/pages/components/checkbox.mdx
@@ -61,7 +61,7 @@ import DisabledCode from '!!raw-loader!../../examples/forms/checkbox/Disabled.ts
   <Disabled />
 </CodeExample>
 
-### Hidden
+### Hidden label
 
 Checkbox labels can be hidden.
 

--- a/src/pages/components/code.mdx
+++ b/src/pages/components/code.mdx
@@ -33,7 +33,8 @@ import ColorCode from '!!raw-loader!../../examples/typography/code/Color.tsx';
 
 ### Size
 
-Code comes in small, medium, and large. The default size is medium.
+Code comes in small, medium, and large. By default, size is inherited from
+the parent element.
 
 import Size from '../../examples/typography/code/Size.tsx';
 import SizeCode from '!!raw-loader!../../examples/typography/code/Size.tsx';


### PR DESCRIPTION
## Description

- `Code` size copy
- Configuration links should use `isExternal`
- Update `react-components` to match package.json

## Checklist

- [x] :ok_hand: website updates are Garden Designer approved (add the designer as a reviewer)
- [x] :black_nib: copy updates are approved (add the content strategist as a reviewer)
- [ ] :link: ~considered opportunities for adding cross-reference URLs (grep for keywords)~
- [ ] :wheelchair: ~analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver~
- [ ] :memo: ~tested in Chrome, Firefox, Safari, Edge, and IE11~
