### PR TITLE
feat(icons): add token metadata

### DIFF
--- a/plugins/gatsby-transformer-garden-svg/gatsby-node.js
+++ b/plugins/gatsby-transformer-garden-svg/gatsby-node.js
@@ -8,6 +8,8 @@
 const { createNodeHelpers } = require('gatsby-node-helpers');
 const { optimize } = require('svgo');
 
+const iconTokens = require('./icon-tokens');
+
 const config = {
   plugins: [
     {
@@ -34,7 +36,7 @@ const parseSvg = svgContent => {
 
 exports.onCreateNode = async ({
   node,
-  actions: { createNode, createParentChildLink },
+  actions: { createNode, createNodeField, createParentChildLink },
   loadNodeContent,
   createNodeId,
   createContentDigest
@@ -59,6 +61,11 @@ exports.onCreateNode = async ({
     ...parsedContent
   });
 
+  createNodeField({
+    node,
+    name: 'token',
+    value: iconTokens.get(node.name)
+  });
   createNode(svgNode);
   createParentChildLink({ parent: node, child: svgNode });
 };

--- a/plugins/gatsby-transformer-garden-svg/icon-tokens.csv
+++ b/plugins/gatsby-transformer-garden-svg/icon-tokens.csv
@@ -1,0 +1,45 @@
+Name,Icon
+Add New,plus
+Alert Error,alert-error
+Alert Info,info
+Alert Success,check-circle
+Alert Warning,alert-warning
+Attachment,paperclip
+Avatar,user-solo
+Back,chevron-left
+Conversation,speech-bubble-conversation
+Close,close
+Dashboard,panels
+Delete,trash
+Edit,pencil
+Email,email
+Emoji,smiley
+External Link,new-window
+Favorite,star
+Filter,filter
+Hide Left,chevron-left
+Hide Down,chevron-down
+Hide Up,chevron-up
+History,history
+Home,home
+Info,info
+Language,globe
+Pagination Left,arrow-left
+Link,link
+Macro,lightning
+Message,speech-bubble-plain
+Notes,notes
+Notification,notification
+Overflow,overflow-vertical
+Phone,phone
+Rearrange,grip
+Redo,edit-redo
+Refresh,reload
+Pagination Right,arrow-right
+Search,search
+Settings,gear
+Sort,sort
+Tag,tag
+Text,text
+Time Zone,clock
+Undo,edit-undo

--- a/plugins/gatsby-transformer-garden-svg/icon-tokens.js
+++ b/plugins/gatsby-transformer-garden-svg/icon-tokens.js
@@ -1,0 +1,31 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+module.exports = (function extractIconTokens() {
+  // gets the csv of the tokens for the icons
+  const csv = fs.readFileSync(path.resolve(__dirname, 'icon-tokens.csv')).toString();
+  //  we skip the first line in a CSV file since that is the header
+  const [, ...tokens] = csv.split('\n');
+  // assumes all icon names are unique, and map 1:1 with a token
+  // in the future in case of icon name having multiple tokens,
+  // we would need [iconName1, iconName2]: token as a mapping.
+  // if we wanted to add multiple tokens to an icon
+  // we would need [iconName1, iconName2]: [token1, token2] as a mapping.
+  const tokenMap = new Map(tokens.map(pair => pair.replace('\r', '').split(',').reverse()));
+
+  return {
+    tokens: tokenMap,
+    get(iconName) {
+      const icon = iconName.replace('-stroke', '').replace('-fill', '');
+
+      return tokenMap.get(icon) || '';
+    }
+  };
+})();

--- a/src/examples/design/icons/SvgSearch.tsx
+++ b/src/examples/design/icons/SvgSearch.tsx
@@ -29,11 +29,26 @@ const StyledSvgWrapper = styled.div<{ isAnswerBot?: boolean }>`
   color: ${p => p.isAnswerBot && '#d6eef1'};
 `;
 
+const StyledMetadataParagraph = styled.p`
+  display: none;
+`;
+
+const StyledCol = styled(Col).attrs({ forwardedAs: 'li' })``;
+
+const StyledRow = styled(Row).attrs({ forwardedAs: 'ul' })``;
+
 export const SvgSearch: React.FC<{
   searchEnabled?: boolean;
   data: {
     edges: [
-      { node: { name: string; relativeDirectory: string; childGardenSvg: { content: string } } }
+      {
+        node: {
+          name: string;
+          relativeDirectory: string;
+          childGardenSvg: { content: string };
+          fields: { token: string };
+        };
+      }
     ];
   };
 }> = ({ data, searchEnabled }) => {
@@ -51,10 +66,6 @@ export const SvgSearch: React.FC<{
   useEffect(() => {
     updatedDebouncedInputValue(inputValue);
   }, [inputValue, updatedDebouncedInputValue]);
-
-  const StyledCol = styled(Col).attrs({ forwardedAs: 'li' })``;
-
-  const StyledRow = styled(Row).attrs({ forwardedAs: 'ul' })``;
 
   const icons = useMemo(() => {
     return data.edges
@@ -78,10 +89,13 @@ export const SvgSearch: React.FC<{
             <Code size="small" title={edge.node.name}>
               {edge.node.name}
             </Code>
+            {edge.node.fields.token ? (
+              <StyledMetadataParagraph>{edge.node.fields.token}</StyledMetadataParagraph>
+            ) : null}
           </StyledIconWrapper>
         </StyledCol>
       ));
-  }, [data, debouncedInputValue, StyledCol]);
+  }, [data, debouncedInputValue]);
 
   return (
     <div>

--- a/src/pages/design/icons/12.mdx
+++ b/src/pages/design/icons/12.mdx
@@ -22,6 +22,9 @@ export const pageQuery = graphql`
           childGardenSvg {
             content
           }
+          fields {
+            token
+          }
         }
       }
     }

--- a/src/pages/design/icons/16.mdx
+++ b/src/pages/design/icons/16.mdx
@@ -22,6 +22,9 @@ export const pageQuery = graphql`
           childGardenSvg {
             content
           }
+          fields {
+            token
+          }
         }
       }
     }

--- a/src/pages/design/icons/26.mdx
+++ b/src/pages/design/icons/26.mdx
@@ -27,6 +27,9 @@ export const pageQuery = graphql`
           childGardenSvg {
             content
           }
+          fields {
+            token
+          }
         }
       }
     }


### PR DESCRIPTION
## Description

This PR adds a hidden `<p />` tag to the icons with a token that it is linked to.

## Detail

The internal workings of this PR takes a CSV list of tokens and parses it to create a map. The map is then used in the `gatsby-transformer-garden-svg` plugin to add a field `token` to the icon file node and use that in the `SvgSearch` component to render an invisible `<p />` tag with the token. We can use this `<p />` tag to query `document.querySelectorAll('#main-content p')` with the expectation that Algolia docsearch will use our text selector `#main-content p` to extract and index the token in the `innerHTML` of each. 

## Checklist

- [ ] :ok_hand: website updates are Garden Designer approved (add the designer as a reviewer)
- [ ] :black_nib: copy updates are approved (add the content strategist as a reviewer)
- [ ] :link: considered opportunities for adding cross-reference URLs (grep for keywords)
- [ ] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [ ] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
