### PR TITLE
chore(workflows): enable submodules in checkout action

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,6 +24,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           ref: ${{ github.event.inputs.branch }}
+          submodules: true
 
       - uses: actions/setup-node@v3
         with:


### PR DESCRIPTION
## Description

This PR enables the use of [HTTPS instead of SSH when cloning down submodules](https://github.com/actions/checkout). This will allow the cloning of `react-components`. 

## Checklist

- [ ] :ok_hand: ~website updates are Garden Designer approved (add the designer as a reviewer)~
- [ ] :black_nib: ~copy updates are approved (add the content strategist as a reviewer)~
- [ ] :link: ~considered opportunities for adding cross-reference URLs (grep for keywords)~
- [ ] :wheelchair: ~analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver~
- [ ] :memo: ~tested in Chrome, Firefox, Safari, Edge, and IE11~
