### PR TITLE
fix(tables): extract overflow tooltip into a forwardRef

### DIFF
--- a/src/examples/table/TableOverflow.tsx
+++ b/src/examples/table/TableOverflow.tsx
@@ -5,8 +5,9 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import React from 'react';
+import React, { ButtonHTMLAttributes } from 'react';
 import { Dropdown, Trigger, Menu, Item } from '@zendeskgarden/react-dropdowns';
+import { Tooltip } from '@zendeskgarden/react-tooltips';
 import {
   Body,
   Cell,
@@ -17,14 +18,19 @@ import {
   Row,
   Table
 } from '@zendeskgarden/react-tables';
-import { Tooltip } from '@zendeskgarden/react-tooltips';
+
+const TooltipOverflowButton = React.forwardRef(
+  (props: ButtonHTMLAttributes<HTMLButtonElement>, ref: React.Ref<HTMLButtonElement>) => (
+    <Tooltip content={props['aria-label']} placement="start">
+      <OverflowButton ref={ref} {...props} />
+    </Tooltip>
+  )
+);
 
 const OverflowMenu = () => (
   <Dropdown>
     <Trigger>
-      <Tooltip content="Row actions">
-        <OverflowButton aria-label="row actions" />
-      </Tooltip>
+      <TooltipOverflowButton aria-label="Row actions" />
     </Trigger>
     <Menu
       placement="bottom-end"


### PR DESCRIPTION
## Description

A recent PR to document and improve table [overflow](https://github.com/zendeskgarden/website/pull/322) accessibility inadvertently diminished overflow menu behavior. This PR restores the [overflow](https://garden.zendesk.com/components/table#overflow) behavior.

## Detail

Thanks to @hzhu for a reminder re: React `forwardRef` needed to retain button functionality within a `Tooltip`.

## Checklist

- [ ] :ok_hand: ~website updates are Garden Designer approved (add the designer as a reviewer)~
- [ ] :black_nib: ~copy updates are approved (add the content strategist as a reviewer)~
- [ ] :link: ~considered opportunities for adding cross-reference URLs (grep for keywords)~
- [x] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [ ] :memo: ~tested in Chrome, Firefox, Safari, Edge, and IE11~
