### PR TITLE
fix(icons): replace svg-icons repo's readme link to preferred/cleaner url

### DIFF
--- a/src/pages/design/icons/index.mdx
+++ b/src/pages/design/icons/index.mdx
@@ -73,7 +73,7 @@ In certain instances where 16px icons will break the line height or will not fit
 
 ### Installation
 
-View the [zendeskgarden/svg-icons](https://github.com/zendeskgarden/svg-icons#garden-svg-icons---)
+View the [zendeskgarden/svg-icons](https://github.com/zendeskgarden/svg-icons#readme)
 repository for implementation instructions.
 
 export const pageQuery = graphql`


### PR DESCRIPTION
<!-- structure the Title above as the first line of a
  https://conventionalcommits.org/ message. example: "chore:
  add a new 'thing' component page". -->

## Description

<!-- a summary of the changes introduced by this PR. this description
     may populate the commit body if the PR is merged. -->
Replaces the URL that points to `svg-icons` readme with a cleaner/preferred URL.

<!-- closes GITHUB_ISSUE -->

## Checklist

- [ ] :ok_hand: website updates are Garden Designer approved (add the designer as a reviewer)
- [ ] :black_nib: copy updates are approved (add the content strategist as a reviewer)
- [ ] :link: considered opportunities for adding cross-reference URLs (grep for keywords)
- [ ] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [ ] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
