### PR TITLE
fix: update help center copy for content design

### DIFF
--- a/src/pages/content/word-list.mdx
+++ b/src/pages/content/word-list.mdx
@@ -330,15 +330,22 @@ Use objective terms instead.
   </Dont>
 </BestPractice>
 
-### Help Center
+### help center
 
-Capitalize both words. Also, refer to it as _Help Center_, not _the Help Center_.
+All lowercase. Help center is not a proper noun.
 
-Example: "Edit articles in Help Center."
-
-A possessive pronoun is OK.
-
-Example: “Edit articles in your Help Center.”
+<BestPractice>
+  <Do>
+    <ul>
+      <li>Use the help center to manage your knowledge.</li>
+    </ul>
+  </Do>
+  <Dont>
+    <ul>
+      <li>Use Help Center to manage your knowledge.</li>
+    </ul>
+  </Dont>
+</BestPractice>
 
 ### help desk
 


### PR DESCRIPTION
## Description

Update wordlist copy from "Help Center" to "help center" per content design.

## Screens

**Before:**

<img width="680" alt="Screen Shot 2021-06-21 at 8 50 53 AM" src="https://user-images.githubusercontent.com/1811365/122791377-06f6b880-d26e-11eb-8fd3-a5ae586a4d25.png">


**After:**
<img width="681" alt="Screen Shot 2021-06-21 at 8 51 05 AM" src="https://user-images.githubusercontent.com/1811365/122791381-09591280-d26e-11eb-964e-122e65b68408.png">




## Checklist

- [x] :ok_hand: website updates are Garden Designer approved (add the designer as a reviewer)
- [x] :black_nib: copy updates are approved (add the content strategist as a reviewer)
- [x] :link: considered opportunities for adding cross-reference URLs (grep for keywords)
- [x] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
