### PR TITLE
fix: markdown `CodeBlock` vertical margining

### DIFF
--- a/src/components/MarkdownProvider/components/CodeBlock.tsx
+++ b/src/components/MarkdownProvider/components/CodeBlock.tsx
@@ -9,8 +9,10 @@ import styled from 'styled-components';
 import { CodeBlock } from '@zendeskgarden/react-typography';
 
 export const StyledCodeBlock = styled(CodeBlock).attrs(p => ({
-  language: p.className ? p.className.replace(/language-/u, '') : undefined
+  language: p.className ? p.className.replace(/language-/u, '') : undefined,
+  containerProps: {
+    style: { margin: `${p.theme.space.md} 0` }
+  }
 }))`
-  margin: ${p => p.theme.space.md} 0;
   border-radius: ${p => p.theme.borderRadii.md};
 `;


### PR DESCRIPTION
## Description

The Garden components reused in MDX are meant to establish vertically collapsed margins. This was lost with the introduction of https://github.com/zendeskgarden/react-components/pull/1012. This PR applies margining to the container where it collapses against surrounding content.

## Detail

Note vertical spacing diffs in the before/after below.

**before**

<img width="742" alt="Screen Shot 2021-10-12 at 6 13 01 PM" src="https://user-images.githubusercontent.com/143773/137036075-1704a4cc-c606-4b6b-a700-94055fa24a37.png">

**after**

<img width="738" alt="Screen Shot 2021-10-12 at 6 13 58 PM" src="https://user-images.githubusercontent.com/143773/137036167-8bdf65a4-006e-49f0-8785-07c4510206b5.png">


## Checklist

- [x] :ok_hand: website updates are Garden Designer approved (add the designer as a reviewer)
- [ ] :black_nib: ~copy updates are approved (add the content strategist as a reviewer)~
- [ ] :link: ~considered opportunities for adding cross-reference URLs (grep for keywords)~
- [ ] :wheelchair: ~analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver~
- [ ] :memo: ~tested in Chrome, Firefox, Safari, Edge, and IE11~
