### PR TITLE
chore(content): add default and system to word list and fix stats to be in alphabetical order

### DIFF
--- a/src/pages/content/word-list.mdx
+++ b/src/pages/content/word-list.mdx
@@ -177,6 +177,12 @@ facts or numbers.
 
 _Data center_ is always two words.
 
+### default
+
+Use _default_ when describing something that is applied on behalf of the user.
+The user can also change what is set as default. For example, the default color
+for a chart can be changed from green to yellow.
+
 ### drop-down
 
 This noun describes a UI element that lets users pick from a series of options.
@@ -400,6 +406,10 @@ Hyphenate sign-on and spell this out on first use.
 
 Don’t use _spam_ as a verb.
 
+### stats
+
+Used in Help Center articles and in reports. Abbreviation OK.
+
 ### subdomain
 
 One word.
@@ -417,9 +427,10 @@ otherwise.
 
 Don’t use. Use _Zendesk Customer Support_ or _Customer Support_ instead.
 
-### stats
+### system
 
-Used in Help Center articles and in reports. Abbreviation OK.
+Use _system_ to describe something that is automatically included by Zendesk
+like a system field or a system role. These things can’t be deleted by the user.
 
 ### thank you, thanks
 


### PR DESCRIPTION
## Description
Add 2 words "default" and "system" to the word list. Saw "stats" was out of alphabetical order and repositioned it.

## Checklist

- [ ] :ok_hand: website updates are Garden Designer approved (add the designer as a reviewer)
- [x] :black_nib: copy updates are approved (add the content strategist as a reviewer)
- [ ] :link: considered opportunities for adding cross-reference URLs (grep for keywords)
- [ ] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [ ] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
