### PR TITLE
fix: enhance content spacing

### DIFF
--- a/src/components/MarkdownProvider/components/Typography.tsx
+++ b/src/components/MarkdownProvider/components/Typography.tsx
@@ -57,14 +57,17 @@ export const StyledH3 = styled(XXL).attrs({ tag: 'h3' })`
 
   /* stylelint-disable-next-line declaration-no-important */
   position: static !important; /* [1] */
+  margin-top: ${p => p.theme.space.md};
 `;
 
 export const StyledH4 = styled(XL).attrs(p => ({ tag: p.tag || 'h4' }))`
   ${headerStyles}
+  margin-top: ${p => p.theme.space.md};
 `;
 
 export const StyledH5 = styled(LG).attrs({ tag: 'h5' })`
   ${headerStyles}
+  margin-top: ${p => p.theme.space.md};
 `;
 
 export const StyledH6 = styled(MD).attrs({ tag: 'h6' })`
@@ -83,7 +86,7 @@ export const StyledHr = styled.hr`
 `;
 
 export const StyledParagraph = styled(Paragraph)`
-  margin-bottom: ${p => p.theme.space.md};
+  margin-bottom: ${p => p.theme.space.sm};
 `;
 
 export const StyledStrong = styled(Span).attrs({ tag: 'strong', isBold: true })``;


### PR DESCRIPTION
## Description

Enhance vertical spacing for paragraph (`<p>`) and  headers (`<h3>` - `<h5>`) .

## Detail

This PR introduces two site-wide style changes that aims to bring better hierarchy and consistency to content by adjusting spacing. @james-sann and I discussed these during pairing sessions and have left comments on the Tables Patterns Figma document for posterity so feel free to check those out! Here's a summary of the changes:

1. Update `<p>` from `margin-bottom: 20px` (medium) to `margin-bottom: 12px` (small)
    1. Tightens the spacing between `<p>` and the element below it, unless the element below it has larger top margin (greater than `12px`). Brings hierarchy and consistency to overall sections that have `<p>` followed by other elements like lists and images. 
    1. `<p>` above headings use margin collapse to take the larger margin. In this case, top margin of headings ('20px'). As a result, no visual difference from this to current production site.
    1. Consecutive `<p>` have a `margin-top: 20px` from `blockquote` [styling](https://github.com/zendeskgarden/react-components/blob/main/packages/typography/src/styled/StyledParagraph.ts#L25-L28
). I am still in search of the historical context for why this this margin top exists. This may be unwarranted, but is no visual difference from this to current production site.

1. Update `<h3>`, `<h4>`, `<h5>` headings from no margin top to `margin-top: 20px` (medium)
    1. This improves the hierarchy by providing more spacing between the heading and the proceeding element unless the proceeding element needs _more_ spacing. Then the proceeding element can use margin collapse and provide more bottom margin. Essentially, this updates h3-h5 to have a minimum top spacing of `20px`.

Feel free to check out the how these changes apply to existing pages, particularly the `/content/voice-and-tone` page because it has many of paragraph and h3-h5 headings.

## Checklist

- [ ] :ok_hand: website updates are Garden Designer approved (add the designer as a reviewer)
- [ ] ~:black_nib: copy updates are approved (add the content strategist as a reviewer)~
- [ ] ~:link: considered opportunities for adding cross-reference URLs (grep for keywords)~
- [ ] ~:wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver~
- [ ] ~:memo: tested in Chrome, Firefox, Safari, Edge, and IE11~
