### PR TITLE
feat(colorpickers): add color swatch page

### DIFF
--- a/src/components/MarkdownProvider/components/CodeExample/utils/retrieveCodesandboxParameters.ts
+++ b/src/components/MarkdownProvider/components/CodeExample/utils/retrieveCodesandboxParameters.ts
@@ -62,7 +62,7 @@ const packageJson = `
     "lodash.debounce": "latest",
     "react-dropzone": "latest",
     "react-window": "latest",
-    "@zendeskgarden/container-utilities": "^0.5.4",
+    "@zendeskgarden/container-utilities": "^0.6.3",
     "@zendeskgarden/css-bedrock": "^8.x",
     "@zendeskgarden/react-accordions": "^8.x",
     "@zendeskgarden/react-avatars": "^8.x",

--- a/src/examples/color-swatch/ColorSwatchCustomTrigger.tsx
+++ b/src/examples/color-swatch/ColorSwatchCustomTrigger.tsx
@@ -1,0 +1,84 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import React, { useState } from 'react';
+import { ColorSwatchDialog } from '@zendeskgarden/react-colorpickers';
+import { Row, Col } from '@zendeskgarden/react-grid';
+import { Tooltip } from '@zendeskgarden/react-tooltips';
+import { IconButton } from '@zendeskgarden/react-buttons';
+import { ReactComponent as PaletteIcon } from '@zendeskgarden/svg-icons/src/16/palette-fill.svg';
+import { DEFAULT_THEME } from '@zendeskgarden/react-theming';
+import { convertToMatrix } from '@zendeskgarden/container-utilities';
+import { labeledColors } from '../../../react-components/packages/colorpickers/stories/examples/utils';
+
+interface IPaletteIconButton {
+  iconColor: string;
+}
+
+const colors = labeledColors(
+  DEFAULT_THEME.palette,
+  ['green', 'red', 'blue', 'yellow'],
+  ['200', '300', '400', '500', '600', '700', '800']
+);
+
+const SELECTED_ROW_INDEX = 0;
+
+const SELECTED_COL_INDEX = 4;
+
+const matrix = convertToMatrix(colors, 7);
+
+const PaletteIconButton = React.forwardRef(
+  (
+    props: IPaletteIconButton & React.ComponentPropsWithoutRef<'button'>,
+    ref: React.Ref<HTMLButtonElement>
+  ) => (
+    <Tooltip content="Palette">
+      <IconButton aria-label="palette" ref={ref} style={{ color: props.iconColor }} {...props}>
+        <PaletteIcon />
+      </IconButton>
+    </Tooltip>
+  )
+);
+
+const Example = () => {
+  const [color, setColor] = useState(matrix[SELECTED_ROW_INDEX][SELECTED_COL_INDEX].value);
+  const [rowIndex, setRowIndex] = useState(SELECTED_ROW_INDEX);
+  const [colIndex, setColIndex] = useState(SELECTED_COL_INDEX);
+  const [selectedRowIndex, setSelectedRowIndex] = useState(SELECTED_ROW_INDEX);
+  const [selectedColIndex, setSelectedColIndex] = useState(SELECTED_COL_INDEX);
+
+  const onChange = (rowIdx: number, colIdx: number) => {
+    setRowIndex(rowIdx);
+    setColIndex(colIdx);
+  };
+
+  const onSelect = (rowIdx: number, colIdx: number) => {
+    setSelectedRowIndex(rowIdx);
+    setSelectedColIndex(colIdx);
+    setColor(matrix[rowIdx][colIdx].value);
+  };
+
+  return (
+    <Row>
+      <Col textAlign="center">
+        <ColorSwatchDialog
+          colors={matrix}
+          onChange={onChange}
+          onSelect={onSelect}
+          rowIndex={rowIndex}
+          colIndex={colIndex}
+          selectedRowIndex={selectedRowIndex}
+          selectedColIndex={selectedColIndex}
+        >
+          <PaletteIconButton iconColor={color} />
+        </ColorSwatchDialog>
+      </Col>
+    </Row>
+  );
+};
+
+export default Example;

--- a/src/examples/color-swatch/ColorSwatchCustomTrigger.tsx
+++ b/src/examples/color-swatch/ColorSwatchCustomTrigger.tsx
@@ -11,19 +11,42 @@ import { Row, Col } from '@zendeskgarden/react-grid';
 import { Tooltip } from '@zendeskgarden/react-tooltips';
 import { IconButton } from '@zendeskgarden/react-buttons';
 import { ReactComponent as PaletteIcon } from '@zendeskgarden/svg-icons/src/16/palette-fill.svg';
-import { DEFAULT_THEME } from '@zendeskgarden/react-theming';
 import { convertToMatrix } from '@zendeskgarden/container-utilities';
-import { labeledColors } from '../../../react-components/packages/colorpickers/stories/examples/utils';
 
 interface IPaletteIconButton {
   iconColor: string;
 }
 
-const colors = labeledColors(
-  DEFAULT_THEME.palette,
-  ['green', 'red', 'blue', 'yellow'],
-  ['200', '300', '400', '500', '600', '700', '800']
-);
+const colors = [
+  { label: 'Blue-200', value: '#cee2f2' },
+  { label: 'Blue-300', value: '#adcce4' },
+  { label: 'Blue-400', value: '#5293c7' },
+  { label: 'Blue-500', value: '#337fbd' },
+  { label: 'Blue-600', value: '#1f73b7' },
+  { label: 'Blue-700', value: '#144a75' },
+  { label: 'Blue-800', value: '#0f3554' },
+  { label: 'Red-200', value: '#f5d5d8' },
+  { label: 'Red-300', value: '#f5b5ba' },
+  { label: 'Red-400', value: '#e35b66' },
+  { label: 'Red-500', value: '#d93f4c' },
+  { label: 'Red-600', value: '#cc3340' },
+  { label: 'Red-700', value: '#8c232c' },
+  { label: 'Red-800', value: '#681219' },
+  { label: 'Yellow-200', value: '#ffeedb' },
+  { label: 'Yellow-300', value: '#fed6a8' },
+  { label: 'Yellow-400', value: '#ffb057' },
+  { label: 'Yellow-500', value: '#f79a3e' },
+  { label: 'Yellow-600', value: '#ed8f1c' },
+  { label: 'Yellow-700', value: '#ad5918' },
+  { label: 'Yellow-800', value: '#703815' },
+  { label: 'Green-200', value: '#d1e8df' },
+  { label: 'Green-300', value: '#aecfc2' },
+  { label: 'Green-400', value: '#5eae91' },
+  { label: 'Green-500', value: '#228f67' },
+  { label: 'Green-600', value: '#038153' },
+  { label: 'Green-700', value: '#186146' },
+  { label: 'Green-800', value: '#0b3b29' }
+];
 
 const SELECTED_ROW_INDEX = 0;
 

--- a/src/examples/color-swatch/ColorSwatchCustomTrigger.tsx
+++ b/src/examples/color-swatch/ColorSwatchCustomTrigger.tsx
@@ -12,47 +12,38 @@ import { Tooltip } from '@zendeskgarden/react-tooltips';
 import { IconButton } from '@zendeskgarden/react-buttons';
 import { ReactComponent as PaletteIcon } from '@zendeskgarden/svg-icons/src/16/palette-fill.svg';
 import { convertToMatrix } from '@zendeskgarden/container-utilities';
+import { PALETTE } from '@zendeskgarden/react-theming';
 
 interface IPaletteIconButton {
   iconColor: string;
 }
+interface ILabledColor {
+  label: string;
+  value: string;
+}
 
-const colors = [
-  { label: 'Blue-200', value: '#cee2f2' },
-  { label: 'Blue-300', value: '#adcce4' },
-  { label: 'Blue-400', value: '#5293c7' },
-  { label: 'Blue-500', value: '#337fbd' },
-  { label: 'Blue-600', value: '#1f73b7' },
-  { label: 'Blue-700', value: '#144a75' },
-  { label: 'Blue-800', value: '#0f3554' },
-  { label: 'Red-200', value: '#f5d5d8' },
-  { label: 'Red-300', value: '#f5b5ba' },
-  { label: 'Red-400', value: '#e35b66' },
-  { label: 'Red-500', value: '#d93f4c' },
-  { label: 'Red-600', value: '#cc3340' },
-  { label: 'Red-700', value: '#8c232c' },
-  { label: 'Red-800', value: '#681219' },
-  { label: 'Yellow-200', value: '#ffeedb' },
-  { label: 'Yellow-300', value: '#fed6a8' },
-  { label: 'Yellow-400', value: '#ffb057' },
-  { label: 'Yellow-500', value: '#f79a3e' },
-  { label: 'Yellow-600', value: '#ed8f1c' },
-  { label: 'Yellow-700', value: '#ad5918' },
-  { label: 'Yellow-800', value: '#703815' },
-  { label: 'Green-200', value: '#d1e8df' },
-  { label: 'Green-300', value: '#aecfc2' },
-  { label: 'Green-400', value: '#5eae91' },
-  { label: 'Green-500', value: '#228f67' },
-  { label: 'Green-600', value: '#038153' },
-  { label: 'Green-700', value: '#186146' },
-  { label: 'Green-800', value: '#0b3b29' }
-];
+const colors = ['blue', 'red', 'yellow', 'green'];
+
+const shades = [200, 300, 400, 500, 600, 700, 800];
+
+const capitalize = (string: string) => string.charAt(0).toUpperCase() + string.slice(1);
+
+const labeledColors = colors.reduce(
+  (acc: ILabledColor[], hue: string) => [
+    ...acc,
+    ...shades.map(shade => ({
+      label: `${capitalize(hue)}-${shade}`,
+      value: (PALETTE as any)[hue][shade]
+    }))
+  ],
+  []
+);
 
 const SELECTED_ROW_INDEX = 0;
 
 const SELECTED_COL_INDEX = 4;
 
-const matrix = convertToMatrix(colors, 7);
+const matrix = convertToMatrix(labeledColors, 7);
 
 const PaletteIconButton = React.forwardRef(
   (

--- a/src/examples/color-swatch/ColorSwatchCustomTrigger.tsx
+++ b/src/examples/color-swatch/ColorSwatchCustomTrigger.tsx
@@ -17,33 +17,43 @@ import { PALETTE } from '@zendeskgarden/react-theming';
 interface IPaletteIconButton {
   iconColor: string;
 }
-interface ILabledColor {
-  label: string;
-  value: string;
-}
 
-const colors = ['blue', 'red', 'yellow', 'green'];
-
-const shades = [200, 300, 400, 500, 600, 700, 800];
-
-const capitalize = (string: string) => string.charAt(0).toUpperCase() + string.slice(1);
-
-const labeledColors = colors.reduce(
-  (acc: ILabledColor[], hue: string) => [
-    ...acc,
-    ...shades.map(shade => ({
-      label: `${capitalize(hue)}-${shade}`,
-      value: (PALETTE as any)[hue][shade]
-    }))
-  ],
-  []
-);
+const colors = [
+  { label: 'Blue-200', value: PALETTE.blue[200] },
+  { label: 'Blue-300', value: PALETTE.blue[300] },
+  { label: 'Blue-400', value: PALETTE.blue[400] },
+  { label: 'Blue-500', value: PALETTE.blue[500] },
+  { label: 'Blue-600', value: PALETTE.blue[600] },
+  { label: 'Blue-700', value: PALETTE.blue[700] },
+  { label: 'Blue-800', value: PALETTE.blue[800] },
+  { label: 'Red-200', value: PALETTE.red[200] },
+  { label: 'Red-300', value: PALETTE.red[300] },
+  { label: 'Red-400', value: PALETTE.red[400] },
+  { label: 'Red-500', value: PALETTE.red[500] },
+  { label: 'Red-600', value: PALETTE.red[600] },
+  { label: 'Red-700', value: PALETTE.red[700] },
+  { label: 'Red-800', value: PALETTE.red[800] },
+  { label: 'Yellow-200', value: PALETTE.yellow[200] },
+  { label: 'Yellow-300', value: PALETTE.yellow[300] },
+  { label: 'Yellow-400', value: PALETTE.yellow[400] },
+  { label: 'Yellow-500', value: PALETTE.yellow[500] },
+  { label: 'Yellow-600', value: PALETTE.yellow[600] },
+  { label: 'Yellow-700', value: PALETTE.yellow[700] },
+  { label: 'Yellow-800', value: PALETTE.yellow[800] },
+  { label: 'Green-200', value: PALETTE.green[200] },
+  { label: 'Green-300', value: PALETTE.green[300] },
+  { label: 'Green-400', value: PALETTE.green[400] },
+  { label: 'Green-500', value: PALETTE.green[500] },
+  { label: 'Green-600', value: PALETTE.green[600] },
+  { label: 'Green-700', value: PALETTE.green[700] },
+  { label: 'Green-800', value: PALETTE.green[800] }
+];
 
 const SELECTED_ROW_INDEX = 0;
 
 const SELECTED_COL_INDEX = 4;
 
-const matrix = convertToMatrix(labeledColors, 7);
+const matrix = convertToMatrix(colors, 7);
 
 const PaletteIconButton = React.forwardRef(
   (

--- a/src/examples/color-swatch/ColorSwatchDefault.tsx
+++ b/src/examples/color-swatch/ColorSwatchDefault.tsx
@@ -11,29 +11,38 @@ import { Row, Col } from '@zendeskgarden/react-grid';
 import { convertToMatrix } from '@zendeskgarden/container-utilities';
 import { PALETTE } from '@zendeskgarden/react-theming';
 
-interface ILabledColor {
-  label: string;
-  value: string;
-}
+const colors = [
+  { label: 'Blue-200', value: PALETTE.blue[200] },
+  { label: 'Blue-300', value: PALETTE.blue[300] },
+  { label: 'Blue-400', value: PALETTE.blue[400] },
+  { label: 'Blue-500', value: PALETTE.blue[500] },
+  { label: 'Blue-600', value: PALETTE.blue[600] },
+  { label: 'Blue-700', value: PALETTE.blue[700] },
+  { label: 'Blue-800', value: PALETTE.blue[800] },
+  { label: 'Red-200', value: PALETTE.red[200] },
+  { label: 'Red-300', value: PALETTE.red[300] },
+  { label: 'Red-400', value: PALETTE.red[400] },
+  { label: 'Red-500', value: PALETTE.red[500] },
+  { label: 'Red-600', value: PALETTE.red[600] },
+  { label: 'Red-700', value: PALETTE.red[700] },
+  { label: 'Red-800', value: PALETTE.red[800] },
+  { label: 'Yellow-200', value: PALETTE.yellow[200] },
+  { label: 'Yellow-300', value: PALETTE.yellow[300] },
+  { label: 'Yellow-400', value: PALETTE.yellow[400] },
+  { label: 'Yellow-500', value: PALETTE.yellow[500] },
+  { label: 'Yellow-600', value: PALETTE.yellow[600] },
+  { label: 'Yellow-700', value: PALETTE.yellow[700] },
+  { label: 'Yellow-800', value: PALETTE.yellow[800] },
+  { label: 'Green-200', value: PALETTE.green[200] },
+  { label: 'Green-300', value: PALETTE.green[300] },
+  { label: 'Green-400', value: PALETTE.green[400] },
+  { label: 'Green-500', value: PALETTE.green[500] },
+  { label: 'Green-600', value: PALETTE.green[600] },
+  { label: 'Green-700', value: PALETTE.green[700] },
+  { label: 'Green-800', value: PALETTE.green[800] }
+];
 
-const colors = ['blue', 'red', 'yellow', 'green'];
-
-const shades = [200, 300, 400, 500, 600, 700, 800];
-
-const capitalize = (string: string) => string.charAt(0).toUpperCase() + string.slice(1);
-
-const labeledColors = colors.reduce(
-  (acc: ILabledColor[], hue: string) => [
-    ...acc,
-    ...shades.map(shade => ({
-      label: `${capitalize(hue)}-${shade}`,
-      value: (PALETTE as any)[hue][shade]
-    }))
-  ],
-  []
-);
-
-const matrix = convertToMatrix(labeledColors, 7);
+const matrix = convertToMatrix(colors, 7);
 
 const Example = () => (
   <Row justifyContent="center">

--- a/src/examples/color-swatch/ColorSwatchDefault.tsx
+++ b/src/examples/color-swatch/ColorSwatchDefault.tsx
@@ -9,39 +9,31 @@ import React from 'react';
 import { ColorSwatch } from '@zendeskgarden/react-colorpickers';
 import { Row, Col } from '@zendeskgarden/react-grid';
 import { convertToMatrix } from '@zendeskgarden/container-utilities';
+import { PALETTE } from '@zendeskgarden/react-theming';
 
-const colors = [
-  { label: 'Blue-200', value: '#cee2f2' },
-  { label: 'Blue-300', value: '#adcce4' },
-  { label: 'Blue-400', value: '#5293c7' },
-  { label: 'Blue-500', value: '#337fbd' },
-  { label: 'Blue-600', value: '#1f73b7' },
-  { label: 'Blue-700', value: '#144a75' },
-  { label: 'Blue-800', value: '#0f3554' },
-  { label: 'Red-200', value: '#f5d5d8' },
-  { label: 'Red-300', value: '#f5b5ba' },
-  { label: 'Red-400', value: '#e35b66' },
-  { label: 'Red-500', value: '#d93f4c' },
-  { label: 'Red-600', value: '#cc3340' },
-  { label: 'Red-700', value: '#8c232c' },
-  { label: 'Red-800', value: '#681219' },
-  { label: 'Yellow-200', value: '#ffeedb' },
-  { label: 'Yellow-300', value: '#fed6a8' },
-  { label: 'Yellow-400', value: '#ffb057' },
-  { label: 'Yellow-500', value: '#f79a3e' },
-  { label: 'Yellow-600', value: '#ed8f1c' },
-  { label: 'Yellow-700', value: '#ad5918' },
-  { label: 'Yellow-800', value: '#703815' },
-  { label: 'Green-200', value: '#d1e8df' },
-  { label: 'Green-300', value: '#aecfc2' },
-  { label: 'Green-400', value: '#5eae91' },
-  { label: 'Green-500', value: '#228f67' },
-  { label: 'Green-600', value: '#038153' },
-  { label: 'Green-700', value: '#186146' },
-  { label: 'Green-800', value: '#0b3b29' }
-];
+interface ILabledColor {
+  label: string;
+  value: string;
+}
 
-const matrix = convertToMatrix(colors, 7);
+const colors = ['blue', 'red', 'yellow', 'green'];
+
+const shades = [200, 300, 400, 500, 600, 700, 800];
+
+const capitalize = (string: string) => string.charAt(0).toUpperCase() + string.slice(1);
+
+const labeledColors = colors.reduce(
+  (acc: ILabledColor[], hue: string) => [
+    ...acc,
+    ...shades.map(shade => ({
+      label: `${capitalize(hue)}-${shade}`,
+      value: (PALETTE as any)[hue][shade]
+    }))
+  ],
+  []
+);
+
+const matrix = convertToMatrix(labeledColors, 7);
 
 const Example = () => (
   <Row justifyContent="center">

--- a/src/examples/color-swatch/ColorSwatchDefault.tsx
+++ b/src/examples/color-swatch/ColorSwatchDefault.tsx
@@ -8,15 +8,38 @@
 import React from 'react';
 import { ColorSwatch } from '@zendeskgarden/react-colorpickers';
 import { Row, Col } from '@zendeskgarden/react-grid';
-import { DEFAULT_THEME } from '@zendeskgarden/react-theming';
 import { convertToMatrix } from '@zendeskgarden/container-utilities';
-import { labeledColors } from '../../../react-components/packages/colorpickers/stories/examples/utils';
 
-export const colors = labeledColors(
-  DEFAULT_THEME.palette,
-  ['green', 'red', 'blue', 'yellow'],
-  ['200', '300', '400', '500', '600', '700', '800']
-);
+const colors = [
+  { label: 'Blue-200', value: '#cee2f2' },
+  { label: 'Blue-300', value: '#adcce4' },
+  { label: 'Blue-400', value: '#5293c7' },
+  { label: 'Blue-500', value: '#337fbd' },
+  { label: 'Blue-600', value: '#1f73b7' },
+  { label: 'Blue-700', value: '#144a75' },
+  { label: 'Blue-800', value: '#0f3554' },
+  { label: 'Red-200', value: '#f5d5d8' },
+  { label: 'Red-300', value: '#f5b5ba' },
+  { label: 'Red-400', value: '#e35b66' },
+  { label: 'Red-500', value: '#d93f4c' },
+  { label: 'Red-600', value: '#cc3340' },
+  { label: 'Red-700', value: '#8c232c' },
+  { label: 'Red-800', value: '#681219' },
+  { label: 'Yellow-200', value: '#ffeedb' },
+  { label: 'Yellow-300', value: '#fed6a8' },
+  { label: 'Yellow-400', value: '#ffb057' },
+  { label: 'Yellow-500', value: '#f79a3e' },
+  { label: 'Yellow-600', value: '#ed8f1c' },
+  { label: 'Yellow-700', value: '#ad5918' },
+  { label: 'Yellow-800', value: '#703815' },
+  { label: 'Green-200', value: '#d1e8df' },
+  { label: 'Green-300', value: '#aecfc2' },
+  { label: 'Green-400', value: '#5eae91' },
+  { label: 'Green-500', value: '#228f67' },
+  { label: 'Green-600', value: '#038153' },
+  { label: 'Green-700', value: '#186146' },
+  { label: 'Green-800', value: '#0b3b29' }
+];
 
 const matrix = convertToMatrix(colors, 7);
 

--- a/src/examples/color-swatch/ColorSwatchDefault.tsx
+++ b/src/examples/color-swatch/ColorSwatchDefault.tsx
@@ -1,0 +1,31 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import React from 'react';
+import { ColorSwatch } from '@zendeskgarden/react-colorpickers';
+import { Row, Col } from '@zendeskgarden/react-grid';
+import { DEFAULT_THEME } from '@zendeskgarden/react-theming';
+import { convertToMatrix } from '@zendeskgarden/container-utilities';
+import { labeledColors } from '../../../react-components/packages/colorpickers/stories/examples/utils';
+
+export const colors = labeledColors(
+  DEFAULT_THEME.palette,
+  ['green', 'red', 'blue', 'yellow'],
+  ['200', '300', '400', '500', '600', '700', '800']
+);
+
+const matrix = convertToMatrix(colors, 7);
+
+const Example = () => (
+  <Row justifyContent="center">
+    <Col size="auto">
+      <ColorSwatch colors={matrix} />
+    </Col>
+  </Row>
+);
+
+export default Example;

--- a/src/examples/color-swatch/ColorSwatchDialog.tsx
+++ b/src/examples/color-swatch/ColorSwatchDialog.tsx
@@ -11,29 +11,38 @@ import { Row, Col } from '@zendeskgarden/react-grid';
 import { convertToMatrix } from '@zendeskgarden/container-utilities';
 import { PALETTE } from '@zendeskgarden/react-theming';
 
-interface ILabledColor {
-  label: string;
-  value: string;
-}
+const colors = [
+  { label: 'Blue-200', value: PALETTE.blue[200] },
+  { label: 'Blue-300', value: PALETTE.blue[300] },
+  { label: 'Blue-400', value: PALETTE.blue[400] },
+  { label: 'Blue-500', value: PALETTE.blue[500] },
+  { label: 'Blue-600', value: PALETTE.blue[600] },
+  { label: 'Blue-700', value: PALETTE.blue[700] },
+  { label: 'Blue-800', value: PALETTE.blue[800] },
+  { label: 'Red-200', value: PALETTE.red[200] },
+  { label: 'Red-300', value: PALETTE.red[300] },
+  { label: 'Red-400', value: PALETTE.red[400] },
+  { label: 'Red-500', value: PALETTE.red[500] },
+  { label: 'Red-600', value: PALETTE.red[600] },
+  { label: 'Red-700', value: PALETTE.red[700] },
+  { label: 'Red-800', value: PALETTE.red[800] },
+  { label: 'Yellow-200', value: PALETTE.yellow[200] },
+  { label: 'Yellow-300', value: PALETTE.yellow[300] },
+  { label: 'Yellow-400', value: PALETTE.yellow[400] },
+  { label: 'Yellow-500', value: PALETTE.yellow[500] },
+  { label: 'Yellow-600', value: PALETTE.yellow[600] },
+  { label: 'Yellow-700', value: PALETTE.yellow[700] },
+  { label: 'Yellow-800', value: PALETTE.yellow[800] },
+  { label: 'Green-200', value: PALETTE.green[200] },
+  { label: 'Green-300', value: PALETTE.green[300] },
+  { label: 'Green-400', value: PALETTE.green[400] },
+  { label: 'Green-500', value: PALETTE.green[500] },
+  { label: 'Green-600', value: PALETTE.green[600] },
+  { label: 'Green-700', value: PALETTE.green[700] },
+  { label: 'Green-800', value: PALETTE.green[800] }
+];
 
-const colors = ['blue', 'red', 'yellow', 'green'];
-
-const shades = [200, 300, 400, 500, 600, 700, 800];
-
-const capitalize = (string: string) => string.charAt(0).toUpperCase() + string.slice(1);
-
-const labeledColors = colors.reduce(
-  (acc: ILabledColor[], hue: string) => [
-    ...acc,
-    ...shades.map(shade => ({
-      label: `${capitalize(hue)}-${shade}`,
-      value: (PALETTE as any)[hue][shade]
-    }))
-  ],
-  []
-);
-
-const matrix = convertToMatrix(labeledColors, 7);
+const matrix = convertToMatrix(colors, 7);
 
 const Example = () => {
   const [rowIndex, setRowIndex] = useState(0);

--- a/src/examples/color-swatch/ColorSwatchDialog.tsx
+++ b/src/examples/color-swatch/ColorSwatchDialog.tsx
@@ -8,15 +8,38 @@
 import React, { useState } from 'react';
 import { ColorSwatchDialog } from '@zendeskgarden/react-colorpickers';
 import { Row, Col } from '@zendeskgarden/react-grid';
-import { DEFAULT_THEME } from '@zendeskgarden/react-theming';
 import { convertToMatrix } from '@zendeskgarden/container-utilities';
-import { labeledColors } from '../../../react-components/packages/colorpickers/stories/examples/utils';
 
-const colors = labeledColors(
-  DEFAULT_THEME.palette,
-  ['green', 'red', 'blue', 'yellow'],
-  ['200', '300', '400', '500', '600', '700', '800']
-);
+const colors = [
+  { label: 'Blue-200', value: '#cee2f2' },
+  { label: 'Blue-300', value: '#adcce4' },
+  { label: 'Blue-400', value: '#5293c7' },
+  { label: 'Blue-500', value: '#337fbd' },
+  { label: 'Blue-600', value: '#1f73b7' },
+  { label: 'Blue-700', value: '#144a75' },
+  { label: 'Blue-800', value: '#0f3554' },
+  { label: 'Red-200', value: '#f5d5d8' },
+  { label: 'Red-300', value: '#f5b5ba' },
+  { label: 'Red-400', value: '#e35b66' },
+  { label: 'Red-500', value: '#d93f4c' },
+  { label: 'Red-600', value: '#cc3340' },
+  { label: 'Red-700', value: '#8c232c' },
+  { label: 'Red-800', value: '#681219' },
+  { label: 'Yellow-200', value: '#ffeedb' },
+  { label: 'Yellow-300', value: '#fed6a8' },
+  { label: 'Yellow-400', value: '#ffb057' },
+  { label: 'Yellow-500', value: '#f79a3e' },
+  { label: 'Yellow-600', value: '#ed8f1c' },
+  { label: 'Yellow-700', value: '#ad5918' },
+  { label: 'Yellow-800', value: '#703815' },
+  { label: 'Green-200', value: '#d1e8df' },
+  { label: 'Green-300', value: '#aecfc2' },
+  { label: 'Green-400', value: '#5eae91' },
+  { label: 'Green-500', value: '#228f67' },
+  { label: 'Green-600', value: '#038153' },
+  { label: 'Green-700', value: '#186146' },
+  { label: 'Green-800', value: '#0b3b29' }
+];
 
 const matrix = convertToMatrix(colors, 7);
 

--- a/src/examples/color-swatch/ColorSwatchDialog.tsx
+++ b/src/examples/color-swatch/ColorSwatchDialog.tsx
@@ -1,0 +1,54 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import React, { useState } from 'react';
+import { ColorSwatchDialog } from '@zendeskgarden/react-colorpickers';
+import { Row, Col } from '@zendeskgarden/react-grid';
+import { DEFAULT_THEME } from '@zendeskgarden/react-theming';
+import { convertToMatrix } from '@zendeskgarden/container-utilities';
+import { labeledColors } from '../../../react-components/packages/colorpickers/stories/examples/utils';
+
+const colors = labeledColors(
+  DEFAULT_THEME.palette,
+  ['green', 'red', 'blue', 'yellow'],
+  ['200', '300', '400', '500', '600', '700', '800']
+);
+
+const matrix = convertToMatrix(colors, 7);
+
+const Example = () => {
+  const [rowIndex, setRowIndex] = useState(0);
+  const [colIndex, setColIndex] = useState(4);
+  const [selectedRowIndex, setSelectedRowIndex] = useState(0);
+  const [selectedColIndex, setSelectedColIndex] = useState(4);
+  const onChange = (rowIdx: number, colIdx: number) => {
+    setRowIndex(rowIdx);
+    setColIndex(colIdx);
+  };
+  const onSelect = (rowIdx: number, colIdx: number) => {
+    setSelectedRowIndex(rowIdx);
+    setSelectedColIndex(colIdx);
+  };
+
+  return (
+    <Row justifyContent="center">
+      <Col size="auto">
+        <ColorSwatchDialog
+          colors={matrix}
+          onChange={onChange}
+          onSelect={onSelect}
+          rowIndex={rowIndex}
+          colIndex={colIndex}
+          selectedRowIndex={selectedRowIndex}
+          selectedColIndex={selectedColIndex}
+        />
+      </Col>
+    </Row>
+  );
+};
+
+export default Example;

--- a/src/examples/color-swatch/ColorSwatchDialog.tsx
+++ b/src/examples/color-swatch/ColorSwatchDialog.tsx
@@ -9,39 +9,31 @@ import React, { useState } from 'react';
 import { ColorSwatchDialog } from '@zendeskgarden/react-colorpickers';
 import { Row, Col } from '@zendeskgarden/react-grid';
 import { convertToMatrix } from '@zendeskgarden/container-utilities';
+import { PALETTE } from '@zendeskgarden/react-theming';
 
-const colors = [
-  { label: 'Blue-200', value: '#cee2f2' },
-  { label: 'Blue-300', value: '#adcce4' },
-  { label: 'Blue-400', value: '#5293c7' },
-  { label: 'Blue-500', value: '#337fbd' },
-  { label: 'Blue-600', value: '#1f73b7' },
-  { label: 'Blue-700', value: '#144a75' },
-  { label: 'Blue-800', value: '#0f3554' },
-  { label: 'Red-200', value: '#f5d5d8' },
-  { label: 'Red-300', value: '#f5b5ba' },
-  { label: 'Red-400', value: '#e35b66' },
-  { label: 'Red-500', value: '#d93f4c' },
-  { label: 'Red-600', value: '#cc3340' },
-  { label: 'Red-700', value: '#8c232c' },
-  { label: 'Red-800', value: '#681219' },
-  { label: 'Yellow-200', value: '#ffeedb' },
-  { label: 'Yellow-300', value: '#fed6a8' },
-  { label: 'Yellow-400', value: '#ffb057' },
-  { label: 'Yellow-500', value: '#f79a3e' },
-  { label: 'Yellow-600', value: '#ed8f1c' },
-  { label: 'Yellow-700', value: '#ad5918' },
-  { label: 'Yellow-800', value: '#703815' },
-  { label: 'Green-200', value: '#d1e8df' },
-  { label: 'Green-300', value: '#aecfc2' },
-  { label: 'Green-400', value: '#5eae91' },
-  { label: 'Green-500', value: '#228f67' },
-  { label: 'Green-600', value: '#038153' },
-  { label: 'Green-700', value: '#186146' },
-  { label: 'Green-800', value: '#0b3b29' }
-];
+interface ILabledColor {
+  label: string;
+  value: string;
+}
 
-const matrix = convertToMatrix(colors, 7);
+const colors = ['blue', 'red', 'yellow', 'green'];
+
+const shades = [200, 300, 400, 500, 600, 700, 800];
+
+const capitalize = (string: string) => string.charAt(0).toUpperCase() + string.slice(1);
+
+const labeledColors = colors.reduce(
+  (acc: ILabledColor[], hue: string) => [
+    ...acc,
+    ...shades.map(shade => ({
+      label: `${capitalize(hue)}-${shade}`,
+      value: (PALETTE as any)[hue][shade]
+    }))
+  ],
+  []
+);
+
+const matrix = convertToMatrix(labeledColors, 7);
 
 const Example = () => {
   const [rowIndex, setRowIndex] = useState(0);

--- a/src/nav/components.yml
+++ b/src/nav/components.yml
@@ -52,6 +52,8 @@
       id: /components/date-picker
     - title: Color picker
       id: /components/color-picker
+    - title: Color swatch
+      id: /components/color-swatch
     - title: Drawer
       id: /components/drawer
     - title: Dropdowns

--- a/src/pages/components/color-picker.mdx
+++ b/src/pages/components/color-picker.mdx
@@ -43,7 +43,7 @@ import ColorpickerDialogCustomTriggerCode from '!!raw-loader!../../examples/colo
 
 ### Dialog
 
-The Color picker can be placed inside a dialog.
+The Color picker can be shown inside a dialog using `<ColorpickerDialog>`.
 
 import ColorpickerDialogDefault from '../../examples/color-picker/ColorpickerDialogDefault.tsx';
 import ColorpickerDialogDefaultCode from '!!raw-loader!../../examples/color-picker/ColorpickerDialogDefault.tsx';

--- a/src/pages/components/color-swatch.mdx
+++ b/src/pages/components/color-swatch.mdx
@@ -1,7 +1,7 @@
 ---
 title: Color swatch
 description: >
-  The Color swatch allows users to choose colors using sliders and input fields.
+  The Color swatch allows users to select a single predefined color.
 package: '@zendeskgarden/react-colorpickers'
 components:
   - colorpickers/src/elements/ColorSwatch/index.tsx

--- a/src/pages/components/color-swatch.mdx
+++ b/src/pages/components/color-swatch.mdx
@@ -1,0 +1,84 @@
+---
+title: Color swatch
+description: >
+  The Color swatch allows users to choose colors using sliders and input fields.
+package: '@zendeskgarden/react-colorpickers'
+components:
+  - colorpickers/src/elements/ColorSwatch/index.tsx
+  - colorpickers/src/elements/ColorSwatchDialog/index.tsx
+---
+
+<Usage>
+  <Use>
+    <ul>
+      <li>To let users change, update, or add predefined colors</li>
+    </ul>
+  </Use>
+  <Misuse>
+    <ul>
+      <li>
+        <Markdown>
+          For more finite control over color selection, use the [Color
+          picker](/components/color-picker)
+        </Markdown>
+      </li>
+    </ul>
+  </Misuse>
+</Usage>
+
+## How to use it
+
+### Default
+
+The Color swatch allows users to select a single predefined color.
+
+import ColorSwatchDefault from '../../examples/color-swatch/ColorSwatchDefault.tsx';
+import ColorSwatchDefaultCode from '!!raw-loader!../../examples/color-swatch/ColorSwatchDefault.tsx';
+
+<CodeExample code={ColorSwatchDefaultCode}>
+  <ColorSwatchDefault />
+</CodeExample>
+
+### Custom trigger
+
+The Color swatch can be displayed using a trigger, e.g. an [Icon button](/components/icon-button).
+
+import ColorSwatchCustomTrigger from '../../examples/color-swatch/ColorSwatchCustomTrigger.tsx';
+import ColorSwatchCustomTriggerCode from '!!raw-loader!../../examples/color-swatch/ColorSwatchCustomTrigger.tsx';
+
+<CodeExample code={ColorSwatchCustomTriggerCode}>
+  <ColorSwatchCustomTrigger />
+</CodeExample>
+
+### Dialog
+
+The Color swatch can be placed inside a dialog.
+
+import ColorSwatchDialog from '../../examples/color-swatch/ColorSwatchDialog.tsx';
+import ColorSwatchDialogCode from '!!raw-loader!../../examples/color-swatch/ColorSwatchDialog.tsx';
+
+<CodeExample code={ColorSwatchDialogCode}>
+  <ColorSwatchDialog />
+</CodeExample>
+
+## API
+
+### ColorSwatch
+
+<Component components={props.data.mdx.components} componentName="colorswatch" />
+
+<PropSheet components={props.data.mdx.components} componentName="colorswatch" />
+
+### ColorSwatchDialog
+
+<Component components={props.data.mdx.components} componentName="colorswatchdialog" />
+
+<PropSheet components={props.data.mdx.components} componentName="colorswatchdialog" />
+
+import { graphql } from 'gatsby';
+
+export const pageQuery = graphql`
+  query ($fileAbsolutePath: String) {
+    ...SidebarPageFragment
+  }
+`;

--- a/src/pages/components/color-swatch.mdx
+++ b/src/pages/components/color-swatch.mdx
@@ -52,7 +52,7 @@ import ColorSwatchCustomTriggerCode from '!!raw-loader!../../examples/color-swat
 
 ### Dialog
 
-The Color swatch can be placed inside a dialog.
+The Color swatch can be shown inside a dialog using `<ColorSwatchDialog>`.
 
 import ColorSwatchDialog from '../../examples/color-swatch/ColorSwatchDialog.tsx';
 import ColorSwatchDialogCode from '!!raw-loader!../../examples/color-swatch/ColorSwatchDialog.tsx';


### PR DESCRIPTION
## Description

This pull request adds the color swatch documentation page to the website.

## Checklist

- [ ] :ok_hand: website updates are Garden Designer approved (add the designer as a reviewer)
- [ ] :black_nib: copy updates are approved (add the content strategist as a reviewer)
- [x] :link: considered opportunities for adding cross-reference URLs (grep for keywords)
- [x] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
