### PR TITLE
fix(a11y): ensure table of contents renders in correct DOM order

### DIFF
--- a/src/layouts/Titled/index.tsx
+++ b/src/layouts/Titled/index.tsx
@@ -20,7 +20,19 @@ const TitledLayout: React.FC<{
 }> = ({ children, title, subtitle, toc }) => (
   <Grid>
     <Row>
-      <Col lg={12} xl={9}>
+      <Col
+        lg={12}
+        xl={3}
+        order={2}
+        css={css`
+          ${p => mediaQuery('down', 'lg', p.theme)} {
+            display: none;
+          }
+        `}
+      >
+        {toc && <TOC data={toc} />}
+      </Col>
+      <Col lg={12} xl={9} order={1}>
         <StyledH1>{title}</StyledH1>
         {subtitle && <Subtitle>{subtitle}</Subtitle>}
         <StyledHr />
@@ -35,17 +47,6 @@ const TitledLayout: React.FC<{
           />
         )}
         {children}
-      </Col>
-      <Col
-        lg={12}
-        xl={3}
-        css={css`
-          ${p => mediaQuery('down', 'lg', p.theme)} {
-            display: none;
-          }
-        `}
-      >
-        {toc && <TOC data={toc} />}
       </Col>
     </Row>
   </Grid>


### PR DESCRIPTION
## Description

This PR updates the DOM ordering of the table-of-contents. It now renders before the main page content for keyboard and assistive device users.

## Checklist

- [ ] :ok_hand: website updates are Garden Designer approved (add the designer as a reviewer)
- [x] :black_nib: copy updates are approved (add the content strategist as a reviewer)
- [x] :link: considered opportunities for adding cross-reference URLs (grep for keywords)
- [x] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
