### PR TITLE
chore(docs): Add a note about IME support to Dropdowns

### DIFF
--- a/src/fragments/dropdowns-filtering-notes.mdx
+++ b/src/fragments/dropdowns-filtering-notes.mdx
@@ -6,5 +6,6 @@
 
 - The dropdowns package does not have filtering logic. The simplest way to include filtering is to control
   the `inputValue` and `onInputValueChange` props, and conditionally render Item components as necessary.
+- Use the `onInputValueChange` prop instead of `onStateChange`, for more accurate IME support
 - There is a known [issue](https://github.com/facebook/react/issues/11538#issuecomment-390386520) with
   Google Translate. As a workaround, wrap any conditionally rendered text node with a `span` element.

--- a/src/fragments/dropdowns-filtering-notes.mdx
+++ b/src/fragments/dropdowns-filtering-notes.mdx
@@ -6,6 +6,6 @@
 
 - The dropdowns package does not have filtering logic. The simplest way to include filtering is to control
   the `inputValue` and `onInputValueChange` props, and conditionally render Item components as necessary.
-- Use the `onInputValueChange` prop instead of `onStateChange`, for more accurate IME support
+- Use the `onInputValueChange` prop instead of or in combination with `onStateChange`, for more accurate IME support
 - There is a known [issue](https://github.com/facebook/react/issues/11538#issuecomment-390386520) with
   Google Translate. As a workaround, wrap any conditionally rendered text node with a `span` element.

--- a/src/fragments/dropdowns-filtering-notes.mdx
+++ b/src/fragments/dropdowns-filtering-notes.mdx
@@ -6,7 +6,7 @@
 
 - The dropdowns package does not have filtering logic. The simplest way to include filtering is to control
   the `inputValue` and `onInputValueChange` props, and conditionally render Item components as necessary.
-- Use the `onInputValueChange` prop instead of or in combination with `onStateChange`, for more accurate IME
+- Use the `onInputValueChange` prop instead of or in combination with `onStateChange` for more accurate IME
   (Input Method Editor) support
 - There is a known [issue](https://github.com/facebook/react/issues/11538#issuecomment-390386520) with
   Google Translate. As a workaround, wrap any conditionally rendered text node with a `span` element.

--- a/src/fragments/dropdowns-filtering-notes.mdx
+++ b/src/fragments/dropdowns-filtering-notes.mdx
@@ -6,6 +6,7 @@
 
 - The dropdowns package does not have filtering logic. The simplest way to include filtering is to control
   the `inputValue` and `onInputValueChange` props, and conditionally render Item components as necessary.
-- Use the `onInputValueChange` prop instead of or in combination with `onStateChange`, for more accurate IME support
+- Use the `onInputValueChange` prop instead of or in combination with `onStateChange`, for more accurate IME
+  (Input Method Editor) support
 - There is a known [issue](https://github.com/facebook/react/issues/11538#issuecomment-390386520) with
   Google Translate. As a workaround, wrap any conditionally rendered text node with a `span` element.


### PR DESCRIPTION
## Description

Added a note to the Dropdown implementation notes, keeping in line with IME issues encountered historically when the `onStateChange` prop was used and resolved by replacing with `onInputValueChange` prop instead to update internal state. All examples in Dropdowns have already been updated to replace `onStateChange` usage with `onInputValueChange`.

## Checklist

- [ ] ~~:ok_hand: design updates are Garden Designer approved (add the
      designer as a reviewer)~~
- [ ] ~~:globe_with_meridians: demo is up-to-date (`yarn start`)~~
- [ ] ~~:arrow_left: renders as expected with reversed (RTL) direction~~
- [ ] ~~:metal: renders as expected with Bedrock CSS (`?bedrock`)~~
- [ ] ~~:wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver~~
- [ ] ~~:guardsman: includes new unit tests~~
- [ ] ~~:memo: tested in Chrome, Firefox, Safari, Edge, and IE11~~