### PR TITLE
feat(chrome): Adds back 26px icons onto the website with textual context

### DIFF
--- a/src/examples/design/icons/SvgSearch.tsx
+++ b/src/examples/design/icons/SvgSearch.tsx
@@ -10,7 +10,7 @@ import { Grid, Row, Col } from '@zendeskgarden/react-grid';
 import debounce from 'lodash/debounce';
 import type { DebouncedFunc } from 'lodash';
 import { rgba } from 'polished';
-import { Field, MediaInput, Label } from '@zendeskgarden/react-forms';
+import { Field, MediaInput } from '@zendeskgarden/react-forms';
 import { ReactComponent as SearchStroke } from '@zendeskgarden/svg-icons/src/16/search-stroke.svg';
 import { Code, XL } from '@zendeskgarden/react-typography';
 import { Button } from '@zendeskgarden/react-buttons';
@@ -68,7 +68,8 @@ interface ISvgSearchProps {
   data: {
     edges: ISvgNodeProps[];
   };
-  collapsible: boolean;
+  inputPlaceholder?: string;
+  defaultCollapsed: boolean;
 }
 
 type ChangeHandler = (event: React.ChangeEvent<HTMLInputElement>) => void;
@@ -90,9 +91,14 @@ const Icon = (edge: ISvgNodeProps) => {
   );
 };
 
