### PR TITLE
fix(deps): rollback `gatsby-plugin-styled-components`

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     "gatsby-plugin-root-import": "2.0.7",
     "gatsby-plugin-sharp": "3.14.1",
     "gatsby-plugin-sitemap": "4.10.0",
-    "gatsby-plugin-styled-components": "4.14.0",
+    "gatsby-plugin-styled-components": "4.11.0",
     "gatsby-plugin-svgr": "3.0.0-beta.0",
     "gatsby-plugin-typescript": "3.14.0",
     "gatsby-remark-autolink-headers": "4.11.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1044,7 +1044,7 @@
     core-js-pure "^3.0.0"
     regenerator-runtime "^0.13.4"
 
-"@babel/runtime@^7.0.0", "@babel/runtime@^7.1.2", "@babel/runtime@^7.10.0", "@babel/runtime@^7.10.2", "@babel/runtime@^7.11.2", "@babel/runtime@^7.12.1", "@babel/runtime@^7.14.0", "@babel/runtime@^7.14.8", "@babel/runtime@^7.15.4", "@babel/runtime@^7.3.4", "@babel/runtime@^7.5.5", "@babel/runtime@^7.7.2", "@babel/runtime@^7.8.4", "@babel/runtime@^7.8.7", "@babel/runtime@^7.9.2":
+"@babel/runtime@^7.0.0", "@babel/runtime@^7.1.2", "@babel/runtime@^7.10.0", "@babel/runtime@^7.10.2", "@babel/runtime@^7.11.2", "@babel/runtime@^7.12.1", "@babel/runtime@^7.14.0", "@babel/runtime@^7.14.6", "@babel/runtime@^7.14.8", "@babel/runtime@^7.15.4", "@babel/runtime@^7.3.4", "@babel/runtime@^7.5.5", "@babel/runtime@^7.7.2", "@babel/runtime@^7.8.4", "@babel/runtime@^7.8.7", "@babel/runtime@^7.9.2":
   version "7.15.4"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.15.4.tgz#fd17d16bfdf878e6dd02d19753a39fa8a8d9c84a"
   integrity sha512-99catp6bHCaxr4sJ/DbTGgHS4+Rs2RVd2g7iOap6SLGPDknRK9ztKNsE/Fg6QhSeh1FGE5f6gHGQmvvn3I3xhw==
@@ -9016,12 +9016,12 @@ gatsby-plugin-sitemap@4.10.0:
     minimatch "^3.0.4"
     sitemap "^7.0.0"
 
-gatsby-plugin-styled-components@4.14.0:
-  version "4.14.0"
-  resolved "https://registry.yarnpkg.com/gatsby-plugin-styled-components/-/gatsby-plugin-styled-components-4.14.0.tgz#2a90694cbf502c674933c022a7d1003f1e2cd08f"
-  integrity sha512-sDyF/27G9Yh/xE8EdWqneCESlMc11AU/RK+vSF2SdQtp09sSCmRvB8CJYX9cWtNjAw7AnEyoXj1h9gSdkbvXdg==
+gatsby-plugin-styled-components@4.11.0:
+  version "4.11.0"
+  resolved "https://registry.yarnpkg.com/gatsby-plugin-styled-components/-/gatsby-plugin-styled-components-4.11.0.tgz#ec06ffe0b1a0f091ed574fef57c7f8115f99b752"
+  integrity sha512-Y99KgpWfdigNWT1nTr/GQLqMsEFsmKcbJYf79ZgIMyRZgYS6LsB3p7hRVRwGpMNuKwiefJweFMtdeYt7l+wgVg==
   dependencies:
-    "@babel/runtime" "^7.15.4"
+    "@babel/runtime" "^7.14.6"
 
 gatsby-plugin-svgr@3.0.0-beta.0:
   version "3.0.0-beta.0"


### PR DESCRIPTION
## Description

It appears that changes under `gatsby-plugin-styled-components` [v4.14.0](https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby-plugin-styled-components/CHANGELOG.md#4140-2021-09-18) are resulting in the following render errors for component page examples:

```
The `StyleSheetManager` expects a valid target or sheet prop!
```

This PR rolls back to the last known working version v4.11.0. Given the nature of the breakage, I will merge this PR upon successful CI staging deploy.

## Detail

Fixes #304 

The issue merged uncaught with the following Renovate: https://github.com/zendeskgarden/website/pull/298.
See https://github.com/gatsbyjs/gatsby/pull/33147 for details. 