### PR TITLE
chore(content): update content design team name and title

### DIFF
--- a/src/pages/content/principles.mdx
+++ b/src/pages/content/principles.mdx
@@ -1,8 +1,8 @@
 ---
 title: Principles
 description: >
-  The domain of UX content strategy is all the language in a user interface (UI). UX content
-  strategists design with words to create experiences that are clear, consistent, and inclusive.
+  The domain of content design is all the language in a user interface (UI). Content
+  designers design with words to create experiences that are clear, consistent, and inclusive.
 ---
 
 | Be clear                                                                        | Be consistent                                                            | Be inclusive                                                                      |


### PR DESCRIPTION
## Description

Update "UX content strategy" and "UX content strategists" to "content design" and "content designers". Team title and role are now up to date.

## Checklist

- [ ] :ok_hand: ~website updates are Garden Designer approved (add the designer as a reviewer)~
- [x] :black_nib: copy updates are approved (add the content strategist as a reviewer)
- [ ] :link: ~considered opportunities for adding cross-reference URLs (grep for keywords)~
- [ ] :wheelchair: ~analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver~
- [ ] :memo: ~tested in Chrome, Firefox, Safari, Edge, and IE11~
