### PR TITLE
fix: use garden component for heading

### DIFF
--- a/src/layouts/Home/components/Search.tsx
+++ b/src/layouts/Home/components/Search.tsx
@@ -11,7 +11,7 @@ import { GatsbyImage } from 'gatsby-plugin-image';
 import { css, ThemeProps, DefaultTheme } from 'styled-components';
 import { getLineHeight, mediaQuery } from '@zendeskgarden/react-theming';
 import { Grid, Row, Col } from '@zendeskgarden/react-grid';
-import { LG } from '@zendeskgarden/react-typography';
+import { LG, XXXL } from '@zendeskgarden/react-typography';
 import MaxWidthLayout from 'layouts/MaxWidth';
 import { SearchInput } from 'layouts/Root/components/SearchInput';
 
@@ -94,13 +94,14 @@ export const Search: React.FC = () => {
               `}
             >
               <div>
-                <h1
+                <XXXL
+                  tag="h1"
                   css={css`
                     ${headerStyling}
                   `}
                 >
                   Welcome to Garden
-                </h1>
+                </XXXL>
                 <LG
                   tag="p"
                   css={css`


### PR DESCRIPTION
## Description

Use Garden typography component for home page heading to leverage as much Garden components as possible. There should be no visual difference.

## Checklist

- [ ] ~:ok_hand: website updates are Garden Designer approved (add the designer as a reviewer)~
- [ ] ~:black_nib: copy updates are approved (add the content strategist as a reviewer)~
- [ ] ~:link: considered opportunities for adding cross-reference URLs (grep for keywords)~
- [x] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
