### PR TITLE
fix(design): convert titles to sentence case

### DIFF
--- a/src/pages/design/icons/index.mdx
+++ b/src/pages/design/icons/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: Icon Overview
+title: Icon overview
 ---
 
 import { graphql } from 'gatsby';

--- a/src/pages/design/icons/library.mdx
+++ b/src/pages/design/icons/library.mdx
@@ -1,10 +1,10 @@
 ---
-title: Icon Library
+title: Icon library
 ---
 
 import { graphql } from 'gatsby';
 
-### All Icons
+### All icons
 
 This is a list of all the icons in the Garden library, independent of context.
 


### PR DESCRIPTION
<!-- structure the Title above as the first line of a
  https://conventionalcommits.org/ message. example: "chore:
  add a new 'thing' component page". -->

## Description
Fix some titles within the design page to follow Garden's grammar guidelines.

<!-- a summary of the changes introduced by this PR. this description
     may populate the commit body if the PR is merged. -->

## Detail

Before:
<img width="817" alt="image" src="https://user-images.githubusercontent.com/30312964/165989205-f5944133-4b0b-4a57-afbd-9f0ef3e0bf06.png">

<img width="822" alt="image" src="https://user-images.githubusercontent.com/30312964/165989252-53b52d98-3809-410e-b3d9-0f4cef86e183.png">

---
After:
<img width="853" alt="image" src="https://user-images.githubusercontent.com/30312964/165989649-6e00bcdb-aa6f-4b0e-ab2f-c32d989e6b1b.png">

<img width="878" alt="image" src="https://user-images.githubusercontent.com/30312964/165989686-e3ac413a-c74a-4b65-962a-4609fdec3fe6.png">


<!-- supporting details; screen shot, code, etc. -->

<!-- closes GITHUB_ISSUE -->

## Checklist

- [x] :black_nib: copy updates are approved (add the content strategist as a reviewer)
- [x] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
