### PR TITLE
chore(components/datepicker): remove momentjs from recommended date formatting libraries

### DIFF
--- a/src/pages/components/date-picker.mdx
+++ b/src/pages/components/date-picker.mdx
@@ -38,8 +38,7 @@ import DefaultCode from '!!raw-loader!../../examples/date-picker/DatepickerDefau
 
 Dates are formatted using the
 [Intl.DateTimeFormat](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/DateTimeFormat)
-utility. For other formats, consider libraries like
-[date-fns](https://date-fns.org/) or [momentjs](https://momentjs.com/).
+utility. For other formats, consider using a library like [date-fns](https://date-fns.org/).
 
 import Custom from '../../examples/date-picker/DatepickerCustom.tsx';
 import CustomCode from '!!raw-loader!../../examples/date-picker/DatepickerCustom.tsx';


### PR DESCRIPTION
## Description

Removing `moment.js` as a recommended solution for formatting dates.

## Detail

Due to `moment.js` currently being a legacy library that is not actively maintained, as well as being not tree shakable, we should not be recommending it in our documentation.

## Checklist

- [ ] :ok_hand: ~~website updates are Garden Designer approved (add the designer as a reviewer)~~
- [ ] :black_nib: ~~copy updates are approved (add the content strategist as a reviewer)~~
- [ ] :link: ~~considered opportunities for adding cross-reference URLs (grep for keywords)~~
- [ ] :wheelchair: ~~analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver~~
- [ ] :memo: ~~tested in Chrome, Firefox, Safari, Edge, and IE11~~
