### PR TITLE
fix: improve footer hierarchy

### DIFF
--- a/src/layouts/Root/components/Footer.tsx
+++ b/src/layouts/Root/components/Footer.tsx
@@ -7,7 +7,6 @@
 
 import React from 'react';
 import styled, { css } from 'styled-components';
-import { math } from 'polished';
 import { getColor, mediaQuery } from '@zendeskgarden/react-theming';
 import { ReactComponent as GardenIcon } from '@zendeskgarden/svg-icons/src/26/garden.svg';
 import { Link } from './StyledNavigationLink';
@@ -20,6 +19,10 @@ const StyledFooterItem = styled(Link)`
   &:hover,
   &:focus {
     color: inherit;
+  }
+
+  ${p => mediaQuery('down', 'sm', p.theme)} {
+    margin-right: 0;
   }
 `;
 
@@ -41,31 +44,9 @@ const Footer: React.FC<IFooterProps> = ({ path }) => (
       <div
         css={css`
           display: flex;
-          padding-bottom: ${p => p.theme.space.md};
-
-          ${p => mediaQuery('down', 'sm', p.theme)} {
-            flex-direction: column;
-            padding-left: ${p => math(`${p.theme.iconSizes.md} + ${p.theme.space.md}`)};
-            text-align: center;
-          }
-        `}
-      >
-        <StyledFooterItem to="https://design.zendesk.com">Blog</StyledFooterItem>
-        <StyledFooterItem to="https://www.github.com/zendeskgarden">GitHub</StyledFooterItem>
-        <StyledFooterItem to="/components/versions">Versions</StyledFooterItem>
-        {path === '/' ? (
-          <StyledFooterItem to="https://www.netlify.com/">
-            This site is powered by Netlify
-          </StyledFooterItem>
-        ) : null}
-      </div>
-      <div
-        css={css`
-          display: flex;
           flex-wrap: wrap;
           align-items: center;
-          border-top: ${p => p.theme.borders.sm} ${p => getColor('kale', 500, p.theme)};
-          padding-top: ${p => p.theme.space.md};
+          padding-bottom: ${p => p.theme.space.md};
 
           ${p => mediaQuery('down', 'sm', p.theme)} {
             flex-direction: column;
@@ -80,7 +61,7 @@ const Footer: React.FC<IFooterProps> = ({ path }) => (
             align-items: center;
 
             ${p => mediaQuery('down', 'sm', p.theme)} {
-              margin-bottom: ${p => p.theme.space.md};
+              margin-bottom: ${p => p.theme.space.xs};
             }
           `}
         >
@@ -94,15 +75,38 @@ const Footer: React.FC<IFooterProps> = ({ path }) => (
         </div>
         <div
           css={css`
-            flex-basis: ${p => math(`${p.theme.iconSizes.md} + ${p.theme.space.md}`)};
-            flex-grow: 1;
             padding: 0 ${p => p.theme.space.sm};
           `}
         >
           Garden is the design system by Zendesk.
         </div>
+      </div>
+      <div
+        css={css`
+          display: flex;
+          border-top: ${p => p.theme.borders.sm} ${p => getColor('kale', 500, p.theme)};
+          padding-top: ${p => p.theme.space.md};
+          padding-bottom: ${p => p.theme.space.lg};
+
+          ${p => mediaQuery('down', 'sm', p.theme)} {
+            flex-direction: column;
+            text-align: center;
+          }
+        `}
+      >
+        <StyledFooterItem to="https://design.zendesk.com">Blog</StyledFooterItem>
+        <StyledFooterItem to="https://www.github.com/zendeskgarden">GitHub</StyledFooterItem>
+        <StyledFooterItem to="/components/versions">Versions</StyledFooterItem>
+        {path === '/' ? (
+          <StyledFooterItem to="https://www.netlify.com/">
+            This site is powered by Netlify
+          </StyledFooterItem>
+        ) : null}
         <div
           css={css`
+            flex-grow: 1;
+            text-align: right;
+
             ${p => mediaQuery('down', 'sm', p.theme)} {
               margin-top: ${p => p.theme.space.md};
               width: 100%;


### PR DESCRIPTION
## Description

As a follow-on to #285, update the footer per design specifications.

## Detail

**BEFORE (desktop)**

<img width="578" alt="Screen Shot 2022-02-10 at 9 23 20 AM" src="https://user-images.githubusercontent.com/143773/153427200-36b7de06-1789-4659-8e83-b68d9f256c84.png">

**AFTER (desktop)**

<img width="578" alt="Screen Shot 2022-02-10 at 9 23 33 AM" src="https://user-images.githubusercontent.com/143773/153427255-2be7f9c0-c389-435b-8644-792aa5725234.png">

---

**BEFORE (mobile)**

<img width="385" alt="Screen Shot 2022-02-10 at 9 25 47 AM" src="https://user-images.githubusercontent.com/143773/153427624-f28665cb-a6b3-4147-832e-020e0ff76f38.png">

**AFTER (mobile)**

<img width="385" alt="Screen Shot 2022-02-10 at 9 26 03 AM" src="https://user-images.githubusercontent.com/143773/153427655-51aa872a-1f70-4f83-9449-4a181fd53eea.png">

## Checklist

- [x] :ok_hand: website updates are Garden Designer approved (add the designer as a reviewer)
- [ ] :black_nib: ~copy updates are approved (add the content strategist as a reviewer)~
- [ ] :link: ~considered opportunities for adding cross-reference URLs (grep for keywords)~
- [ ] :wheelchair: ~analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver~
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
