### PR TITLE
feat(sheet): add documentation

### DIFF
--- a/src/examples/chrome/SheetDefault.tsx
+++ b/src/examples/chrome/SheetDefault.tsx
@@ -47,7 +47,6 @@ const Example = () => {
             <Toggle
               checked={isSheetOpen}
               onChange={() => setSheetOpen(!isSheetOpen)}
-              aria-expanded={isSheetOpen}
               aria-controls={sheetId}
             >
               <Label>Show Sheet</Label>
@@ -57,7 +56,13 @@ const Example = () => {
       </Row>
 
       <StyledRow justifyContent="end">
-        <Sheet id={sheetId} isOpen={isSheetOpen} focusOnMount restoreFocus>
+        <Sheet
+          id={sheetId}
+          isOpen={isSheetOpen}
+          focusOnMount
+          restoreFocus
+          aria-expanded={isSheetOpen}
+        >
           <Sheet.Header>
             <Sheet.Title>Garden</Sheet.Title>
             <Sheet.Description>Vegetables in the Garden</Sheet.Description>

--- a/src/examples/chrome/SheetDefault.tsx
+++ b/src/examples/chrome/SheetDefault.tsx
@@ -20,18 +20,16 @@ const StyledField = styled(Field)`
 const StyledRow = styled(Row)`
   border: ${props => props.theme.borderWidths.sm} dashed;
   border-color: ${props => getColor('neutralHue', 400, props.theme)};
+`;
 
+const StyledSheet = styled(Sheet)`
   ${props => mediaQuery('down', 'sm', props.theme)} {
-    & > aside {
-      box-sizing: content-box;
-      width: 100%;
-    }
+    width: 100%;
 
-    /* stylelint-disable */
-    & > aside > div {
+    /* sheet inner wrapper */
+    & > div {
       min-width: 100%;
     }
-    /* stylelint-enable */
   }
 `;
 
@@ -56,7 +54,7 @@ const Example = () => {
       </Row>
 
       <StyledRow justifyContent="end">
-        <Sheet
+        <StyledSheet
           id={sheetId}
           isOpen={isSheetOpen}
           focusOnMount
@@ -94,7 +92,7 @@ const Example = () => {
           </Sheet.Footer>
 
           <Sheet.Close onClick={() => setSheetOpen(false)} />
-        </Sheet>
+        </StyledSheet>
       </StyledRow>
     </Grid>
   );

--- a/src/examples/chrome/SheetDefault.tsx
+++ b/src/examples/chrome/SheetDefault.tsx
@@ -6,20 +6,44 @@
  */
 
 import React, { useState } from 'react';
+import styled from 'styled-components';
 import { Sheet } from '@zendeskgarden/react-chrome';
 import { Grid, Row, Col } from '@zendeskgarden/react-grid';
 import { Button } from '@zendeskgarden/react-buttons';
 import { Field, Toggle, Label } from '@zendeskgarden/react-forms';
+import { getColor, mediaQuery } from '@zendeskgarden/react-theming';
+
+const StyledField = styled(Field)`
+  margin: ${props => props.theme.space.md};
+`;
+
+const StyledRow = styled(Row)`
+  border: ${props => props.theme.borderWidths.sm} dashed;
+  border-color: ${props => getColor('neutralHue', 400, props.theme)};
+
+  ${props => mediaQuery('down', 'sm', props.theme)} {
+    & > aside {
+      box-sizing: content-box;
+      width: 100%;
+    }
+
+    /* stylelint-disable */
+    & > aside > div {
+      min-width: 100%;
+    }
+    /* stylelint-enable */
+  }
+`;
 
 const Example = () => {
   const [sheetId] = useState('sheet-example');
   const [isSheetOpen, setSheetOpen] = useState(true);
 
   return (
-    <Grid gutters={false} style={{ outline: '1px dotted gray' }}>
-      <Row style={{ height: '100%' }} justifyContent="between">
-        <Col size={4}>
-          <Field style={{ marginLeft: '20px', marginTop: '20px' }}>
+    <Grid gutters={false}>
+      <Row>
+        <Col>
+          <StyledField>
             <Toggle
               checked={isSheetOpen}
               onChange={() => setSheetOpen(!isSheetOpen)}
@@ -28,51 +52,45 @@ const Example = () => {
             >
               <Label>Show Sheet</Label>
             </Toggle>
-          </Field>
-        </Col>
-
-        <Col size={8}>
-          <div style={{ width: '100%', height: '500px', display: 'flex' }}>
-            {/* the div below represents main content sharing space with the Sheet in a container */}
-            <div style={{ flexGrow: 1 }} />
-
-            <Sheet id={sheetId} isOpen={isSheetOpen}>
-              <Sheet.Header>
-                <Sheet.Title>Garden</Sheet.Title>
-                <Sheet.Description>Vegetables in the Garden</Sheet.Description>
-              </Sheet.Header>
-
-              <Sheet.Body>
-                Shaved almonds soy milk black bean chili dip second course salad edamame apple
-                vinaigrette cremini mushrooms tofu mint with fiery fruit coconut sugar roasted
-                peanuts Thai dark and stormy banana crunchy seaweed sparkling pomegranate punch
-                summer blackberries strawberry spinach salad crispy Thai curry mediterranean
-                vegetables crumbled lentils. Apricot shiitake mushrooms seasonal rich coconut cream
-                ginger carrot spiced juice guacamole hot sandwiches burritos jalapeño four-layer
-                green tea overflowing berries pomegranate avocado basil pesto Thai super chili.
-                Blueberries casserole cumin picnic salad cherries heat miso turmeric glazed
-                aubergine vine tomatoes cool fig arugula cashew salad chia seeds homemade balsamic
-                sesame soba noodles. Corn amaranth salsify bunya nuts nori azuki bean chickweed
-                potato bell pepper artichoke. Nori grape silver beet broccoli kombu beet greens fava
-                bean potato
-              </Sheet.Body>
-
-              <Sheet.Footer>
-                <Sheet.FooterItem>
-                  <Button>Action</Button>
-                </Sheet.FooterItem>
-                <Sheet.FooterItem>
-                  <Button isPrimary onClick={() => setSheetOpen(false)}>
-                    Close
-                  </Button>
-                </Sheet.FooterItem>
-              </Sheet.Footer>
-
-              <Sheet.Close onClick={() => setSheetOpen(false)} />
-            </Sheet>
-          </div>
+          </StyledField>
         </Col>
       </Row>
+
+      <StyledRow justifyContent="end">
+        <Sheet id={sheetId} isOpen={isSheetOpen} focusOnMount restoreFocus>
+          <Sheet.Header>
+            <Sheet.Title>Garden</Sheet.Title>
+            <Sheet.Description>Vegetables in the Garden</Sheet.Description>
+          </Sheet.Header>
+
+          <Sheet.Body>
+            Shaved almonds soy milk black bean chili dip second course salad edamame apple
+            vinaigrette cremini mushrooms tofu mint with fiery fruit coconut sugar roasted peanuts
+            Thai dark and stormy banana crunchy seaweed sparkling pomegranate punch summer
+            blackberries strawberry spinach salad crispy Thai curry mediterranean vegetables
+            crumbled lentils. Apricot shiitake mushrooms seasonal rich coconut cream ginger carrot
+            spiced juice guacamole hot sandwiches burritos jalapeño four-layer green tea overflowing
+            berries pomegranate avocado basil pesto Thai super chili. Blueberries casserole cumin
+            picnic salad cherries heat miso turmeric glazed aubergine vine tomatoes cool fig arugula
+            cashew salad chia seeds homemade balsamic sesame soba noodles. Corn amaranth salsify
+            bunya nuts nori azuki bean chickweed potato bell pepper artichoke. Nori grape silver
+            beet broccoli kombu beet greens fava bean potato
+          </Sheet.Body>
+
+          <Sheet.Footer>
+            <Sheet.FooterItem>
+              <Button>Action</Button>
+            </Sheet.FooterItem>
+            <Sheet.FooterItem>
+              <Button isPrimary onClick={() => setSheetOpen(false)}>
+                Close
+              </Button>
+            </Sheet.FooterItem>
+          </Sheet.Footer>
+
+          <Sheet.Close onClick={() => setSheetOpen(false)} />
+        </Sheet>
+      </StyledRow>
     </Grid>
   );
 };

--- a/src/examples/chrome/SheetDefault.tsx
+++ b/src/examples/chrome/SheetDefault.tsx
@@ -1,0 +1,80 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import React, { useState } from 'react';
+import { Sheet } from '@zendeskgarden/react-chrome';
+import { Grid, Row, Col } from '@zendeskgarden/react-grid';
+import { Button } from '@zendeskgarden/react-buttons';
+import { Field, Toggle, Label } from '@zendeskgarden/react-forms';
+
+const Example = () => {
+  const [sheetId] = useState('sheet-example');
+  const [isSheetOpen, setSheetOpen] = useState(true);
+
+  return (
+    <Grid gutters={false} style={{ outline: '1px dotted gray' }}>
+      <Row style={{ height: '100%' }} justifyContent="between">
+        <Col size={4}>
+          <Field style={{ marginLeft: '20px', marginTop: '20px' }}>
+            <Toggle
+              checked={isSheetOpen}
+              onChange={() => setSheetOpen(!isSheetOpen)}
+              aria-expanded={isSheetOpen}
+              aria-controls={sheetId}
+            >
+              <Label>Show Sheet</Label>
+            </Toggle>
+          </Field>
+        </Col>
+
+        <Col size={8}>
+          <div style={{ width: '100%', height: '500px', display: 'flex' }}>
+            {/* the div below represents main content sharing space with the Sheet in a container */}
+            <div style={{ flexGrow: 1 }} />
+
+            <Sheet id={sheetId} isOpen={isSheetOpen}>
+              <Sheet.Header>
+                <Sheet.Title>Garden</Sheet.Title>
+                <Sheet.Description>Vegetables in the Garden</Sheet.Description>
+              </Sheet.Header>
+
+              <Sheet.Body>
+                Shaved almonds soy milk black bean chili dip second course salad edamame apple
+                vinaigrette cremini mushrooms tofu mint with fiery fruit coconut sugar roasted
+                peanuts Thai dark and stormy banana crunchy seaweed sparkling pomegranate punch
+                summer blackberries strawberry spinach salad crispy Thai curry mediterranean
+                vegetables crumbled lentils. Apricot shiitake mushrooms seasonal rich coconut cream
+                ginger carrot spiced juice guacamole hot sandwiches burritos jalapeño four-layer
+                green tea overflowing berries pomegranate avocado basil pesto Thai super chili.
+                Blueberries casserole cumin picnic salad cherries heat miso turmeric glazed
+                aubergine vine tomatoes cool fig arugula cashew salad chia seeds homemade balsamic
+                sesame soba noodles. Corn amaranth salsify bunya nuts nori azuki bean chickweed
+                potato bell pepper artichoke. Nori grape silver beet broccoli kombu beet greens fava
+                bean potato
+              </Sheet.Body>
+
+              <Sheet.Footer>
+                <Sheet.FooterItem>
+                  <Button>Action</Button>
+                </Sheet.FooterItem>
+                <Sheet.FooterItem>
+                  <Button isPrimary onClick={() => setSheetOpen(false)}>
+                    Close
+                  </Button>
+                </Sheet.FooterItem>
+              </Sheet.Footer>
+
+              <Sheet.Close onClick={() => setSheetOpen(false)} />
+            </Sheet>
+          </div>
+        </Col>
+      </Row>
+    </Grid>
+  );
+};
+
+export default Example;

--- a/src/examples/chrome/SheetFooters.tsx
+++ b/src/examples/chrome/SheetFooters.tsx
@@ -40,13 +40,25 @@ const StyledSheetFooterItem = styled(Sheet.FooterItem)`
 const Example = () => (
   <Row>
     <StyledCol sm={12} md={4} lg={4}>
-      <StyledSheet isOpen size="100%">
+      <StyledSheet
+        isOpen
+        size="100%"
+        aria-describedby=""
+        aria-labelledby=""
+        title="Sheet with no footer"
+      >
         <Sheet.Close />
       </StyledSheet>
     </StyledCol>
 
     <StyledCol sm={12} md={4} lg={4}>
-      <StyledSheet isOpen size="100%">
+      <StyledSheet
+        isOpen
+        size="100%"
+        aria-describedby=""
+        aria-labelledby=""
+        title="Sheet footer with an anchor"
+      >
         <Sheet.Body />
 
         <Sheet.Footer isCompact>
@@ -58,7 +70,13 @@ const Example = () => (
     </StyledCol>
 
     <StyledCol sm={12} md={4} lg={4}>
-      <StyledSheet isOpen size="100%">
+      <StyledSheet
+        isOpen
+        size="100%"
+        aria-describedby=""
+        aria-labelledby=""
+        title="Sheet footer with buttons"
+      >
         <Sheet.Body />
 
         <Sheet.Footer>

--- a/src/examples/chrome/SheetFooters.tsx
+++ b/src/examples/chrome/SheetFooters.tsx
@@ -36,7 +36,7 @@ const StyledSheet = styled(Sheet)`
 
 const StyledSheetFooterItem = styled(Sheet.FooterItem)`
   &:first-child {
-    margin-left: 0;
+    margin-${props => (props.theme.rtl ? 'right' : 'left')}: 0;
   }
 `;
 

--- a/src/examples/chrome/SheetFooters.tsx
+++ b/src/examples/chrome/SheetFooters.tsx
@@ -1,0 +1,66 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import React from 'react';
+import { Sheet } from '@zendeskgarden/react-chrome';
+import { Grid, Row, Col } from '@zendeskgarden/react-grid';
+import { Anchor, Button } from '@zendeskgarden/react-buttons';
+
+const surroundingBorder = '1px dotted gray';
+const surroundingBorderStyle = {
+  borderRight: surroundingBorder,
+  borderTop: surroundingBorder,
+  borderBottom: surroundingBorder
+};
+
+const Example = () => (
+  <Grid gutters="sm">
+    <Row style={{ height: '525px' }}>
+      <Col size={4}>
+        <Sheet isOpen size="100%" style={surroundingBorderStyle}>
+          <Sheet.Close />
+        </Sheet>
+      </Col>
+
+      <Col size={4}>
+        <Sheet isOpen size="100%" style={surroundingBorderStyle}>
+          {/* div element below emulates Sheet.Body in its absence */}
+          <div style={{ flexGrow: 1 }} />
+
+          <Sheet.Footer isCompact>
+            <Sheet.FooterItem>
+              <Anchor>Anchor</Anchor>
+            </Sheet.FooterItem>
+          </Sheet.Footer>
+
+          <Sheet.Close />
+        </Sheet>
+      </Col>
+
+      <Col size={4}>
+        <Sheet isOpen size="100%" style={surroundingBorderStyle}>
+          {/* div element below emulates Sheet.Body in its absence */}
+          <div style={{ flexGrow: 1 }} />
+
+          <Sheet.Footer>
+            {/* margin-left was set to 0 due to column width wrapping the two buttons */}
+            <Sheet.FooterItem style={{ marginLeft: '0' }}>
+              <Button>Action</Button>
+            </Sheet.FooterItem>
+            <Sheet.FooterItem>
+              <Button isPrimary>Close</Button>
+            </Sheet.FooterItem>
+          </Sheet.Footer>
+
+          <Sheet.Close />
+        </Sheet>
+      </Col>
+    </Row>
+  </Grid>
+);
+
+export default Example;

--- a/src/examples/chrome/SheetFooters.tsx
+++ b/src/examples/chrome/SheetFooters.tsx
@@ -39,7 +39,7 @@ const StyledSheetFooterItem = styled(Sheet.FooterItem)`
 
 const Example = () => (
   <Row>
-    <StyledCol sm={12} md={4} lg={4}>
+    <StyledCol md>
       <StyledSheet
         isOpen
         size="100%"
@@ -51,7 +51,7 @@ const Example = () => (
       </StyledSheet>
     </StyledCol>
 
-    <StyledCol sm={12} md={4} lg={4}>
+    <StyledCol md>
       <StyledSheet
         isOpen
         size="100%"
@@ -69,7 +69,7 @@ const Example = () => (
       </StyledSheet>
     </StyledCol>
 
-    <StyledCol sm={12} md={4} lg={4}>
+    <StyledCol md>
       <StyledSheet
         isOpen
         size="100%"

--- a/src/examples/chrome/SheetFooters.tsx
+++ b/src/examples/chrome/SheetFooters.tsx
@@ -40,25 +40,13 @@ const StyledSheetFooterItem = styled(Sheet.FooterItem)`
 const Example = () => (
   <Row>
     <StyledCol md>
-      <StyledSheet
-        isOpen
-        size="100%"
-        aria-describedby=""
-        aria-labelledby=""
-        title="Sheet with no footer"
-      >
+      <StyledSheet isOpen size="100%">
         <Sheet.Close />
       </StyledSheet>
     </StyledCol>
 
     <StyledCol md>
-      <StyledSheet
-        isOpen
-        size="100%"
-        aria-describedby=""
-        aria-labelledby=""
-        title="Sheet footer with an anchor"
-      >
+      <StyledSheet isOpen size="100%">
         <Sheet.Body />
 
         <Sheet.Footer isCompact>
@@ -70,13 +58,7 @@ const Example = () => (
     </StyledCol>
 
     <StyledCol md>
-      <StyledSheet
-        isOpen
-        size="100%"
-        aria-describedby=""
-        aria-labelledby=""
-        title="Sheet footer with buttons"
-      >
+      <StyledSheet isOpen size="100%">
         <Sheet.Body />
 
         <Sheet.Footer>

--- a/src/examples/chrome/SheetFooters.tsx
+++ b/src/examples/chrome/SheetFooters.tsx
@@ -12,11 +12,14 @@ import { Row, Col } from '@zendeskgarden/react-grid';
 import { Anchor, Button } from '@zendeskgarden/react-buttons';
 import { getColor, mediaQuery } from '@zendeskgarden/react-theming';
 
+const sheetHeight = 480;
+const condensedSheetHeight = 380;
+
 const StyledCol = styled(Col)`
-  height: ${props => props.theme.space.base * 120}px;
+  height: ${sheetHeight}px;
 
   ${props => mediaQuery('down', 'sm', props.theme)} {
-    height: ${props => props.theme.space.base * 80}px;
+    height: ${condensedSheetHeight}px;
 
     &:not(:last-child) {
       margin-bottom: ${props => props.theme.space.md};
@@ -25,9 +28,9 @@ const StyledCol = styled(Col)`
 `;
 
 const StyledSheet = styled(Sheet)`
-  border-top: ${props => props.theme.borderWidths.sm} dashed;
-  border-right: ${props => props.theme.borderWidths.sm} dashed;
-  border-bottom: ${props => props.theme.borderWidths.sm} dashed;
+  border: ${props => props.theme.borderWidths.sm} dashed;
+  ${props => (props.theme.rtl ? 'border-right' : 'border-left')}: ${props =>
+    props.theme.borderWidths.sm} solid;
   border-color: ${props => getColor('neutralHue', 400, props.theme)};
 `;
 

--- a/src/examples/chrome/SheetFooters.tsx
+++ b/src/examples/chrome/SheetFooters.tsx
@@ -6,61 +6,74 @@
  */
 
 import React from 'react';
+import styled from 'styled-components';
 import { Sheet } from '@zendeskgarden/react-chrome';
-import { Grid, Row, Col } from '@zendeskgarden/react-grid';
+import { Row, Col } from '@zendeskgarden/react-grid';
 import { Anchor, Button } from '@zendeskgarden/react-buttons';
+import { getColor, mediaQuery } from '@zendeskgarden/react-theming';
 
-const surroundingBorder = '1px dotted gray';
-const surroundingBorderStyle = {
-  borderRight: surroundingBorder,
-  borderTop: surroundingBorder,
-  borderBottom: surroundingBorder
-};
+const StyledCol = styled(Col)`
+  height: ${props => props.theme.space.base * 120}px;
+
+  ${props => mediaQuery('down', 'sm', props.theme)} {
+    height: ${props => props.theme.space.base * 80}px;
+
+    &:not(:last-child) {
+      margin-bottom: ${props => props.theme.space.md};
+    }
+  }
+`;
+
+const StyledSheet = styled(Sheet)`
+  border-top: ${props => props.theme.borderWidths.sm} dashed;
+  border-right: ${props => props.theme.borderWidths.sm} dashed;
+  border-bottom: ${props => props.theme.borderWidths.sm} dashed;
+  border-color: ${props => getColor('neutralHue', 400, props.theme)};
+`;
+
+const StyledSheetFooterItem = styled(Sheet.FooterItem)`
+  &:first-child {
+    margin-left: 0;
+  }
+`;
 
 const Example = () => (
-  <Grid gutters="sm">
-    <Row style={{ height: '525px' }}>
-      <Col size={4}>
-        <Sheet isOpen size="100%" style={surroundingBorderStyle}>
-          <Sheet.Close />
-        </Sheet>
-      </Col>
+  <Row>
+    <StyledCol sm={12} md={4} lg={4}>
+      <StyledSheet isOpen size="100%">
+        <Sheet.Close />
+      </StyledSheet>
+    </StyledCol>
 
-      <Col size={4}>
-        <Sheet isOpen size="100%" style={surroundingBorderStyle}>
-          {/* div element below emulates Sheet.Body in its absence */}
-          <div style={{ flexGrow: 1 }} />
+    <StyledCol sm={12} md={4} lg={4}>
+      <StyledSheet isOpen size="100%">
+        <Sheet.Body />
 
-          <Sheet.Footer isCompact>
-            <Sheet.FooterItem>
-              <Anchor>Anchor</Anchor>
-            </Sheet.FooterItem>
-          </Sheet.Footer>
+        <Sheet.Footer isCompact>
+          <Anchor>Anchor</Anchor>
+        </Sheet.Footer>
 
-          <Sheet.Close />
-        </Sheet>
-      </Col>
+        <Sheet.Close />
+      </StyledSheet>
+    </StyledCol>
 
-      <Col size={4}>
-        <Sheet isOpen size="100%" style={surroundingBorderStyle}>
-          {/* div element below emulates Sheet.Body in its absence */}
-          <div style={{ flexGrow: 1 }} />
+    <StyledCol sm={12} md={4} lg={4}>
+      <StyledSheet isOpen size="100%">
+        <Sheet.Body />
 
-          <Sheet.Footer>
-            {/* margin-left was set to 0 due to column width wrapping the two buttons */}
-            <Sheet.FooterItem style={{ marginLeft: '0' }}>
-              <Button>Action</Button>
-            </Sheet.FooterItem>
-            <Sheet.FooterItem>
-              <Button isPrimary>Close</Button>
-            </Sheet.FooterItem>
-          </Sheet.Footer>
+        <Sheet.Footer>
+          <StyledSheetFooterItem>
+            <Button>Action</Button>
+          </StyledSheetFooterItem>
+          <StyledSheetFooterItem>
+            <Button isPrimary>Close</Button>
+          </StyledSheetFooterItem>
+        </Sheet.Footer>
 
-          <Sheet.Close />
-        </Sheet>
-      </Col>
-    </Row>
-  </Grid>
+        <Sheet.Close />
+      </StyledSheet>
+    </StyledCol>
+  </Row>
 );
 
 export default Example;

--- a/src/examples/chrome/SheetFooters.tsx
+++ b/src/examples/chrome/SheetFooters.tsx
@@ -12,14 +12,11 @@ import { Row, Col } from '@zendeskgarden/react-grid';
 import { Anchor, Button } from '@zendeskgarden/react-buttons';
 import { getColor, mediaQuery } from '@zendeskgarden/react-theming';
 
-const sheetHeight = 480;
-const condensedSheetHeight = 380;
-
 const StyledCol = styled(Col)`
-  height: ${sheetHeight}px;
+  height: 480px;
 
   ${props => mediaQuery('down', 'sm', props.theme)} {
-    height: ${condensedSheetHeight}px;
+    height: 320px;
 
     &:not(:last-child) {
       margin-bottom: ${props => props.theme.space.md};

--- a/src/examples/chrome/SheetHeaders.tsx
+++ b/src/examples/chrome/SheetHeaders.tsx
@@ -33,13 +33,25 @@ const StyledSheet = styled(Sheet)`
 const Example = () => (
   <Row>
     <StyledCol sm={12} md={4} lg={4}>
-      <StyledSheet isOpen size="100%">
+      <StyledSheet
+        isOpen
+        size="100%"
+        aria-describedby=""
+        aria-labelledby=""
+        title="Sheet with no title"
+      >
         <Sheet.Close />
       </StyledSheet>
     </StyledCol>
 
     <StyledCol sm={12} md={4} lg={4}>
-      <StyledSheet isOpen size="100%">
+      <StyledSheet
+        isOpen
+        size="100%"
+        aria-describedby=""
+        aria-labelledby=""
+        title="Sheet with title"
+      >
         <Sheet.Header>
           <Sheet.Title>Heading</Sheet.Title>
         </Sheet.Header>
@@ -48,7 +60,13 @@ const Example = () => (
     </StyledCol>
 
     <StyledCol sm={12} md={4} lg={4}>
-      <StyledSheet isOpen size="100%">
+      <StyledSheet
+        isOpen
+        size="100%"
+        aria-describedby=""
+        aria-labelledby=""
+        title="Sheet with title and description"
+      >
         <Sheet.Header>
           <Sheet.Title>Heading</Sheet.Title>
           <Sheet.Description>Description</Sheet.Description>

--- a/src/examples/chrome/SheetHeaders.tsx
+++ b/src/examples/chrome/SheetHeaders.tsx
@@ -1,0 +1,50 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import React from 'react';
+import { Sheet } from '@zendeskgarden/react-chrome';
+import { Grid, Row, Col } from '@zendeskgarden/react-grid';
+
+const surroundingBorder = '1px dotted gray';
+const surroundingBorderStyle = {
+  borderRight: surroundingBorder,
+  borderTop: surroundingBorder,
+  borderBottom: surroundingBorder
+};
+
+const Example = () => (
+  <Grid gutters="sm">
+    <Row style={{ height: '525px' }}>
+      <Col size={4}>
+        <Sheet isOpen size="100%" style={surroundingBorderStyle}>
+          <Sheet.Close />
+        </Sheet>
+      </Col>
+
+      <Col size={4}>
+        <Sheet isOpen size="100%" style={surroundingBorderStyle}>
+          <Sheet.Header>
+            <Sheet.Title>Heading</Sheet.Title>
+          </Sheet.Header>
+          <Sheet.Close />
+        </Sheet>
+      </Col>
+
+      <Col size={4}>
+        <Sheet isOpen size="100%" style={surroundingBorderStyle}>
+          <Sheet.Header>
+            <Sheet.Title>Heading</Sheet.Title>
+            <Sheet.Description>Description</Sheet.Description>
+          </Sheet.Header>
+          <Sheet.Close />
+        </Sheet>
+      </Col>
+    </Row>
+  </Grid>
+);
+
+export default Example;

--- a/src/examples/chrome/SheetHeaders.tsx
+++ b/src/examples/chrome/SheetHeaders.tsx
@@ -11,11 +11,14 @@ import { Sheet } from '@zendeskgarden/react-chrome';
 import { Row, Col } from '@zendeskgarden/react-grid';
 import { getColor, mediaQuery } from '@zendeskgarden/react-theming';
 
+const sheetHeight = 480;
+const condensedSheetHeight = 380;
+
 const StyledCol = styled(Col)`
-  height: ${props => props.theme.space.base * 120}px;
+  height: ${sheetHeight}px;
 
   ${props => mediaQuery('down', 'sm', props.theme)} {
-    height: ${props => props.theme.space.base * 80}px;
+    height: ${condensedSheetHeight}px;
 
     &:not(:last-child) {
       margin-bottom: ${props => props.theme.space.md};
@@ -24,9 +27,9 @@ const StyledCol = styled(Col)`
 `;
 
 const StyledSheet = styled(Sheet)`
-  border-top: ${props => props.theme.borderWidths.sm} dashed;
-  border-right: ${props => props.theme.borderWidths.sm} dashed;
-  border-bottom: ${props => props.theme.borderWidths.sm} dashed;
+  border: ${props => props.theme.borderWidths.sm} dashed;
+  ${props => (props.theme.rtl ? 'border-right' : 'border-left')}: ${props =>
+    props.theme.borderWidths.sm} solid;
   border-color: ${props => getColor('neutralHue', 400, props.theme)};
 `;
 

--- a/src/examples/chrome/SheetHeaders.tsx
+++ b/src/examples/chrome/SheetHeaders.tsx
@@ -6,45 +6,57 @@
  */
 
 import React from 'react';
+import styled from 'styled-components';
 import { Sheet } from '@zendeskgarden/react-chrome';
-import { Grid, Row, Col } from '@zendeskgarden/react-grid';
+import { Row, Col } from '@zendeskgarden/react-grid';
+import { getColor, mediaQuery } from '@zendeskgarden/react-theming';
 
-const surroundingBorder = '1px dotted gray';
-const surroundingBorderStyle = {
-  borderRight: surroundingBorder,
-  borderTop: surroundingBorder,
-  borderBottom: surroundingBorder
-};
+const StyledCol = styled(Col)`
+  height: ${props => props.theme.space.base * 120}px;
+
+  ${props => mediaQuery('down', 'sm', props.theme)} {
+    height: ${props => props.theme.space.base * 80}px;
+
+    &:not(:last-child) {
+      margin-bottom: ${props => props.theme.space.md};
+    }
+  }
+`;
+
+const StyledSheet = styled(Sheet)`
+  border-top: ${props => props.theme.borderWidths.sm} dashed;
+  border-right: ${props => props.theme.borderWidths.sm} dashed;
+  border-bottom: ${props => props.theme.borderWidths.sm} dashed;
+  border-color: ${props => getColor('neutralHue', 400, props.theme)};
+`;
 
 const Example = () => (
-  <Grid gutters="sm">
-    <Row style={{ height: '525px' }}>
-      <Col size={4}>
-        <Sheet isOpen size="100%" style={surroundingBorderStyle}>
-          <Sheet.Close />
-        </Sheet>
-      </Col>
+  <Row>
+    <StyledCol sm={12} md={4} lg={4}>
+      <StyledSheet isOpen size="100%">
+        <Sheet.Close />
+      </StyledSheet>
+    </StyledCol>
 
-      <Col size={4}>
-        <Sheet isOpen size="100%" style={surroundingBorderStyle}>
-          <Sheet.Header>
-            <Sheet.Title>Heading</Sheet.Title>
-          </Sheet.Header>
-          <Sheet.Close />
-        </Sheet>
-      </Col>
+    <StyledCol sm={12} md={4} lg={4}>
+      <StyledSheet isOpen size="100%">
+        <Sheet.Header>
+          <Sheet.Title>Heading</Sheet.Title>
+        </Sheet.Header>
+        <Sheet.Close />
+      </StyledSheet>
+    </StyledCol>
 
-      <Col size={4}>
-        <Sheet isOpen size="100%" style={surroundingBorderStyle}>
-          <Sheet.Header>
-            <Sheet.Title>Heading</Sheet.Title>
-            <Sheet.Description>Description</Sheet.Description>
-          </Sheet.Header>
-          <Sheet.Close />
-        </Sheet>
-      </Col>
-    </Row>
-  </Grid>
+    <StyledCol sm={12} md={4} lg={4}>
+      <StyledSheet isOpen size="100%">
+        <Sheet.Header>
+          <Sheet.Title>Heading</Sheet.Title>
+          <Sheet.Description>Description</Sheet.Description>
+        </Sheet.Header>
+        <Sheet.Close />
+      </StyledSheet>
+    </StyledCol>
+  </Row>
 );
 
 export default Example;

--- a/src/examples/chrome/SheetHeaders.tsx
+++ b/src/examples/chrome/SheetHeaders.tsx
@@ -11,14 +11,11 @@ import { Sheet } from '@zendeskgarden/react-chrome';
 import { Row, Col } from '@zendeskgarden/react-grid';
 import { getColor, mediaQuery } from '@zendeskgarden/react-theming';
 
-const sheetHeight = 480;
-const condensedSheetHeight = 380;
-
 const StyledCol = styled(Col)`
-  height: ${sheetHeight}px;
+  height: 480px;
 
   ${props => mediaQuery('down', 'sm', props.theme)} {
-    height: ${condensedSheetHeight}px;
+    height: 320px;
 
     &:not(:last-child) {
       margin-bottom: ${props => props.theme.space.md};

--- a/src/examples/chrome/SheetHeaders.tsx
+++ b/src/examples/chrome/SheetHeaders.tsx
@@ -33,25 +33,13 @@ const StyledSheet = styled(Sheet)`
 const Example = () => (
   <Row>
     <StyledCol md>
-      <StyledSheet
-        isOpen
-        size="100%"
-        aria-describedby=""
-        aria-labelledby=""
-        title="Sheet with no title"
-      >
+      <StyledSheet isOpen size="100%">
         <Sheet.Close />
       </StyledSheet>
     </StyledCol>
 
     <StyledCol md>
-      <StyledSheet
-        isOpen
-        size="100%"
-        aria-describedby=""
-        aria-labelledby=""
-        title="Sheet with title"
-      >
+      <StyledSheet isOpen size="100%">
         <Sheet.Header>
           <Sheet.Title>Heading</Sheet.Title>
         </Sheet.Header>
@@ -60,13 +48,7 @@ const Example = () => (
     </StyledCol>
 
     <StyledCol md>
-      <StyledSheet
-        isOpen
-        size="100%"
-        aria-describedby=""
-        aria-labelledby=""
-        title="Sheet with title and description"
-      >
+      <StyledSheet isOpen size="100%">
         <Sheet.Header>
           <Sheet.Title>Heading</Sheet.Title>
           <Sheet.Description>Description</Sheet.Description>

--- a/src/examples/chrome/SheetHeaders.tsx
+++ b/src/examples/chrome/SheetHeaders.tsx
@@ -32,7 +32,7 @@ const StyledSheet = styled(Sheet)`
 
 const Example = () => (
   <Row>
-    <StyledCol sm={12} md={4} lg={4}>
+    <StyledCol md>
       <StyledSheet
         isOpen
         size="100%"
@@ -44,7 +44,7 @@ const Example = () => (
       </StyledSheet>
     </StyledCol>
 
-    <StyledCol sm={12} md={4} lg={4}>
+    <StyledCol md>
       <StyledSheet
         isOpen
         size="100%"
@@ -59,7 +59,7 @@ const Example = () => (
       </StyledSheet>
     </StyledCol>
 
-    <StyledCol sm={12} md={4} lg={4}>
+    <StyledCol md>
       <StyledSheet
         isOpen
         size="100%"

--- a/src/examples/chrome/SheetPlacement.tsx
+++ b/src/examples/chrome/SheetPlacement.tsx
@@ -56,8 +56,8 @@ const Example = () => {
       <StyledRow justifyContent={placement}>
         <StyledSheet isOpen placement={placement}>
           <Sheet.Header>
-            <Sheet.Title>Placement</Sheet.Title>
-            <Sheet.Description>From side to side</Sheet.Description>
+            <Sheet.Title>Garden</Sheet.Title>
+            <Sheet.Description>Vegetables in the Garden</Sheet.Description>
           </Sheet.Header>
 
           <Sheet.Body>

--- a/src/examples/chrome/SheetPlacement.tsx
+++ b/src/examples/chrome/SheetPlacement.tsx
@@ -46,8 +46,8 @@ const Example = () => {
         <Col sm={3} md={4} lg={7}>
           <Sheet isOpen placement={placement} size="100%">
             <Sheet.Header>
-              <Sheet.Title>Garden</Sheet.Title>
-              <Sheet.Description>Vegetables in the Garden</Sheet.Description>
+              <Sheet.Title>Placement</Sheet.Title>
+              <Sheet.Description>From side to side</Sheet.Description>
             </Sheet.Header>
 
             <Sheet.Body>

--- a/src/examples/chrome/SheetPlacement.tsx
+++ b/src/examples/chrome/SheetPlacement.tsx
@@ -1,0 +1,80 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import React, { useState } from 'react';
+import { Sheet } from '@zendeskgarden/react-chrome';
+import { Grid, Row, Col } from '@zendeskgarden/react-grid';
+import { Button } from '@zendeskgarden/react-buttons';
+import { Field, Toggle, Label } from '@zendeskgarden/react-forms';
+
+const Example = () => {
+  const [placement, setSheetPlacement] = useState<'start' | 'end' | undefined>('start');
+  const toggleSheetPlacement = () => {
+    if (placement === 'end') setSheetPlacement('start');
+    if (placement === 'start') setSheetPlacement('end');
+  };
+
+  return (
+    <Grid gutters={false}>
+      <Row style={{ marginBottom: '20px' }}>
+        <Col>
+          <Field>
+            <Toggle checked={placement === 'start'} onChange={toggleSheetPlacement}>
+              <Label>Place at start of container</Label>
+            </Toggle>
+          </Field>
+        </Col>
+      </Row>
+
+      <Row style={{ outline: '1px dotted gray' }}>
+        <Col size={12}>
+          <div
+            style={{
+              width: '100%',
+              height: '415px',
+              display: 'flex',
+              justifyContent: placement === 'end' ? 'flex-end' : 'flex-start'
+            }}
+          >
+            <Sheet isOpen placement={placement}>
+              <Sheet.Header>
+                <Sheet.Title>Garden</Sheet.Title>
+                <Sheet.Description>Vegetables in the Garden</Sheet.Description>
+              </Sheet.Header>
+
+              <Sheet.Body>
+                Shaved almonds soy milk black bean chili dip second course salad edamame apple
+                vinaigrette cremini mushrooms tofu mint with fiery fruit coconut sugar roasted
+                peanuts Thai dark and stormy banana crunchy seaweed sparkling pomegranate punch
+                summer blackberries strawberry spinach salad crispy Thai curry mediterranean
+                vegetables crumbled lentils. Apricot shiitake mushrooms seasonal rich coconut cream
+                ginger carrot spiced juice guacamole hot sandwiches burritos jalapeño four-layer
+                green tea overflowing berries pomegranate avocado basil pesto Thai super chili.
+                Blueberries casserole cumin picnic salad cherries heat miso turmeric glazed
+                aubergine vine tomatoes cool fig arugula cashew salad chia seeds homemade balsamic
+                sesame soba noodles. Corn amaranth salsify bunya nuts nori azuki bean chickweed
+                potato bell pepper artichoke. Nori grape silver beet broccoli kombu beet greens fava
+                bean potato
+              </Sheet.Body>
+
+              <Sheet.Footer>
+                <Sheet.FooterItem>
+                  <Button>Basic</Button>
+                </Sheet.FooterItem>
+                <Sheet.FooterItem>
+                  <Button isPrimary>Primary</Button>
+                </Sheet.FooterItem>
+              </Sheet.Footer>
+            </Sheet>
+          </div>
+        </Col>
+      </Row>
+    </Grid>
+  );
+};
+
+export default Example;

--- a/src/examples/chrome/SheetPlacement.tsx
+++ b/src/examples/chrome/SheetPlacement.tsx
@@ -24,7 +24,7 @@ const StyledRow = styled(Row)`
 
 const StyledSheet = styled(Sheet)`
   ${props => mediaQuery('down', 'sm', props.theme)} {
-    width: 100%;
+    width: 90%;
 
     /* sheet inner wrapper */
     & > div {
@@ -34,7 +34,7 @@ const StyledSheet = styled(Sheet)`
 `;
 
 const Example = () => {
-  const [placement, setSheetPlacement] = useState<'start' | 'end' | undefined>('start');
+  const [placement, setSheetPlacement] = useState<'start' | 'end'>('start');
 
   const toggleSheetPlacement = useCallback(() => {
     if (placement === 'end') setSheetPlacement('start');

--- a/src/examples/chrome/SheetPlacement.tsx
+++ b/src/examples/chrome/SheetPlacement.tsx
@@ -11,7 +11,7 @@ import { Sheet } from '@zendeskgarden/react-chrome';
 import { Grid, Row, Col } from '@zendeskgarden/react-grid';
 import { Button } from '@zendeskgarden/react-buttons';
 import { Field, Toggle, Label } from '@zendeskgarden/react-forms';
-import { getColor } from '@zendeskgarden/react-theming';
+import { getColor, mediaQuery } from '@zendeskgarden/react-theming';
 
 const StyledField = styled(Field)`
   margin: ${props => props.theme.space.md};
@@ -20,6 +20,17 @@ const StyledField = styled(Field)`
 const StyledRow = styled(Row)`
   border: ${props => props.theme.borderWidths.sm} dashed;
   border-color: ${props => getColor('neutralHue', 400, props.theme)};
+`;
+
+const StyledSheet = styled(Sheet)`
+  ${props => mediaQuery('down', 'sm', props.theme)} {
+    width: 100%;
+
+    /* sheet inner wrapper */
+    & > div {
+      min-width: 100%;
+    }
+  }
 `;
 
 const Example = () => {
@@ -43,37 +54,35 @@ const Example = () => {
       </Row>
 
       <StyledRow justifyContent={placement}>
-        <Col sm={3} md={4} lg={7}>
-          <Sheet isOpen placement={placement} size="100%">
-            <Sheet.Header>
-              <Sheet.Title>Placement</Sheet.Title>
-              <Sheet.Description>From side to side</Sheet.Description>
-            </Sheet.Header>
+        <StyledSheet isOpen placement={placement}>
+          <Sheet.Header>
+            <Sheet.Title>Placement</Sheet.Title>
+            <Sheet.Description>From side to side</Sheet.Description>
+          </Sheet.Header>
 
-            <Sheet.Body>
-              Shaved almonds soy milk black bean chili dip second course salad edamame apple
-              vinaigrette cremini mushrooms tofu mint with fiery fruit coconut sugar roasted peanuts
-              Thai dark and stormy banana crunchy seaweed sparkling pomegranate punch summer
-              blackberries strawberry spinach salad crispy Thai curry mediterranean vegetables
-              crumbled lentils. Apricot shiitake mushrooms seasonal rich coconut cream ginger carrot
-              spiced juice guacamole hot sandwiches burritos jalapeño four-layer green tea
-              overflowing berries pomegranate avocado basil pesto Thai super chili. Blueberries
-              casserole cumin picnic salad cherries heat miso turmeric glazed aubergine vine
-              tomatoes cool fig arugula cashew salad chia seeds homemade balsamic sesame soba
-              noodles. Corn amaranth salsify bunya nuts nori azuki bean chickweed potato bell pepper
-              artichoke. Nori grape silver beet broccoli kombu beet greens fava bean potato
-            </Sheet.Body>
+          <Sheet.Body>
+            Shaved almonds soy milk black bean chili dip second course salad edamame apple
+            vinaigrette cremini mushrooms tofu mint with fiery fruit coconut sugar roasted peanuts
+            Thai dark and stormy banana crunchy seaweed sparkling pomegranate punch summer
+            blackberries strawberry spinach salad crispy Thai curry mediterranean vegetables
+            crumbled lentils. Apricot shiitake mushrooms seasonal rich coconut cream ginger carrot
+            spiced juice guacamole hot sandwiches burritos jalapeño four-layer green tea overflowing
+            berries pomegranate avocado basil pesto Thai super chili. Blueberries casserole cumin
+            picnic salad cherries heat miso turmeric glazed aubergine vine tomatoes cool fig arugula
+            cashew salad chia seeds homemade balsamic sesame soba noodles. Corn amaranth salsify
+            bunya nuts nori azuki bean chickweed potato bell pepper artichoke. Nori grape silver
+            beet broccoli kombu beet greens fava bean potato
+          </Sheet.Body>
 
-            <Sheet.Footer>
-              <Sheet.FooterItem>
-                <Button>Basic</Button>
-              </Sheet.FooterItem>
-              <Sheet.FooterItem>
-                <Button isPrimary>Primary</Button>
-              </Sheet.FooterItem>
-            </Sheet.Footer>
-          </Sheet>
-        </Col>
+          <Sheet.Footer>
+            <Sheet.FooterItem>
+              <Button>Basic</Button>
+            </Sheet.FooterItem>
+            <Sheet.FooterItem>
+              <Button isPrimary>Primary</Button>
+            </Sheet.FooterItem>
+          </Sheet.Footer>
+        </StyledSheet>
       </StyledRow>
     </Grid>
   );

--- a/src/examples/chrome/SheetPlacement.tsx
+++ b/src/examples/chrome/SheetPlacement.tsx
@@ -5,74 +5,76 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import React, { useState } from 'react';
+import React, { useCallback, useState } from 'react';
+import styled from 'styled-components';
 import { Sheet } from '@zendeskgarden/react-chrome';
 import { Grid, Row, Col } from '@zendeskgarden/react-grid';
 import { Button } from '@zendeskgarden/react-buttons';
 import { Field, Toggle, Label } from '@zendeskgarden/react-forms';
+import { getColor } from '@zendeskgarden/react-theming';
+
+const StyledField = styled(Field)`
+  margin: ${props => props.theme.space.md};
+`;
+
+const StyledRow = styled(Row)`
+  border: ${props => props.theme.borderWidths.sm} dashed;
+  border-color: ${props => getColor('neutralHue', 400, props.theme)};
+`;
 
 const Example = () => {
   const [placement, setSheetPlacement] = useState<'start' | 'end' | undefined>('start');
-  const toggleSheetPlacement = () => {
+
+  const toggleSheetPlacement = useCallback(() => {
     if (placement === 'end') setSheetPlacement('start');
     if (placement === 'start') setSheetPlacement('end');
-  };
+  }, [placement]);
 
   return (
     <Grid gutters={false}>
-      <Row style={{ marginBottom: '20px' }}>
+      <Row>
         <Col>
-          <Field>
+          <StyledField>
             <Toggle checked={placement === 'start'} onChange={toggleSheetPlacement}>
               <Label>Place at start of container</Label>
             </Toggle>
-          </Field>
+          </StyledField>
         </Col>
       </Row>
 
-      <Row style={{ outline: '1px dotted gray' }}>
-        <Col size={12}>
-          <div
-            style={{
-              width: '100%',
-              height: '415px',
-              display: 'flex',
-              justifyContent: placement === 'end' ? 'flex-end' : 'flex-start'
-            }}
-          >
-            <Sheet isOpen placement={placement}>
-              <Sheet.Header>
-                <Sheet.Title>Garden</Sheet.Title>
-                <Sheet.Description>Vegetables in the Garden</Sheet.Description>
-              </Sheet.Header>
+      <StyledRow justifyContent={placement}>
+        <Col sm={3} md={4} lg={7}>
+          <Sheet isOpen placement={placement} size="100%">
+            <Sheet.Header>
+              <Sheet.Title>Garden</Sheet.Title>
+              <Sheet.Description>Vegetables in the Garden</Sheet.Description>
+            </Sheet.Header>
 
-              <Sheet.Body>
-                Shaved almonds soy milk black bean chili dip second course salad edamame apple
-                vinaigrette cremini mushrooms tofu mint with fiery fruit coconut sugar roasted
-                peanuts Thai dark and stormy banana crunchy seaweed sparkling pomegranate punch
-                summer blackberries strawberry spinach salad crispy Thai curry mediterranean
-                vegetables crumbled lentils. Apricot shiitake mushrooms seasonal rich coconut cream
-                ginger carrot spiced juice guacamole hot sandwiches burritos jalapeño four-layer
-                green tea overflowing berries pomegranate avocado basil pesto Thai super chili.
-                Blueberries casserole cumin picnic salad cherries heat miso turmeric glazed
-                aubergine vine tomatoes cool fig arugula cashew salad chia seeds homemade balsamic
-                sesame soba noodles. Corn amaranth salsify bunya nuts nori azuki bean chickweed
-                potato bell pepper artichoke. Nori grape silver beet broccoli kombu beet greens fava
-                bean potato
-              </Sheet.Body>
+            <Sheet.Body>
+              Shaved almonds soy milk black bean chili dip second course salad edamame apple
+              vinaigrette cremini mushrooms tofu mint with fiery fruit coconut sugar roasted peanuts
+              Thai dark and stormy banana crunchy seaweed sparkling pomegranate punch summer
+              blackberries strawberry spinach salad crispy Thai curry mediterranean vegetables
+              crumbled lentils. Apricot shiitake mushrooms seasonal rich coconut cream ginger carrot
+              spiced juice guacamole hot sandwiches burritos jalapeño four-layer green tea
+              overflowing berries pomegranate avocado basil pesto Thai super chili. Blueberries
+              casserole cumin picnic salad cherries heat miso turmeric glazed aubergine vine
+              tomatoes cool fig arugula cashew salad chia seeds homemade balsamic sesame soba
+              noodles. Corn amaranth salsify bunya nuts nori azuki bean chickweed potato bell pepper
+              artichoke. Nori grape silver beet broccoli kombu beet greens fava bean potato
+            </Sheet.Body>
 
-              <Sheet.Footer>
-                <Sheet.FooterItem>
-                  <Button>Basic</Button>
-                </Sheet.FooterItem>
-                <Sheet.FooterItem>
-                  <Button isPrimary>Primary</Button>
-                </Sheet.FooterItem>
-              </Sheet.Footer>
-            </Sheet>
-          </div>
+            <Sheet.Footer>
+              <Sheet.FooterItem>
+                <Button>Basic</Button>
+              </Sheet.FooterItem>
+              <Sheet.FooterItem>
+                <Button isPrimary>Primary</Button>
+              </Sheet.FooterItem>
+            </Sheet.Footer>
+          </Sheet>
         </Col>
-      </Row>
+      </StyledRow>
     </Grid>
   );
 };

--- a/src/examples/chrome/SheetSize.tsx
+++ b/src/examples/chrome/SheetSize.tsx
@@ -13,13 +13,6 @@ import { Button } from '@zendeskgarden/react-buttons';
 import { Fieldset, Field, Radio, Label } from '@zendeskgarden/react-forms';
 import { getColor } from '@zendeskgarden/react-theming';
 
-const [col4, col6, px380, px480] = [
-  { label: '4 columns', sheet: '100%', cols: 4 },
-  { label: '6 columns', sheet: '100%', cols: 6 },
-  { label: '380 pixels', sheet: '380px', cols: 'auto' },
-  { label: '480 pixels', sheet: '480px', cols: 'auto' }
-];
-
 const StyledFieldset = styled(Fieldset)`
   margin: ${props => props.theme.space.md};
 `;
@@ -35,6 +28,13 @@ const StyledSheetFooterItem = styled(Sheet.FooterItem)`
     margin-left: 0;
   }
 `;
+
+const [col4, col6, px380, px480] = [
+  { label: '4 columns', sheet: '100%', cols: 4 },
+  { label: '6 columns', sheet: '100%', cols: 6 },
+  { label: '380 pixels', sheet: '380px', cols: 'auto' },
+  { label: '480 pixels', sheet: '480px', cols: 'auto' }
+];
 
 const Example = () => {
   const [size, setSheetSize] =

--- a/src/examples/chrome/SheetSize.tsx
+++ b/src/examples/chrome/SheetSize.tsx
@@ -1,0 +1,83 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import React, { useState } from 'react';
+import { Sheet } from '@zendeskgarden/react-chrome';
+import { Grid, Row, Col } from '@zendeskgarden/react-grid';
+import { Button } from '@zendeskgarden/react-buttons';
+import { Fieldset, Field, Radio, Label } from '@zendeskgarden/react-forms';
+
+const [col4, col6, px380, px480] = ['4', '6', '380px', '480px'];
+
+const Example = () => {
+  const [size, setSheetSize] = useState(px380);
+
+  return (
+    <Grid gutters={false} style={{ outline: '1px dotted gray' }}>
+      <Row justifyContent="between">
+        <Col size="auto">
+          <Fieldset style={{ margin: '25px' }}>
+            <Fieldset.Legend>Sheet size</Fieldset.Legend>
+            {[col4, col6, px380, px480].map((sampleSize: string) => (
+              <Field key={`sizes-${sampleSize}`}>
+                <Radio
+                  name="default example"
+                  value={sampleSize}
+                  checked={size === sampleSize}
+                  onChange={() => setSheetSize(sampleSize)}
+                >
+                  <Label>
+                    {sampleSize} {sampleSize.endsWith('px') ? '' : 'columns'}
+                  </Label>
+                </Radio>
+              </Field>
+            ))}
+          </Fieldset>
+        </Col>
+
+        <Col size={size.endsWith('px') ? 9 : Number.parseInt(size, 10)}>
+          <div
+            style={{ width: '100%', height: '500px', display: 'flex', justifyContent: 'flex-end' }}
+          >
+            <Sheet isOpen size={size.endsWith('px') ? size : '100%'}>
+              <Sheet.Header>
+                <Sheet.Title>Garden</Sheet.Title>
+                <Sheet.Description>Vegetables in the Garden</Sheet.Description>
+              </Sheet.Header>
+
+              <Sheet.Body>
+                Shaved almonds soy milk black bean chili dip second course salad edamame apple
+                vinaigrette cremini mushrooms tofu mint with fiery fruit coconut sugar roasted
+                peanuts Thai dark and stormy banana crunchy seaweed sparkling pomegranate punch
+                summer blackberries strawberry spinach salad crispy Thai curry mediterranean
+                vegetables crumbled lentils. Apricot shiitake mushrooms seasonal rich coconut cream
+                ginger carrot spiced juice guacamole hot sandwiches burritos jalapeño four-layer
+                green tea overflowing berries pomegranate avocado basil pesto Thai super chili.
+                Blueberries casserole cumin picnic salad cherries heat miso turmeric glazed
+                aubergine vine tomatoes cool fig arugula cashew salad chia seeds homemade balsamic
+                sesame soba noodles. Corn amaranth salsify bunya nuts nori azuki bean chickweed
+                potato bell pepper artichoke. Nori grape silver beet broccoli kombu beet greens fava
+                bean potato
+              </Sheet.Body>
+
+              <Sheet.Footer>
+                <Sheet.FooterItem style={{ marginLeft: 0 }}>
+                  <Button>Basic</Button>
+                </Sheet.FooterItem>
+                <Sheet.FooterItem>
+                  <Button isPrimary>Primary</Button>
+                </Sheet.FooterItem>
+              </Sheet.Footer>
+            </Sheet>
+          </div>
+        </Col>
+      </Row>
+    </Grid>
+  );
+};
+
+export default Example;

--- a/src/examples/chrome/SheetSize.tsx
+++ b/src/examples/chrome/SheetSize.tsx
@@ -61,8 +61,8 @@ const Example = () => {
         <Col size={size.cols}>
           <Sheet isOpen isAnimated={false} size={size.sheet}>
             <Sheet.Header>
-              <Sheet.Title>Garden</Sheet.Title>
-              <Sheet.Description>Vegetables in the Garden</Sheet.Description>
+              <Sheet.Title>Size</Sheet.Title>
+              <Sheet.Description>Sizing the Sheet</Sheet.Description>
             </Sheet.Header>
 
             <Sheet.Body>

--- a/src/examples/chrome/SheetSize.tsx
+++ b/src/examples/chrome/SheetSize.tsx
@@ -61,8 +61,8 @@ const Example = () => {
         <Col size={size.cols}>
           <Sheet isOpen isAnimated={false} size={size.sheet}>
             <Sheet.Header>
-              <Sheet.Title>Size</Sheet.Title>
-              <Sheet.Description>Sizing the Sheet</Sheet.Description>
+              <Sheet.Title>Garden</Sheet.Title>
+              <Sheet.Description>Vegetables in the Garden</Sheet.Description>
             </Sheet.Header>
 
             <Sheet.Body>

--- a/src/examples/chrome/SheetSize.tsx
+++ b/src/examples/chrome/SheetSize.tsx
@@ -6,76 +6,90 @@
  */
 
 import React, { useState } from 'react';
+import styled from 'styled-components';
 import { Sheet } from '@zendeskgarden/react-chrome';
 import { Grid, Row, Col } from '@zendeskgarden/react-grid';
 import { Button } from '@zendeskgarden/react-buttons';
 import { Fieldset, Field, Radio, Label } from '@zendeskgarden/react-forms';
+import { getColor } from '@zendeskgarden/react-theming';
 
-const [col4, col6, px380, px480] = ['4', '6', '380px', '480px'];
+const [col4, col6, px380, px480] = [
+  { label: '4 columns', sheet: '100%', cols: 4 },
+  { label: '6 columns', sheet: '100%', cols: 6 },
+  { label: '380 pixels', sheet: '380px', cols: 'auto' },
+  { label: '480 pixels', sheet: '480px', cols: 'auto' }
+];
+
+const StyledFieldset = styled(Fieldset)`
+  margin: ${props => props.theme.space.md};
+`;
+
+const StyledRow = styled(Row)`
+  border: ${props => props.theme.borderWidths.sm} dashed;
+  border-color: ${props => getColor('neutralHue', 400, props.theme)};
+  overflow: auto;
+`;
+
+const StyledSheetFooterItem = styled(Sheet.FooterItem)`
+  &:first-child {
+    margin-left: 0;
+  }
+`;
 
 const Example = () => {
-  const [size, setSheetSize] = useState(px380);
+  const [size, setSheetSize] =
+    useState<{ label: string; sheet: string; cols: string | number }>(px380);
 
   return (
-    <Grid gutters={false} style={{ outline: '1px dotted gray' }}>
-      <Row justifyContent="between">
-        <Col size="auto">
-          <Fieldset style={{ margin: '25px' }}>
-            <Fieldset.Legend>Sheet size</Fieldset.Legend>
-            {[col4, col6, px380, px480].map((sampleSize: string) => (
-              <Field key={`sizes-${sampleSize}`}>
-                <Radio
-                  name="default example"
-                  value={sampleSize}
-                  checked={size === sampleSize}
-                  onChange={() => setSheetSize(sampleSize)}
-                >
-                  <Label>
-                    {sampleSize} {sampleSize.endsWith('px') ? '' : 'columns'}
-                  </Label>
+    <Grid gutters={false}>
+      <Row>
+        <Col>
+          <StyledFieldset>
+            <StyledFieldset.Legend>Sheet size</StyledFieldset.Legend>
+            {[col4, col6, px380, px480].map(sampleSize => (
+              <Field key={`sizes-${sampleSize.label.replace(' ', '-')}`}>
+                <Radio checked={size === sampleSize} onChange={() => setSheetSize(sampleSize)}>
+                  <Label>{sampleSize.label}</Label>
                 </Radio>
               </Field>
             ))}
-          </Fieldset>
-        </Col>
-
-        <Col size={size.endsWith('px') ? 9 : Number.parseInt(size, 10)}>
-          <div
-            style={{ width: '100%', height: '500px', display: 'flex', justifyContent: 'flex-end' }}
-          >
-            <Sheet isOpen size={size.endsWith('px') ? size : '100%'}>
-              <Sheet.Header>
-                <Sheet.Title>Garden</Sheet.Title>
-                <Sheet.Description>Vegetables in the Garden</Sheet.Description>
-              </Sheet.Header>
-
-              <Sheet.Body>
-                Shaved almonds soy milk black bean chili dip second course salad edamame apple
-                vinaigrette cremini mushrooms tofu mint with fiery fruit coconut sugar roasted
-                peanuts Thai dark and stormy banana crunchy seaweed sparkling pomegranate punch
-                summer blackberries strawberry spinach salad crispy Thai curry mediterranean
-                vegetables crumbled lentils. Apricot shiitake mushrooms seasonal rich coconut cream
-                ginger carrot spiced juice guacamole hot sandwiches burritos jalapeño four-layer
-                green tea overflowing berries pomegranate avocado basil pesto Thai super chili.
-                Blueberries casserole cumin picnic salad cherries heat miso turmeric glazed
-                aubergine vine tomatoes cool fig arugula cashew salad chia seeds homemade balsamic
-                sesame soba noodles. Corn amaranth salsify bunya nuts nori azuki bean chickweed
-                potato bell pepper artichoke. Nori grape silver beet broccoli kombu beet greens fava
-                bean potato
-              </Sheet.Body>
-
-              <Sheet.Footer>
-                <Sheet.FooterItem style={{ marginLeft: 0 }}>
-                  <Button>Basic</Button>
-                </Sheet.FooterItem>
-                <Sheet.FooterItem>
-                  <Button isPrimary>Primary</Button>
-                </Sheet.FooterItem>
-              </Sheet.Footer>
-            </Sheet>
-          </div>
+          </StyledFieldset>
         </Col>
       </Row>
+
+      <StyledRow justifyContent="end">
+        <Col size={size.cols}>
+          <Sheet isOpen isAnimated={false} size={size.sheet}>
+            <Sheet.Header>
+              <Sheet.Title>Garden</Sheet.Title>
+              <Sheet.Description>Vegetables in the Garden</Sheet.Description>
+            </Sheet.Header>
+
+            <Sheet.Body>
+              Shaved almonds soy milk black bean chili dip second course salad edamame apple
+              vinaigrette cremini mushrooms tofu mint with fiery fruit coconut sugar roasted peanuts
+              Thai dark and stormy banana crunchy seaweed sparkling pomegranate punch summer
+              blackberries strawberry spinach salad crispy Thai curry mediterranean vegetables
+              crumbled lentils. Apricot shiitake mushrooms seasonal rich coconut cream ginger carrot
+              spiced juice guacamole hot sandwiches burritos jalapeño four-layer green tea
+              overflowing berries pomegranate avocado basil pesto Thai super chili. Blueberries
+              casserole cumin picnic salad cherries heat miso turmeric glazed aubergine vine
+              tomatoes cool fig arugula cashew salad chia seeds homemade balsamic sesame soba
+              noodles. Corn amaranth salsify bunya nuts nori azuki bean chickweed potato bell pepper
+              artichoke. Nori grape silver beet broccoli kombu beet greens fava bean potato
+            </Sheet.Body>
+
+            <Sheet.Footer>
+              <StyledSheetFooterItem>
+                <Button>Basic</Button>
+              </StyledSheetFooterItem>
+              <StyledSheetFooterItem>
+                <Button isPrimary>Primary</Button>
+              </StyledSheetFooterItem>
+            </Sheet.Footer>
+          </Sheet>
+        </Col>
+      </StyledRow>
     </Grid>
   );
 };

--- a/src/nav/components.yml
+++ b/src/nav/components.yml
@@ -48,8 +48,6 @@
           title: Toggle icon button
     - title: Chrome
       id: /components/chrome
-    - title: Sheet
-      id: /components/sheet
     - title: Date picker
       id: /components/date-picker
     - title: Color picker
@@ -116,6 +114,8 @@
           title: Notifications
     - title: Pagination
       id: /components/pagination
+    - title: Sheet
+      id: /components/sheet
     - title: Stepper
       id: /components/stepper
     - title: Table

--- a/src/nav/components.yml
+++ b/src/nav/components.yml
@@ -48,6 +48,8 @@
           title: Toggle icon button
     - title: Chrome
       id: /components/chrome
+    - title: Sheet
+      id: /components/sheet
     - title: Date picker
       id: /components/date-picker
     - title: Color picker

--- a/src/pages/components/sheet.mdx
+++ b/src/pages/components/sheet.mdx
@@ -23,8 +23,10 @@ components:
   <Misuse>
     <ul>
       <li>
-        For an experience where the primary view is obscured to display supplementary information or
-        actions, use a [Drawer](components/drawer)
+        <Markdown>
+          For an experience where the primary view is obscured to display supplementary information
+          or actions, use a [Drawer](/components/drawer)
+        </Markdown>
       </li>
     </ul>
   </Misuse>

--- a/src/pages/components/sheet.mdx
+++ b/src/pages/components/sheet.mdx
@@ -162,8 +162,8 @@ Nest it within a [Header](#sheetheader) component.
 
 <Component components={props.data.mdx.subcomponents} componentName="sheet.header" />
 
-Nest a Header within the [Sheet](#sheet) component. If neither [Title][#sheettitle] nor
-[Description][#sheetdescription] are used, the Header should be omitted.
+Nest a Header within the [Sheet](#sheet) component. If neither [Title](#sheettitle) nor
+[Description](#sheetdescription) are used, the Header should be omitted.
 
 <PropSheet components={props.data.mdx.subcomponents} componentName="sheet.header" />
 

--- a/src/pages/components/sheet.mdx
+++ b/src/pages/components/sheet.mdx
@@ -1,0 +1,169 @@
+---
+title: Sheet
+description: >
+  The Sheet component is a container that acts as a supplementary view, providing access to important contextual information.
+package: '@zendeskgarden/react-chrome'
+components:
+  - chrome/src/elements/sheet/Sheet.tsx
+  - chrome/src/elements/sheet/components/Body.tsx
+  - chrome/src/elements/sheet/components/Title.tsx
+  - chrome/src/elements/sheet/components/Description.tsx
+  - chrome/src/elements/sheet/components/Header.tsx
+  - chrome/src/elements/sheet/components/Footer.tsx
+  - chrome/src/elements/sheet/components/FooterItem.tsx
+  - chrome/src/elements/sheet/components/Close.tsx
+---
+
+<Usage>
+  <Use>
+    <ul>
+      <li>To display additional information that aids the primary view</li>
+    </ul>
+  </Use>
+  <Misuse>
+    <ul>
+      <li>
+        For an experience where the primary view is obscured to display supplementary information or
+        actions, use a [Drawer](components/drawer)
+      </li>
+    </ul>
+  </Misuse>
+</Usage>
+
+## How to use it
+
+### Default
+
+A typical usage of a Sheet component.
+
+import SheetDefault from '../../examples/chrome/SheetDefault.tsx';
+import SheetDefaultCode from '!!raw-loader!../../examples/chrome/SheetDefault.tsx';
+
+<CodeExample code={SheetDefaultCode}>
+  <SheetDefault />
+</CodeExample>
+
+### Footers
+
+Sheet footers comes in three variations: no footer, footer with an [Anchor](components/anchor),
+and footer with [Buttons](components/button).
+
+import SheetFooters from '../../examples/chrome/SheetFooters.tsx';
+import SheetFootersCode from '!!raw-loader!../../examples/chrome/SheetFooters.tsx';
+
+<CodeExample code={SheetFootersCode}>
+  <SheetFooters />
+</CodeExample>
+
+### Headers
+
+Sheet headers come in three variations: no title, title, and title with description.
+
+import SheetHeaders from '../../examples/chrome/SheetHeaders.tsx';
+import SheetHeadersCode from '!!raw-loader!../../examples/chrome/SheetHeaders.tsx';
+
+<CodeExample code={SheetHeadersCode}>
+  <SheetHeaders />
+</CodeExample>
+
+### Placement
+
+Sheets can be placed at the start or end of the container. End is the default placement.
+
+import SheetPlacement from '../../examples/chrome/SheetPlacement.tsx';
+import SheetPlacementCode from '!!raw-loader!../../examples/chrome/SheetPlacement.tsx';
+
+<CodeExample code={SheetPlacementCode}>
+  <SheetPlacement />
+</CodeExample>
+
+### Size
+
+Sheets default to 380px in width. You can customise the width based on your intended
+sexperience to any size using pixels or our grid system.
+
+import SheetSize from '../../examples/chrome/SheetSize.tsx';
+import SheetSizeCode from '!!raw-loader!../../examples/chrome/SheetSize.tsx';
+
+<CodeExample code={SheetSizeCode}>
+  <SheetSize />
+</CodeExample>
+
+## API
+
+### Sheet
+
+<Component components={props.data.mdx.components} componentName="sheet" />
+
+The Sheet component provides state and accessibility attributes to its children.
+
+<PropSheet components={props.data.mdx.components} componentName="sheet" />
+
+### Sheet.Body
+
+The Sheet Body component is placed in the [`Sheet`](#sheet) component.
+This component requires accessible functionality to make the
+element focusable, if keyboard scrolling is needed.
+
+<Component components={props.data.mdx.components} componentName="sheet.body" />
+
+<PropSheet components={props.data.mdx.components} componentName="sheet.body" />
+
+### Sheet.Title
+
+The Sheet Title labels the Sheet for assistive technology.
+This component is nested in the [`Sheet.Header`](#sheetheader) component.
+
+<Component components={props.data.mdx.components} componentName="sheet.title" />
+
+<PropSheet components={props.data.mdx.components} componentName="sheet.title" />
+
+### Sheet.Description
+
+The Sheet Description describes the Sheet for assistive technology.
+This component is nested in the [`Sheet.Header`](#sheetheader) component.
+
+<Component components={props.data.mdx.components} componentName="sheet.description" />
+
+<PropSheet components={props.data.mdx.components} componentName="sheet.description" />
+
+### Sheet.Header
+
+The Sheet Header component is placed in the [`Sheet`](#sheet) component.
+
+<Component components={props.data.mdx.components} componentName="sheet.header" />
+
+<PropSheet components={props.data.mdx.components} componentName="sheet.header" />
+
+### Sheet.Footer
+
+The Sheet Footer component is placed in the [`Sheet`](#sheet) component.
+The component can alternate to compact styling.
+
+<Component components={props.data.mdx.components} componentName="sheet.footer" />
+
+<PropSheet components={props.data.mdx.components} componentName="sheet.footer" />
+
+### Sheet.FooterItem
+
+The Sheet FooterItem component is nested in the [`Sheet.Footer`](#sheetfooter) component.
+
+<Component components={props.data.mdx.components} componentName="sheet.footeritem" />
+
+<PropSheet components={props.data.mdx.components} componentName="sheet.footeritem" />
+
+### Sheet.Close
+
+The Sheet Close button component is placed in the [`Sheet`](#sheet) component.
+
+<Component components={props.data.mdx.components} componentName="sheet.close" />
+
+<PropSheet components={props.data.mdx.components} componentName="sheet.close" />
+
+import { graphql } from 'gatsby';
+
+export const pageQuery = graphql`
+  query ($fileAbsolutePath: String) {
+    ...SidebarPageFragment
+  }
+`;

--- a/src/pages/components/sheet.mdx
+++ b/src/pages/components/sheet.mdx
@@ -47,8 +47,8 @@ import SheetDefaultCode from '!!raw-loader!../../examples/chrome/SheetDefault.ts
 
 ### Footers
 
-Sheet footers comes in three variations: no footer, footer with an [Anchor](components/anchor),
-and footer with [Buttons](components/button).
+Sheet footers comes in three variations: no footer, footer with an [Anchor](/components/anchor),
+and footer with [Buttons](/components/button).
 
 import SheetFooters from '../../examples/chrome/SheetFooters.tsx';
 import SheetFootersCode from '!!raw-loader!../../examples/chrome/SheetFooters.tsx';
@@ -82,7 +82,7 @@ import SheetPlacementCode from '!!raw-loader!../../examples/chrome/SheetPlacemen
 ### Size
 
 Sheets default to 380px in width. You can customise the width based on your intended
-experience to any size using pixels or our grid system.
+experience to any size using pixels or our [grid system](/components/grid).
 
 import SheetSize from '../../examples/chrome/SheetSize.tsx';
 import SheetSizeCode from '!!raw-loader!../../examples/chrome/SheetSize.tsx';
@@ -108,7 +108,7 @@ The Sheet component follows this structure:
   </Sheet.Header>
   
   <Sheet.Body>
-    {/* main content of the Sheet */}
+    {/* main content of the sheet */}
   </Sheet.Body>
 
   <Sheet.Footer>
@@ -125,15 +125,15 @@ The Sheet component follows this structure:
 
 <Component components={props.data.mdx.components} componentName="sheet" />
 
-The Sheet component provides state and accessibility attributes to its children.
+The `Sheet` component provides state and accessibility attributes to its children.
 
 <PropSheet components={props.data.mdx.components} componentName="sheet" />
 
 ### Sheet.Body
 
-The Sheet Body component is placed in the [`Sheet`](#sheet) component.
-This component requires accessible functionality to make the
-element focusable, if keyboard scrolling is needed.
+Nest `Sheet.Body` in the [`Sheet`](#sheet) component.
+`Sheet.Body` requires additional accessible functionality to make the
+element focusable for keyboard scrolling.
 
 <Component components={props.data.mdx.components} componentName="sheet.body" />
 
@@ -141,8 +141,8 @@ element focusable, if keyboard scrolling is needed.
 
 ### Sheet.Title
 
-The Sheet Title labels the Sheet for assistive technology.
-This component is nested in the [`Sheet.Header`](#sheetheader) component.
+`Sheet.Title` labels the Sheet for assistive technology.
+Nest `Sheet.Title` in the [`Sheet.Header`](#sheetheader) component.
 
 <Component components={props.data.mdx.components} componentName="sheet.title" />
 
@@ -150,8 +150,8 @@ This component is nested in the [`Sheet.Header`](#sheetheader) component.
 
 ### Sheet.Description
 
-The Sheet Description describes the Sheet for assistive technology.
-This component is nested in the [`Sheet.Header`](#sheetheader) component.
+`Sheet.Description` describes the Sheet for assistive technology.
+Nest `Sheet.Description` in the [`Sheet.Header`](#sheetheader) component.
 
 <Component components={props.data.mdx.components} componentName="sheet.description" />
 
@@ -159,7 +159,7 @@ This component is nested in the [`Sheet.Header`](#sheetheader) component.
 
 ### Sheet.Header
 
-The Sheet Header component is placed in the [`Sheet`](#sheet) component.
+Nest `Sheet Header` in the [`Sheet`](#sheet) component.
 
 <Component components={props.data.mdx.components} componentName="sheet.header" />
 
@@ -167,8 +167,8 @@ The Sheet Header component is placed in the [`Sheet`](#sheet) component.
 
 ### Sheet.Footer
 
-The Sheet Footer component is placed in the [`Sheet`](#sheet) component.
-The component can alternate to compact styling.
+Nest `Sheet.Footer` in the [`Sheet`](#sheet) component.
+Can be default or compact in size. This reduces padding on footer items.
 
 <Component components={props.data.mdx.components} componentName="sheet.footer" />
 
@@ -176,7 +176,7 @@ The component can alternate to compact styling.
 
 ### Sheet.FooterItem
 
-The Sheet FooterItem component is nested in the [`Sheet.Footer`](#sheetfooter) component.
+Nest `Sheet.FooterItem` in the [`Sheet.Footer`](#sheetfooter) component.
 
 <Component components={props.data.mdx.components} componentName="sheet.footeritem" />
 
@@ -184,7 +184,8 @@ The Sheet FooterItem component is nested in the [`Sheet.Footer`](#sheetfooter) c
 
 ### Sheet.Close
 
-The Sheet Close button component is placed in the [`Sheet`](#sheet) component.
+Nest `Sheet.Close` button in the [`Sheet`](#sheet) component.
+`Sheet.Close` should be the last subcomponent in `Sheet` for consistent tab order.
 
 <Component components={props.data.mdx.components} componentName="sheet.close" />
 

--- a/src/pages/components/sheet.mdx
+++ b/src/pages/components/sheet.mdx
@@ -126,69 +126,69 @@ The Sheet component follows this structure:
 
 <Component components={props.data.mdx.components} componentName="sheet" />
 
-The `Sheet` component provides state and accessibility attributes to its children.
+The Sheet component provides state and accessibility attributes to its children.
 
 <PropSheet components={props.data.mdx.components} componentName="sheet" />
 
-### Sheet.Body
+#### Sheet.Body
 
 <Component components={props.data.mdx.subcomponents} componentName="sheet.body" />
 
-Nest `Sheet.Body` in the [`Sheet`](#sheet) component.
-`Sheet.Body` requires additional accessible functionality to make the
+Nest Body in the [Sheet](#sheet) component.
+Body requires additional accessible functionality to make the
 element focusable for keyboard scrolling.
 
 <PropSheet components={props.data.mdx.subcomponents} componentName="sheet.body" />
 
-### Sheet.Title
+#### Sheet.Title
 
 <Component components={props.data.mdx.subcomponents} componentName="sheet.title" />
 
-`Sheet.Title` labels the Sheet for assistive technology.
-Nest `Sheet.Title` in the [`Sheet.Header`](#sheetheader) component.
+Title labels the Sheet for assistive technology.
+Nest Title in the [Sheet.Header](#sheetheader) component.
 
 <PropSheet components={props.data.mdx.subcomponents} componentName="sheet.title" />
 
-### Sheet.Description
+#### Sheet.Description
 
 <Component components={props.data.mdx.subcomponents} componentName="sheet.description" />
 
-`Sheet.Description` describes the Sheet for assistive technology.
-Nest `Sheet.Description` in the [`Sheet.Header`](#sheetheader) component.
+Description describes the Sheet for assistive technology.
+Nest Description in the [Sheet.Header](#sheetheader) component.
 
 <PropSheet components={props.data.mdx.subcomponents} componentName="sheet.description" />
 
-### Sheet.Header
+#### Sheet.Header
 
 <Component components={props.data.mdx.subcomponents} componentName="sheet.header" />
 
-Nest `Sheet Header` in the [`Sheet`](#sheet) component.
+Nest Header in the [Sheet](#sheet) component.
 
 <PropSheet components={props.data.mdx.subcomponents} componentName="sheet.header" />
 
-### Sheet.Footer
+#### Sheet.Footer
 
 <Component components={props.data.mdx.subcomponents} componentName="sheet.footer" />
 
-Nest `Sheet.Footer` in the [`Sheet`](#sheet) component.
+Nest Footer in the [Sheet](#sheet) component.
 Can be default or compact in size. This reduces padding on footer items.
 
 <PropSheet components={props.data.mdx.subcomponents} componentName="sheet.footer" />
 
-### Sheet.FooterItem
+#### Sheet.FooterItem
 
 <Component components={props.data.mdx.subcomponents} componentName="sheet.footeritem" />
 
-Nest `Sheet.FooterItem` in the [`Sheet.Footer`](#sheetfooter) component.
+Nest FooterItem in the [Sheet.Footer](#sheetfooter) component.
 
 <PropSheet components={props.data.mdx.subcomponents} componentName="sheet.footeritem" />
 
-### Sheet.Close
+#### Sheet.Close
 
 <Component components={props.data.mdx.subcomponents} componentName="sheet.close" />
 
-Nest `Sheet.Close` button in the [`Sheet`](#sheet) component.
-`Sheet.Close` should be the last subcomponent in `Sheet` for consistent tab order.
+Nest Close button in the [Sheet](#sheet) component.
+Close should be the last subcomponent in Sheet for consistent tab order.
 
 <PropSheet components={props.data.mdx.subcomponents} componentName="sheet.close" />
 

--- a/src/pages/components/sheet.mdx
+++ b/src/pages/components/sheet.mdx
@@ -93,6 +93,34 @@ import SheetSizeCode from '!!raw-loader!../../examples/chrome/SheetSize.tsx';
 
 ## API
 
+The Sheet component follows this structure:
+
+<!-- prettier-ignore -->
+```jsx
+<Sheet>
+  <Sheet.Header>
+    <Sheet.Title>
+      {/* a text to label the sheet */}
+    </Sheet.Title>
+    <Sheet.Description>
+      {/* a text describing the sheet */}
+    </Sheet.Description>
+  </Sheet.Header>
+  
+  <Sheet.Body>
+    {/* main content of the Sheet */}
+  </Sheet.Body>
+
+  <Sheet.Footer>
+    <Sheet.FooterItem>
+      {/* items to set in the footer, such as buttons */}
+    </Sheet.FooterItem>
+  </Sheet.Footer>
+
+  <Sheet.Close />
+</Sheet>
+```
+
 ### Sheet
 
 <Component components={props.data.mdx.components} componentName="sheet" />

--- a/src/pages/components/sheet.mdx
+++ b/src/pages/components/sheet.mdx
@@ -82,7 +82,7 @@ import SheetPlacementCode from '!!raw-loader!../../examples/chrome/SheetPlacemen
 ### Size
 
 Sheets default to 380px in width. You can customise the width based on your intended
-sexperience to any size using pixels or our grid system.
+experience to any size using pixels or our grid system.
 
 import SheetSize from '../../examples/chrome/SheetSize.tsx';
 import SheetSizeCode from '!!raw-loader!../../examples/chrome/SheetSize.tsx';

--- a/src/pages/components/sheet.mdx
+++ b/src/pages/components/sheet.mdx
@@ -122,6 +122,8 @@ The Sheet component follows this structure:
 </Sheet>
 ```
 
+Please keep the subcomponent structure in the order displayed in the example above.
+
 ### Sheet
 
 <Component components={props.data.mdx.components} componentName="sheet" />
@@ -134,9 +136,8 @@ The Sheet component provides state and accessibility attributes to its children.
 
 <Component components={props.data.mdx.subcomponents} componentName="sheet.body" />
 
-Nest Body in the [Sheet](#sheet) component.
-Body requires additional accessible functionality to make the
-element focusable for keyboard scrolling.
+A Body requires additional accessible functionality to make the
+element focusable for keyboard scrolling. Nest it within the [Sheet](#sheet) component.
 
 <PropSheet components={props.data.mdx.subcomponents} componentName="sheet.body" />
 
@@ -144,8 +145,7 @@ element focusable for keyboard scrolling.
 
 <Component components={props.data.mdx.subcomponents} componentName="sheet.title" />
 
-Title labels the Sheet for assistive technology.
-Nest Title in the [Sheet.Header](#sheetheader) component.
+A Title labels the Sheet for assistive technology. Nest it within a [Header](#sheetheader) component.
 
 <PropSheet components={props.data.mdx.subcomponents} componentName="sheet.title" />
 
@@ -153,8 +153,8 @@ Nest Title in the [Sheet.Header](#sheetheader) component.
 
 <Component components={props.data.mdx.subcomponents} componentName="sheet.description" />
 
-Description describes the Sheet for assistive technology.
-Nest Description in the [Sheet.Header](#sheetheader) component.
+A Description describes the Sheet for assistive technology.
+Nest it within a [Header](#sheetheader) component.
 
 <PropSheet components={props.data.mdx.subcomponents} componentName="sheet.description" />
 
@@ -162,7 +162,8 @@ Nest Description in the [Sheet.Header](#sheetheader) component.
 
 <Component components={props.data.mdx.subcomponents} componentName="sheet.header" />
 
-Nest Header in the [Sheet](#sheet) component.
+Nest a Header within the [Sheet](#sheet) component. If neither [Title][#sheettitle] nor
+[Description][#sheetdescription] are used, the Header should be omitted.
 
 <PropSheet components={props.data.mdx.subcomponents} componentName="sheet.header" />
 
@@ -170,8 +171,7 @@ Nest Header in the [Sheet](#sheet) component.
 
 <Component components={props.data.mdx.subcomponents} componentName="sheet.footer" />
 
-Nest Footer in the [Sheet](#sheet) component.
-Can be default or compact in size. This reduces padding on footer items.
+Nest a Footer within the [Sheet](#sheet) component.
 
 <PropSheet components={props.data.mdx.subcomponents} componentName="sheet.footer" />
 
@@ -179,7 +179,7 @@ Can be default or compact in size. This reduces padding on footer items.
 
 <Component components={props.data.mdx.subcomponents} componentName="sheet.footeritem" />
 
-Nest FooterItem in the [Sheet.Footer](#sheetfooter) component.
+Nest a FooterItem within the [Footer](#sheetfooter) component.
 
 <PropSheet components={props.data.mdx.subcomponents} componentName="sheet.footeritem" />
 
@@ -187,8 +187,7 @@ Nest FooterItem in the [Sheet.Footer](#sheetfooter) component.
 
 <Component components={props.data.mdx.subcomponents} componentName="sheet.close" />
 
-Nest Close button in the [Sheet](#sheet) component.
-Close should be the last subcomponent in Sheet for consistent tab order.
+Nest a Close button within a [Sheet](#sheet) component as the last child for consistent tab order.
 
 <PropSheet components={props.data.mdx.subcomponents} componentName="sheet.close" />
 

--- a/src/pages/components/sheet.mdx
+++ b/src/pages/components/sheet.mdx
@@ -5,6 +5,7 @@ description: >
 package: '@zendeskgarden/react-chrome'
 components:
   - chrome/src/elements/sheet/Sheet.tsx
+subcomponents:
   - chrome/src/elements/sheet/components/Body.tsx
   - chrome/src/elements/sheet/components/Title.tsx
   - chrome/src/elements/sheet/components/Description.tsx
@@ -131,65 +132,65 @@ The `Sheet` component provides state and accessibility attributes to its childre
 
 ### Sheet.Body
 
+<Component components={props.data.mdx.subcomponents} componentName="sheet.body" />
+
 Nest `Sheet.Body` in the [`Sheet`](#sheet) component.
 `Sheet.Body` requires additional accessible functionality to make the
 element focusable for keyboard scrolling.
 
-<Component components={props.data.mdx.components} componentName="sheet.body" />
-
-<PropSheet components={props.data.mdx.components} componentName="sheet.body" />
+<PropSheet components={props.data.mdx.subcomponents} componentName="sheet.body" />
 
 ### Sheet.Title
+
+<Component components={props.data.mdx.subcomponents} componentName="sheet.title" />
 
 `Sheet.Title` labels the Sheet for assistive technology.
 Nest `Sheet.Title` in the [`Sheet.Header`](#sheetheader) component.
 
-<Component components={props.data.mdx.components} componentName="sheet.title" />
-
-<PropSheet components={props.data.mdx.components} componentName="sheet.title" />
+<PropSheet components={props.data.mdx.subcomponents} componentName="sheet.title" />
 
 ### Sheet.Description
+
+<Component components={props.data.mdx.subcomponents} componentName="sheet.description" />
 
 `Sheet.Description` describes the Sheet for assistive technology.
 Nest `Sheet.Description` in the [`Sheet.Header`](#sheetheader) component.
 
-<Component components={props.data.mdx.components} componentName="sheet.description" />
-
-<PropSheet components={props.data.mdx.components} componentName="sheet.description" />
+<PropSheet components={props.data.mdx.subcomponents} componentName="sheet.description" />
 
 ### Sheet.Header
 
+<Component components={props.data.mdx.subcomponents} componentName="sheet.header" />
+
 Nest `Sheet Header` in the [`Sheet`](#sheet) component.
 
-<Component components={props.data.mdx.components} componentName="sheet.header" />
-
-<PropSheet components={props.data.mdx.components} componentName="sheet.header" />
+<PropSheet components={props.data.mdx.subcomponents} componentName="sheet.header" />
 
 ### Sheet.Footer
+
+<Component components={props.data.mdx.subcomponents} componentName="sheet.footer" />
 
 Nest `Sheet.Footer` in the [`Sheet`](#sheet) component.
 Can be default or compact in size. This reduces padding on footer items.
 
-<Component components={props.data.mdx.components} componentName="sheet.footer" />
-
-<PropSheet components={props.data.mdx.components} componentName="sheet.footer" />
+<PropSheet components={props.data.mdx.subcomponents} componentName="sheet.footer" />
 
 ### Sheet.FooterItem
 
+<Component components={props.data.mdx.subcomponents} componentName="sheet.footeritem" />
+
 Nest `Sheet.FooterItem` in the [`Sheet.Footer`](#sheetfooter) component.
 
-<Component components={props.data.mdx.components} componentName="sheet.footeritem" />
-
-<PropSheet components={props.data.mdx.components} componentName="sheet.footeritem" />
+<PropSheet components={props.data.mdx.subcomponents} componentName="sheet.footeritem" />
 
 ### Sheet.Close
+
+<Component components={props.data.mdx.subcomponents} componentName="sheet.close" />
 
 Nest `Sheet.Close` button in the [`Sheet`](#sheet) component.
 `Sheet.Close` should be the last subcomponent in `Sheet` for consistent tab order.
 
-<Component components={props.data.mdx.components} componentName="sheet.close" />
-
-<PropSheet components={props.data.mdx.components} componentName="sheet.close" />
+<PropSheet components={props.data.mdx.subcomponents} componentName="sheet.close" />
 
 import { graphql } from 'gatsby';
 

--- a/src/pages/components/sheet.mdx
+++ b/src/pages/components/sheet.mdx
@@ -82,7 +82,7 @@ import SheetPlacementCode from '!!raw-loader!../../examples/chrome/SheetPlacemen
 
 ### Size
 
-Sheets default to 380px in width. You can customise the width based on your intended
+Sheets default to 380px in width. You can customize the width based on your intended
 experience to any size using pixels or our [grid system](/components/grid).
 
 import SheetSize from '../../examples/chrome/SheetSize.tsx';


### PR DESCRIPTION
## Description

This PR adds documentation for the `Sheet` component.

## Detail

The PR adds the `Sheet` component with 5 examples and documentation for usage and API.

## Checklist

- [x] :ok_hand: website updates are Garden Designer approved (add the designer as a reviewer)
- [ ] :black_nib: copy updates are approved (add the content strategist as a reviewer)
- [x] :link: considered opportunities for adding cross-reference URLs (grep for keywords)
- [x] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
