### PR TITLE
feat(content): add actionable language page

### DIFF
--- a/src/nav/content.yml
+++ b/src/nav/content.yml
@@ -19,4 +19,4 @@
 - title: Guides
   items:
     - id: /content/actionable-language
-      title: Actionable Language
+      title: Actionable language

--- a/src/nav/content.yml
+++ b/src/nav/content.yml
@@ -16,3 +16,7 @@
       title: Punctuation
     - id: /content/word-list
       title: Word list
+- title: Guides
+  items:
+    - id: /content/actionable-language
+      title: Actionable Language

--- a/src/pages/content/actionable-language.mdx
+++ b/src/pages/content/actionable-language.mdx
@@ -1,0 +1,125 @@
+---
+title: Actionable language
+---
+
+For calls to action (CTAs), try to be as specific as possible.
+This helps the user know exactly what to expect and what they can
+do when they interact with the CTA. Use this guide to find the most
+appropriate verb for an experience that includes CTAs.
+
+CTAs are most often used in [buttons](/components/button) and [anchors](/components/anchor).
+
+## To make a selection
+
+### Select
+
+Use “Select” when the user must make a decision among multiple options.
+
+## To give a person ownership
+
+### Assign
+
+Use “Assign” when referring to ownership and responsibility.
+
+## To move back and forth
+
+### Back
+
+Use “Back” to take the user to the previous step in a multi-step process.
+Pair this with [“Next”](#next). In the event that a user will lose changes,
+warn them ahead of time that they will lose any changes that have been made.
+
+### Previous
+
+Use “Previous” instead of [“Back”](#back) for pagination in tables.
+
+### Next
+
+Use “Next” to take the user to the next step in a multi-step process.
+Pair this with [“Back”](#back).
+
+- **Don’t use:** Proceed, Continue
+
+## To postpone action
+
+### Skip
+
+Use “Skip” to allow the user to postpone an action or decision.
+It’s a way for the user to avoid interruption and proceed with their current task.
+
+## To receive confirmation
+
+### Done
+
+Use “Done” to confirm the completion of a multi-step process.
+
+- **Don’t use:** OK, Got it
+
+## To make changes
+
+### Create
+
+Use “Create” when the user is about to make a brand new thing in the product.
+
+### Add
+
+Use “Add” when moving something in the product from one place to another.
+
+- Example: “Add team”, “Add channel”
+
+## To remove
+
+### Clear
+
+Use clear to remove a selection.
+
+- **Don’t use:** Deselect
+
+## To commit
+
+### Save
+
+Use “Save” when the user makes changes and wants to commit them.
+
+## To cancel
+
+### Cancel
+
+Use “Cancel” when the user makes edits but wants to discard them. It dismisses
+the page the user was editing and returns the user to the entry point they came from.
+
+- **Don’t use:** Discard changes
+
+### Leave without saving
+
+“Leave without saving” is similar to “Cancel'', with one key difference: it
+reverts all values on the page to the last saved state without reloading the page.
+
+- **Don’t use:** Discard changes
+
+### Undo
+
+Revert back to the previous state.
+
+- **Don’t use:** Dismiss, No thanks
+
+## To learn
+
+### Find out more
+
+Use “Find out more” to launch a modal that introduces a new feature.
+
+### Learn about
+
+Launch a link to the Zendesk help center.
+
+- Example: “Learn about user profiles”
+- **Don’t use:** Learn more
+
+import { graphql } from 'gatsby';
+
+export const pageQuery = graphql`
+  query ($fileAbsolutePath: String) {
+    ...SidebarPageFragment
+  }
+`;

--- a/src/pages/content/actionable-language.mdx
+++ b/src/pages/content/actionable-language.mdx
@@ -53,7 +53,15 @@ It’s a way for the user to avoid interruption and proceed with their current t
 
 Use “Done” to confirm the completion of a multi-step process.
 
-- **Don’t use:** OK, Got it
+- **Don’t use:** OK, Got it, Close
+
+### OK
+
+CTAs make it clear what will happen when a user interacts with it.
+“OK” doesn’t do a great job of that. For mobile experiences,
+it’s okay to use “OK” but write it as “OK”.
+
+- **Don’t use:** Okay
 
 ## To make changes
 
@@ -92,7 +100,7 @@ the page the user was editing and returns the user to the entry point they came 
 
 ### Leave without saving
 
-“Leave without saving” is similar to “Cancel'', with one key difference: it
+“Leave without saving” is similar to [“Cancel"](#cancel), with one key difference: it
 reverts all values on the page to the last saved state without reloading the page.
 
 - **Don’t use:** Discard changes
@@ -111,7 +119,10 @@ Use “Find out more” to launch a modal that introduces a new feature.
 
 ### Learn about
 
-Launch a link to the Zendesk help center.
+Use “Learn about” to include a link to the Zendesk help center.
+Have the link be a few words about what the user will learn.
+Avoid the standalone “Learn more” and help center article titles
+that can’t be localized.
 
 - Example: “Learn about user profiles”
 - **Don’t use:** Learn more

--- a/src/pages/content/word-list.mdx
+++ b/src/pages/content/word-list.mdx
@@ -14,48 +14,6 @@ Describes a set of standards that make our product usable to people experiencing
 disabilities. Avoid using accessible as a synonym for “simple.” For that
 purpose, use terms like easy to learn, easy to use, or intuitive.
 
-### add
-
-Use _add_ when moving a “thing” in the product from one place to another.
-
-- Compare with [assign](#assign), [create](#create)
-
-<BestPractice>
-  <Do>
-    <ul>
-      <li>Add a user to a group.</li>
-      <li>Assign user to a group.</li>
-    </ul>
-  </Do>
-  <Dont>
-    <ul>
-      <li>Assign a ticket to this agent.</li>
-      <li>Add this ticket to the agent.</li>
-    </ul>
-  </Dont>
-</BestPractice>
-
-### assign
-
-Use _assign_ when referring to ownership and responsibility.
-
-- Compare with [add](#add), [create](#create)
-
-### create
-
-Use _create_ when you’re about to make a brand new thing in the product.
-
-- Compare with [add](#add)
-
-<BestPractice>
-  <Do>
-    <p>Create object record.</p>
-  </Do>
-  <Dont>
-    <p>Add a new object record.</p>
-  </Dont>
-</BestPractice>
-
 <!-- markdownlint-disable -->
 
 ### aka, a.k.a.
@@ -182,11 +140,6 @@ the _Channel pull endpoint_.
 Lowercase when talking about a chat message or the verb. Capitalize when
 referring to the feature or the product, such as _Zendesk Chat_.
 
-### choose, select
-
-Use _choose_ when the user makes a decision or action. Use _select_ when the user is
-considering a list of items.
-
 ### click, swipe, tap
 
 Avoid using platform-specific words like _click_, _swipe_, or _tap_.
@@ -223,11 +176,6 @@ facts or numbers.
 ### data center
 
 _Data center_ is always two words.
-
-### deselect, cancel
-
-Use _clear_ or _cancel_ instead of "deselect." As in, “Clear these checkboxes”
-or “Cancel this selection.”
 
 ### done
 
@@ -384,26 +332,6 @@ Use [Pascal case](https://en.wikipedia.org/wiki/Camel_case). Not Javascript or j
 ### knowledge base
 
 Two words, lowercase. Sometimes called KB for short.
-
-### Learn about vs. learn more
-
-We reserve the linked words _Learn about_ to begin links to the Zendesk Help
-Center. Avoid the standalone "Learn more" to prevent the repetition of the
-phrase in screen readers. Include a few short words about what the user will
-learn.
-
-- Use this formula: "Learn about [linked subject]”
-- Aim for a maximum of four words per link
-- Avoid Help Center article names that can’t be localized
-
-<BestPractice>
-  <Do>
-    <p>Learn about user profiles</p>
-  </Do>
-  <Dont>
-    <p>Learn more</p>
-  </Dont>
-</BestPractice>
 
 ### macOS
 

--- a/src/pages/content/word-list.mdx
+++ b/src/pages/content/word-list.mdx
@@ -177,27 +177,6 @@ facts or numbers.
 
 _Data center_ is always two words.
 
-### done
-
-Avoid _done_ since it doesn’t provide enough information. Button labels should
-make it clear what’s going to happen when the user clicks.
-
-<BestPractice>
-  <Do>
-    <p>
-      Description: Settings updated <br />
-      Button label: Go to Admin Center
-    </p>
-  </Do>
-  <Dont>
-    <p>
-      Description: Settings updated
-      <br />
-      Button label: Done
-    </p>
-  </Dont>
-</BestPractice>
-
 ### drop-down
 
 This noun describes a UI element that lets users pick from a series of options.
@@ -354,13 +333,6 @@ text.
 _New_ requires gender for many languages. _Add_ is a better substitute. Features
 that are new to the user are best communicated through emails, landing pages,
 and marketing materials.
-
-### OK
-
-Avoid _OK_ as a button label. Button labels should make it clear what’s going to
-happen when the user clicks it. Never use "Okay."
-
-On mobile devices it’s permitted to use OK for button text.
 
 ### OAuth
 


### PR DESCRIPTION
## Description

This PR adds a new content section "Actionable language".

## Detail

Adding the new section "Actionable language" and removing some of the words from the "Word list" page for clarity.
The actionable language has been put under a new sub nav category "Guides".

## Checklist

- [ ] :ok_hand: ~~website updates are Garden Designer approved (add the designer as a reviewer)~~
- [x] :black_nib: copy updates are approved (add the content strategist as a reviewer)
- [x] :link: considered opportunities for adding cross-reference URLs (grep for keywords)
- [ ] :wheelchair: ~~analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver~~
- [ ] :memo: ~~tested in Chrome, Firefox, Safari, Edge, and IE11~~
