### PR TITLE
chore: replace Bedrock CSS link

### DIFF
--- a/src/nav/components.yml
+++ b/src/nav/components.yml
@@ -4,7 +4,7 @@
       title: Overview
 - title: Foundations
   items:
-    - id: https://zendeskgarden.github.io/css-components/bedrock/
+    - id: https://github.com/zendeskgarden/css-components/tree/main/packages/bedrock
       title: Bedrock CSS
     - id: https://github.com/zendeskgarden/tailwindcss
       title: Design tokens


### PR DESCRIPTION
## Description

Prevent zendeskgarden/css-components#326 from nuking the link. The updated location is really where this should've been pointing to all along. The demo page offers little to no actual documentation.
