### PR TITLE
chore(algolia): test hidden element is parsed by docsearch

### DIFF
--- a/src/pages/design/icons/12.mdx
+++ b/src/pages/design/icons/12.mdx
@@ -6,6 +6,8 @@ import { SvgSearch } from '../../../examples/design/icons/SvgSearch';
 
 <SvgSearch data={props.data.svgIcons} />
 
+<p style={{ display: 'none' }}>algolia</p>
+
 import { graphql } from 'gatsby';
 
 export const pageQuery = graphql`


### PR DESCRIPTION
## Description

This PR adds a hard-coded example to see if Docsearch picks up a hidden element that matches a selector defined in the configuration.

## Detail

Prerequisite to #352 - there will be future plans to remove this change.

## Checklist

- [ ] :ok_hand: website updates are Garden Designer approved (add the designer as a reviewer)
- [ ] :black_nib: copy updates are approved (add the content strategist as a reviewer)
- [ ] :link: considered opportunities for adding cross-reference URLs (grep for keywords)
- [ ] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [ ] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
