### PR TITLE
docs(well): remove close api

### DIFF
--- a/src/pages/components/well.mdx
+++ b/src/pages/components/well.mdx
@@ -4,7 +4,6 @@ description: >
   A Well is a container that groups related content.
 package: '@zendeskgarden/react-notifications'
 components:
-  - notifications/src/elements/content/Close.tsx
   - notifications/src/elements/content/Paragraph.tsx
   - notifications/src/elements/content/Title.tsx
   - notifications/src/elements/Well.tsx
@@ -87,12 +86,6 @@ import RecessedCode from '!!raw-loader!../../examples/notifications/well/WellRec
 <Configuration reactPackage={props.data.mdx.package} components={props.data.mdx.components} />
 
 ## API
-
-### Close
-
-<Component components={props.data.mdx.components} componentName="close" />
-
-<PropSheet components={props.data.mdx.components} componentName="close" />
 
 ### Paragraph
 


### PR DESCRIPTION
<!-- structure the Title above as the first line of a
  https://conventionalcommits.org/ message. example: "chore:
  add a new 'thing' component page". -->

## Description

Remove the Close API from the Well component documentation per

> Although Close could exist in a Well, design intent is that it never would. So it should be removed from this particular page.

## Checklist

- [ ] :ok_hand: website updates are Garden Designer approved (add the designer as a reviewer)
- [ ] :black_nib: copy updates are approved (add the content strategist as a reviewer)
- [ ] :link: considered opportunities for adding cross-reference URLs (grep for keywords)
- [ ] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [ ] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