-export const SvgSearch: React.FC<ISvgSearchProps> = ({ data, collapsible, searchEnabled }) => {
+export const SvgSearch: React.FC<ISvgSearchProps> = ({
+  data,
+  defaultCollapsed,
+  inputPlaceholder,
+  searchEnabled
+}) => {
   const [inputValue, setInputValue] = useState('');
-  const [collapsed, setCollapsed] = useState(collapsible);
+  const [collapsed, setCollapsed] = useState(defaultCollapsed);
   const debounceRef = useRef<DebouncedFunc<ChangeHandler>>();
 
   const icons = useMemo(() => {
@@ -143,8 +149,11 @@ export const SvgSearch: React.FC<ISvgSearchProps> = ({ data, collapsible, search
                 margin-bottom: ${p => p.theme.space.lg};
               `}
             >
-              <Label>Search icons</Label>
-              <MediaInput start={<SearchStroke />} onChange={onInputChange} />
+              <MediaInput
+                start={<SearchStroke />}
+                placeholder={inputPlaceholder}
+                onChange={onInputChange}
+              />
             </Field>
           </Col>
         </Row>
@@ -183,5 +192,5 @@ export const SvgSearch: React.FC<ISvgSearchProps> = ({ data, collapsible, search
 
 SvgSearch.defaultProps = {
   searchEnabled: true,
-  collapsible: false
+  defaultCollapsed: true
 };

--- a/src/examples/design/icons/SvgSearch.tsx
+++ b/src/examples/design/icons/SvgSearch.tsx
@@ -10,7 +10,7 @@ import { Grid, Row, Col } from '@zendeskgarden/react-grid';
 import debounce from 'lodash/debounce';
 import type { DebouncedFunc } from 'lodash';
 import { rgba } from 'polished';
-import { Field, MediaInput } from '@zendeskgarden/react-forms';
+import { Field, MediaInput, Label } from '@zendeskgarden/react-forms';
 import { ReactComponent as SearchStroke } from '@zendeskgarden/svg-icons/src/16/search-stroke.svg';
 import { Code, XL } from '@zendeskgarden/react-typography';
 import { Button } from '@zendeskgarden/react-buttons';
@@ -149,6 +149,7 @@ export const SvgSearch: React.FC<ISvgSearchProps> = ({
                 margin-bottom: ${p => p.theme.space.lg};
               `}
             >
+              <Label hidden>Search icons</Label>
               <MediaInput
                 start={<SearchStroke />}
                 placeholder={inputPlaceholder}

--- a/src/examples/design/icons/SvgSearch.tsx
+++ b/src/examples/design/icons/SvgSearch.tsx
@@ -68,6 +68,7 @@ interface ISvgSearchProps {
   data: {
     edges: ISvgNodeProps[];
   };
+  collapsible: boolean;
 }
 
 type ChangeHandler = (event: React.ChangeEvent<HTMLInputElement>) => void;
@@ -89,9 +90,9 @@ const Icon = (edge: ISvgNodeProps) => {
   );
 };
 
-export const SvgSearch: React.FC<ISvgSearchProps> = ({ data, searchEnabled }) => {
+export const SvgSearch: React.FC<ISvgSearchProps> = ({ data, collapsible, searchEnabled }) => {
   const [inputValue, setInputValue] = useState('');
-  const [collapsed, setCollapsed] = useState(true);
+  const [collapsed, setCollapsed] = useState(collapsible);
   const debounceRef = useRef<DebouncedFunc<ChangeHandler>>();
 
   const icons = useMemo(() => {
@@ -181,5 +182,6 @@ export const SvgSearch: React.FC<ISvgSearchProps> = ({ data, searchEnabled }) =>
 };
 
 SvgSearch.defaultProps = {
-  searchEnabled: true
+  searchEnabled: true,
+  collapsible: false
 };

--- a/src/nav/design.yml
+++ b/src/nav/design.yml
@@ -13,4 +13,4 @@
         - id: /design/icons/library
           title: Library
         - id: /design/icons/chrome-icons
-          title: Chrome Icons
+          title: Chrome icons

--- a/src/nav/design.yml
+++ b/src/nav/design.yml
@@ -12,3 +12,5 @@
           title: Overview
         - id: /design/icons/library
           title: Library
+        - id: /design/icons/chrome-icons
+          title: Chrome Icons

--- a/src/pages/components/chrome.mdx
+++ b/src/pages/components/chrome.mdx
@@ -73,6 +73,10 @@ import NavigationCode from '!!raw-loader!../../examples/chrome/ChromeNavigation.
   <Navigation />
 </CodeExample>
 
+### Icons
+
+Chrome uses [26px sized icons](/design/icons/chrome-icons) made specifically for this component.
+
 ## Configuration
 
 <Configuration reactPackage={props.data.mdx.package} components={props.data.mdx.components} />

--- a/src/pages/design/icons/chrome-icons.mdx
+++ b/src/pages/design/icons/chrome-icons.mdx
@@ -1,16 +1,15 @@
 ---
-title: Icon Library
+title: Chrome Icons
 ---
 
 import { graphql } from 'gatsby';
 
-### All Icons
-
-This is a list of all the icons in the Garden library, independent of context.
+Below are all the icons currently available to use in the [Chrome](/components/chrome) component.
+These icons should only be used within Chrome.
 
 import { SvgSearch } from '../../../examples/design/icons/SvgSearch';
 
-<SvgSearch data={props.data.svgIcons} collapsible />
+<SvgSearch data={props.data.svgIcons} />
 
 export const pageQuery = graphql`
   query ($fileAbsolutePath: String) {
@@ -18,7 +17,7 @@ export const pageQuery = graphql`
     svgIcons: allFile(
       filter: {
         sourceInstanceName: { eq: "svg-icons" }
-        relativeDirectory: { eq: "16" }
+        relativeDirectory: { eq: "26" }
         name: { glob: "!wordmark-*" }
       }
       sort: { fields: name, order: ASC }

--- a/src/pages/design/icons/chrome-icons.mdx
+++ b/src/pages/design/icons/chrome-icons.mdx
@@ -1,5 +1,5 @@
 ---
-title: Chrome Icons
+title: Chrome icons
 ---
 
 import { graphql } from 'gatsby';
@@ -9,7 +9,7 @@ These icons should only be used within Chrome.
 
 import { SvgSearch } from '../../../examples/design/icons/SvgSearch';
 
-<SvgSearch data={props.data.svgIcons} />
+<SvgSearch data={props.data.svgIcons} defaultCollapsed={false} inputPlaceholder="Search icons" />
 
 export const pageQuery = graphql`
   query ($fileAbsolutePath: String) {

--- a/src/pages/design/icons/library.mdx
+++ b/src/pages/design/icons/library.mdx
@@ -10,7 +10,7 @@ This is a list of all the icons in the Garden library, independent of context.
 
 import { SvgSearch } from '../../../examples/design/icons/SvgSearch';
 
-<SvgSearch data={props.data.svgIcons} collapsible />
+<SvgSearch data={props.data.svgIcons} inputPlaceholder="Filter all icons" />
 
 export const pageQuery = graphql`
   query ($fileAbsolutePath: String) {

--- a/src/pages/design/icons/library.mdx
+++ b/src/pages/design/icons/library.mdx
@@ -10,7 +10,7 @@ This is a list of all the icons in the Garden library, independent of context.
 
 import { SvgSearch } from '../../../examples/design/icons/SvgSearch';
 
-<SvgSearch data={props.data.svgIcons} inputPlaceholder="Filter all icons" />
+<SvgSearch data={props.data.svgIcons} inputPlaceholder="Search icons" />
 
 export const pageQuery = graphql`
   query ($fileAbsolutePath: String) {


### PR DESCRIPTION
<!-- structure the Title above as the first line of a
  https://conventionalcommits.org/ message. example: "chore:
  add a new 'thing' component page". -->

## Description
Adds the 26px icons back into the website with a description of their usage.
Also, added a new prop for `svgSearch`, in order to control the collapsible. 

<!-- a summary of the changes introduced by this PR. this description
     may populate the commit body if the PR is merged. -->

## Detail
This PR also adds a section to the Chome component page that redirects the user to the 26px icons.
<img width="1045" alt="image" src="https://user-images.githubusercontent.com/30312964/163895845-ff14d466-1188-40fa-86e3-2811e24a9a58.png">

The hyperlink will direct the user a library of chrome icons (26px).
<img width="1294" alt="image" src="https://user-images.githubusercontent.com/30312964/163895870-da811432-77ab-45bb-9997-2301934d27ed.png">

<!-- supporting details; screen shot, code, etc. -->

<!-- closes GITHUB_ISSUE -->

## Checklist
- [x] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
