### PR TITLE
chore(versions): update links to previous versions

### DIFF
--- a/src/pages/components/versions.mdx
+++ b/src/pages/components/versions.mdx
@@ -6,8 +6,8 @@ description: >
 
 Garden website release documentation
 
-- [Version 7](https://garden-v7.netlify.app/)
-- [Version 6](https://garden-v6.netlify.app/)
+- [Version 7](https://606fa12ea4f2996a9cfd97aa--zendeskgarden.netlify.app/)
+- [Version 6](https://606f9e155f932060ab2899e8--zendeskgarden.netlify.app/)
 
 import { graphql } from 'gatsby';
 


### PR DESCRIPTION
## Description

Use links that are administered by the internal zendesk-garden account.
