### PR TITLE
chore(api): add descriptions and notes to components in Forms package

### DIFF
--- a/src/pages/components/checkbox.mdx
+++ b/src/pages/components/checkbox.mdx
@@ -148,9 +148,23 @@ import ValidationCode from '!!raw-loader!../../examples/forms/checkbox/Validatio
 
 ## API
 
+The Checkbox component follows this structure:
+
+```jsx
+<Field>
+  <Checkbox>
+    <Label />
+    <Hint />
+  </Checkbox>
+  <Message />
+</Field>
+```
+
 ### Checkbox
 
 <Component components={props.data.mdx.components} componentName="checkbox" />
+
+Nest a Checkbox within a [Field](#field) component.
 
 <PropSheet components={props.data.mdx.components} componentName="checkbox" />
 
@@ -158,11 +172,16 @@ import ValidationCode from '!!raw-loader!../../examples/forms/checkbox/Validatio
 
 <Component components={props.data.mdx.components} componentName="field" />
 
+A Field provides accessibility attributes to its child [Checkbox](#checkbox) field by associating it
+with the corresponding [Label](#label) and [Hint](#hint).
+
 <PropSheet components={props.data.mdx.components} componentName="field" />
 
 ### Hint
 
 <Component components={props.data.mdx.components} componentName="hint" />
+
+Nest the Hint within the [Checkbox](#checkbox) component.
 
 <PropSheet components={props.data.mdx.components} componentName="hint" />
 
@@ -170,11 +189,16 @@ import ValidationCode from '!!raw-loader!../../examples/forms/checkbox/Validatio
 
 <Component components={props.data.mdx.components} componentName="label" />
 
+Nest the Label within the [Checkbox](#checkbox) component.
+
 <PropSheet components={props.data.mdx.components} componentName="label" />
 
 ### Message
 
 <Component components={props.data.mdx.components} componentName="message" />
+
+The Message component applies appropriate icon and styles based on the validation provided. Nest
+it within a [Field](#field) component.
 
 <PropSheet components={props.data.mdx.components} componentName="message" />
 

--- a/src/pages/components/file-upload.mdx
+++ b/src/pages/components/file-upload.mdx
@@ -76,17 +76,44 @@ import SizeCode from '!!raw-loader!../../examples/forms/file-upload/Size.tsx';
 
 ## API
 
+The FileUpload component follows this structure:
+
+```jsx
+<Field>
+  <Label />
+  <Hint />
+  <FileUpload>
+    <Input />
+  </FileUpload>
+</Field>
+<FileList>
+  <FileList.Item>
+    <File>
+      <File.Close />
+      <Progress />
+    </File>
+  </FileList.Item>
+  {/* etc. */}
+</FileList>
+```
+
 import COMPONENTS from '../../examples/forms/file-upload/components.ts';
 
 ### Field
 
 <Component components={props.data.mdx.components} componentName="field" />
 
+A Field provides accessibility attributes to its child [FileUpload](#fileupload) field by associating it
+with the corresponding [Label](#label) and [Hint](#hint).
+
 <PropSheet components={props.data.mdx.components} componentName="field" />
 
 ### File
 
 <Component components={props.data.mdx.components} componentName="file" />
+
+The File component displays an icon based on the provided type, or a generic one when type is not specified.
+In case of multiple File components, nest each within an [Item](#filelistitem) component.
 
 <PropSheet components={props.data.mdx.components} componentName="file" />
 
@@ -98,18 +125,22 @@ import COMPONENTS from '../../examples/forms/file-upload/components.ts';
 
 <Component components={props.data.mdx.components} componentName="fileList" />
 
+Use the FileList component when displaying a list of multiple files.
+
 <PropSheet components={props.data.mdx.components} componentName="fileList" />
 
 #### FileList.Item
 
 <Component components={COMPONENTS} componentName="fileList.item" />
 
+Nest an Item within a [FileList](#filelist) component.
+
 ### FileUpload
 
 <Component components={props.data.mdx.components} componentName="fileUpload" />
 
-The File upload component works together with a library like
-[react-dropzone](https://react-dropzone.js.org/).
+The FileUpload component works together with a library like
+[react-dropzone](https://react-dropzone.js.org/). Nest it within a [Field](#field) component.
 
 <PropSheet components={props.data.mdx.components} componentName="fileUpload" />
 
@@ -117,17 +148,23 @@ The File upload component works together with a library like
 
 <Component components={props.data.mdx.components} componentName="hint" />
 
+Nest the Hint within a [Field](#field) component.
+
 <PropSheet components={props.data.mdx.components} componentName="hint" />
 
 ### Input
 
 <Component components={props.data.mdx.components} componentName="input" />
 
+Nest the Input within the [FileUpload](#fileupload) component. See an [example](#default) usage.
+
 <PropSheet components={props.data.mdx.components} componentName="input" />
 
 ### Label
 
 <Component components={props.data.mdx.components} componentName="label" />
+
+Nest the Label within a [Field](#field) component.
 
 <PropSheet components={props.data.mdx.components} componentName="label" />
 

--- a/src/pages/components/input-group.mdx
+++ b/src/pages/components/input-group.mdx
@@ -90,9 +90,22 @@ import SizeCode from '!!raw-loader!../../examples/forms/input-group/Size.tsx';
 
 ## API
 
+The InputGroup component follows this structure:
+
+```jsx
+<Field>
+  <Label />
+  <Hint />
+  <InputGroup />
+</Field>
+```
+
 ### InputGroup
 
 <Component components={props.data.mdx.components} componentName="inputGroup" />
+
+An InputGroup provides styles for grouping child inputs and buttons together. Nest an InputGroup within a
+[Field](#field) component.
 
 <PropSheet components={props.data.mdx.components} componentName="inputGroup" />
 

--- a/src/pages/components/input.mdx
+++ b/src/pages/components/input.mdx
@@ -166,9 +166,22 @@ import ValidationCode from '!!raw-loader!../../examples/forms/inputs/Validation.
 
 ## API
 
+The Input component follows this structure:
+
+```jsx
+<Field>
+  <Label />
+  <Hint />
+  <Input />
+  <Message />
+</Field>
+```
+
 ### FauxInput
 
 <Component components={props.data.mdx.components} componentName="fauxInput" />
+
+Nest a FauxInput within a [Field](#field) component.
 
 <PropSheet components={props.data.mdx.components} componentName="fauxInput" />
 
@@ -176,11 +189,16 @@ import ValidationCode from '!!raw-loader!../../examples/forms/inputs/Validation.
 
 <Component components={props.data.mdx.components} componentName="field" />
 
+A Field provides accessibility attributes to its child [Input](#input) field by associating it
+with the corresponding [Label](#label) and [Hint](#hint).
+
 <PropSheet components={props.data.mdx.components} componentName="field" />
 
 ### Hint
 
 <Component components={props.data.mdx.components} componentName="hint" />
+
+Nest the Hint within a [Field](#field) component.
 
 <PropSheet components={props.data.mdx.components} componentName="hint" />
 
@@ -188,11 +206,15 @@ import ValidationCode from '!!raw-loader!../../examples/forms/inputs/Validation.
 
 <Component components={props.data.mdx.components} componentName="input" />
 
+Nest an Input within a [Field](#field) component.
+
 <PropSheet components={props.data.mdx.components} componentName="input" />
 
 ### Label
 
 <Component components={props.data.mdx.components} componentName="label" />
+
+Nest the Label within a [Field](#field) component.
 
 <PropSheet components={props.data.mdx.components} componentName="label" />
 
@@ -200,11 +222,17 @@ import ValidationCode from '!!raw-loader!../../examples/forms/inputs/Validation.
 
 <Component components={props.data.mdx.components} componentName="mediaInput" />
 
+A MediaInput displays provided media elements at the start and/or end of the input. Nest
+it within a [Field](#field) component.
+
 <PropSheet components={props.data.mdx.components} componentName="mediaInput" />
 
 ### Message
 
 <Component components={props.data.mdx.components} componentName="message" />
+
+The Message component applies appropriate icon and styles based on the validation provided. Nest
+it within a [Field](#field) component.
 
 <PropSheet components={props.data.mdx.components} componentName="message" />
 

--- a/src/pages/components/multi-thumb-range.mdx
+++ b/src/pages/components/multi-thumb-range.mdx
@@ -92,9 +92,23 @@ import ValidationCode from '!!raw-loader!../../examples/forms/multithumbrange/Mu
 
 ## API
 
+The MultiThumbRange component follows this structure:
+
+```jsx
+<Field>
+  <Label />
+  <Hint />
+  <MultiThumbRange />
+  <Message />
+</Field>
+```
+
 ### Field
 
 <Component components={props.data.mdx.components} componentName="field" />
+
+A Field provides accessibility attributes to its child [MultiThumbRange](#multithumbrange) field by
+associating it with the corresponding [Label](#label) and [Hint](#hint).
 
 <PropSheet components={props.data.mdx.components} componentName="field" />
 
@@ -102,11 +116,15 @@ import ValidationCode from '!!raw-loader!../../examples/forms/multithumbrange/Mu
 
 <Component components={props.data.mdx.components} componentName="hint" />
 
+Nest the Hint within a [Field](#field) component.
+
 <PropSheet components={props.data.mdx.components} componentName="hint" />
 
 ### Label
 
 <Component components={props.data.mdx.components} componentName="label" />
+
+Nest the Label within a [Field](#field) component.
 
 <PropSheet components={props.data.mdx.components} componentName="label" />
 
@@ -114,11 +132,16 @@ import ValidationCode from '!!raw-loader!../../examples/forms/multithumbrange/Mu
 
 <Component components={props.data.mdx.components} componentName="message" />
 
+The Message component applies appropriate icon and styles based on the validation provided. Nest
+it within a [Field](#field) component.
+
 <PropSheet components={props.data.mdx.components} componentName="message" />
 
 ### MultiThumbRange
 
 <Component components={props.data.mdx.components} componentName="multiThumbRange" />
+
+Nest a MultiThumbRange within a [Field](#field) component.
 
 <PropSheet components={props.data.mdx.components} componentName="multiThumbRange" />
 

--- a/src/pages/components/radio.mdx
+++ b/src/pages/components/radio.mdx
@@ -111,9 +111,24 @@ import ValidationCode from '!!raw-loader!../../examples/forms/radio/Validation.t
 
 ## API
 
+The Radio component follows this structure:
+
+```jsx
+<Field>
+  <Radio>
+    <Label />
+    <Hint />
+  </Radio>
+  <Message />
+</Field>
+```
+
 ### Field
 
 <Component components={props.data.mdx.components} componentName="field" />
+
+A Field provides accessibility attributes to its child [Radio](#radio) field by associating it
+with the corresponding [Label](#label) and [Hint](#hint).
 
 <PropSheet components={props.data.mdx.components} componentName="field" />
 
@@ -121,9 +136,14 @@ import ValidationCode from '!!raw-loader!../../examples/forms/radio/Validation.t
 
 <Component components={props.data.mdx.components} componentName="fieldset" />
 
+The Fieldset component provides styles for grouping child form inputs. Wrap related [Field](#field)
+components and a [Legend](#fieldsetlegend) together within a Fieldset component. See an [example](#validation) usage.
+
 <PropSheet components={props.data.mdx.components} componentName="fieldset" />
 
 #### Fieldset.Legend
+
+Nest a Legend within a [Fieldset](#fieldset) component.
 
 <Component
   components={[
@@ -139,11 +159,15 @@ import ValidationCode from '!!raw-loader!../../examples/forms/radio/Validation.t
 
 <Component components={props.data.mdx.components} componentName="hint" />
 
+Nest the Hint within the [Radio](#radio) component.
+
 <PropSheet components={props.data.mdx.components} componentName="hint" />
 
 ### Label
 
 <Component components={props.data.mdx.components} componentName="label" />
+
+Nest the Label within the [Radio](#radio) component.
 
 <PropSheet components={props.data.mdx.components} componentName="label" />
 
@@ -151,11 +175,16 @@ import ValidationCode from '!!raw-loader!../../examples/forms/radio/Validation.t
 
 <Component components={props.data.mdx.components} componentName="message" />
 
+The Message component applies appropriate icon and styles based on the validation provided. Nest
+it within a [Field](#field) component.
+
 <PropSheet components={props.data.mdx.components} componentName="message" />
 
 ### Radio
 
 <Component components={props.data.mdx.components} componentName="radio" />
+
+Nest a Radio within a [Field](#field) component.
 
 <PropSheet components={props.data.mdx.components} componentName="radio" />
 

--- a/src/pages/components/range.mdx
+++ b/src/pages/components/range.mdx
@@ -102,9 +102,23 @@ import ValidationCode from '!!raw-loader!../../examples/forms/range/RangeValidat
 
 ## API
 
+The Range component follows this structure:
+
+```jsx
+<Field>
+  <Label />
+  <Hint />
+  <Range />
+  <Message />
+</Field>
+```
+
 ### Field
 
 <Component components={props.data.mdx.components} componentName="field" />
+
+A Field provides accessibility attributes to its child [Range](#range) field by associating it
+with the corresponding [Label](#label) and [Hint](#hint).
 
 <PropSheet components={props.data.mdx.components} componentName="field" />
 
@@ -112,11 +126,15 @@ import ValidationCode from '!!raw-loader!../../examples/forms/range/RangeValidat
 
 <Component components={props.data.mdx.components} componentName="hint" />
 
+Nest the Hint within a [Field](#field) component.
+
 <PropSheet components={props.data.mdx.components} componentName="hint" />
 
 ### Label
 
 <Component components={props.data.mdx.components} componentName="label" />
+
+Nest the Label within a [Field](#field) component.
 
 <PropSheet components={props.data.mdx.components} componentName="label" />
 
@@ -124,11 +142,16 @@ import ValidationCode from '!!raw-loader!../../examples/forms/range/RangeValidat
 
 <Component components={props.data.mdx.components} componentName="message" />
 
+The Message component applies appropriate icon and styles based on the validation provided. Nest
+it within a [Field](#field) component.
+
 <PropSheet components={props.data.mdx.components} componentName="message" />
 
 ### Range
 
 <Component components={props.data.mdx.components} componentName="range" />
+
+Nest a Range within a [Field](#field) component.
 
 <PropSheet components={props.data.mdx.components} componentName="range" />
 

--- a/src/pages/components/textarea.mdx
+++ b/src/pages/components/textarea.mdx
@@ -69,9 +69,21 @@ import DragHandlesCode from '!!raw-loader!../../examples/forms/textarea/DragHand
 
 ## API
 
+The Textarea component follows this structure:
+
+```jsx
+<Field>
+  <Label />
+  <Textarea />
+</Field>
+```
+
 ### Field
 
 <Component components={props.data.mdx.components} componentName="field" />
+
+A Field provides accessibility attributes to its child [Textarea](#textarea) field by associating it
+with the corresponding [Label](#label) and [Hint](#hint).
 
 <PropSheet components={props.data.mdx.components} componentName="field" />
 
@@ -79,11 +91,15 @@ import DragHandlesCode from '!!raw-loader!../../examples/forms/textarea/DragHand
 
 <Component components={props.data.mdx.components} componentName="label" />
 
+Nest the Label within a [Field](#field) component.
+
 <PropSheet components={props.data.mdx.components} componentName="label" />
 
 ### Textarea
 
 <Component components={props.data.mdx.components} componentName="textarea" />
+
+Nest a Textarea within a [Field](#field) component.
 
 <PropSheet components={props.data.mdx.components} componentName="textarea" />
 

--- a/src/pages/components/toggle.mdx
+++ b/src/pages/components/toggle.mdx
@@ -106,9 +106,24 @@ import ValidationCode from '!!raw-loader!../../examples/forms/toggle/Validation.
 
 ## API
 
+The Toggle component follows this structure:
+
+```jsx
+<Field>
+  <Toggle>
+    <Label />
+    <Hint />
+    <Message />
+  </Toggle>
+</Field>
+```
+
 ### Field
 
 <Component components={props.data.mdx.components} componentName="field" />
+
+A Field provides accessibility attributes to its child [Toggle](#toggle) field by associating it
+with the corresponding [Label](#label) and [Hint](#hint).
 
 <PropSheet components={props.data.mdx.components} componentName="field" />
 
@@ -116,11 +131,15 @@ import ValidationCode from '!!raw-loader!../../examples/forms/toggle/Validation.
 
 <Component components={props.data.mdx.components} componentName="hint" />
 
+Nest the Hint within the [Toggle](#toggle) component.
+
 <PropSheet components={props.data.mdx.components} componentName="hint" />
 
 ### Label
 
 <Component components={props.data.mdx.components} componentName="label" />
+
+Nest the Label within the [Toggle](#toggle) component.
 
 <PropSheet components={props.data.mdx.components} componentName="label" />
 
@@ -128,11 +147,16 @@ import ValidationCode from '!!raw-loader!../../examples/forms/toggle/Validation.
 
 <Component components={props.data.mdx.components} componentName="message" />
 
+The Message component applies appropriate icon and styles based on the validation provided. Nest
+it within a [Field](#field) component.
+
 <PropSheet components={props.data.mdx.components} componentName="message" />
 
 ### Toggle
 
 <Component components={props.data.mdx.components} componentName="toggle" />
+
+Nest a Toggle within a [Field](#field) component.
 
 <PropSheet components={props.data.mdx.components} componentName="toggle" />
 


### PR DESCRIPTION
This PR aims to restore and improve component documentation while following our content standards. Consideration was given to:

- providing information in a consistent, simple, clear and accessible way
- avoiding overloading with text or repetition
- using ways to make the content easier to scan quickly

## Checklist

- [x] :ok_hand: website updates are Garden Designer approved (add the designer as a reviewer)
- [x] :black_nib: copy updates are approved (add the content strategist as a reviewer)
- [x] :link: considered opportunities for adding cross-reference URLs (grep for keywords)
- [x] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
