### PR TITLE
chore(examples/stepper): add tab index to buttons in active step

### DIFF
--- a/src/examples/accordions/stepper/StepperDefault.tsx
+++ b/src/examples/accordions/stepper/StepperDefault.tsx
@@ -37,7 +37,9 @@ const Example = () => {
           Your garden&apos;s success depends on its location, so choose a spot that has healthy
           soil, gets good light, and is easily watered.
           <StyledButtons>
-            <Button onClick={onNext}>Next</Button>
+            <Button tabIndex={step === 0 ? -1 : undefined} onClick={onNext}>
+              Next
+            </Button>
           </StyledButtons>
         </Stepper.Content>
       </Stepper.Step>
@@ -48,8 +50,12 @@ const Example = () => {
           consider aesthetics like color and layout. If you&apos;re growing food, think about
           harvest times and the kinds of pests that might be attracted to your crops.
           <StyledButtons>
-            <Button onClick={onBack}>Back</Button>
-            <Button onClick={onNext}>Next</Button>
+            <Button tabIndex={step === 1 ? -1 : undefined} onClick={onBack}>
+              Back
+            </Button>
+            <Button tabIndex={step === 1 ? -1 : undefined} onClick={onNext}>
+              Next
+            </Button>
           </StyledButtons>
         </Stepper.Content>
       </Stepper.Step>
@@ -59,7 +65,9 @@ const Example = () => {
           Buy clean, hearty, disease-free seeds. Most seed from reliable seed companies will meet
           these specifications.
           <StyledButtons>
-            <Button onClick={onBack}>Back</Button>
+            <Button tabIndex={step === 2 ? -1 : undefined} onClick={onBack}>
+              Back
+            </Button>
           </StyledButtons>
         </Stepper.Content>
       </Stepper.Step>

--- a/src/examples/accordions/stepper/StepperDefault.tsx
+++ b/src/examples/accordions/stepper/StepperDefault.tsx
@@ -37,7 +37,7 @@ const Example = () => {
           Your garden&apos;s success depends on its location, so choose a spot that has healthy
           soil, gets good light, and is easily watered.
           <StyledButtons>
-            <Button tabIndex={step === 0 ? -1 : undefined} onClick={onNext}>
+            <Button tabIndex={step === 0 ? undefined : -1} onClick={onNext}>
               Next
             </Button>
           </StyledButtons>
@@ -50,10 +50,10 @@ const Example = () => {
           consider aesthetics like color and layout. If you&apos;re growing food, think about
           harvest times and the kinds of pests that might be attracted to your crops.
           <StyledButtons>
-            <Button tabIndex={step === 1 ? -1 : undefined} onClick={onBack}>
+            <Button tabIndex={step === 1 ? undefined : -1} onClick={onBack}>
               Back
             </Button>
-            <Button tabIndex={step === 1 ? -1 : undefined} onClick={onNext}>
+            <Button tabIndex={step === 1 ? undefined : -1} onClick={onNext}>
               Next
             </Button>
           </StyledButtons>
@@ -65,7 +65,7 @@ const Example = () => {
           Buy clean, hearty, disease-free seeds. Most seed from reliable seed companies will meet
           these specifications.
           <StyledButtons>
-            <Button tabIndex={step === 2 ? -1 : undefined} onClick={onBack}>
+            <Button tabIndex={step === 2 ? undefined : -1} onClick={onBack}>
               Back
             </Button>
           </StyledButtons>


### PR DESCRIPTION
## Description

This PR updates one of the `Stepper` component examples to use a `tabIndex` of `-1` when in a selected step.

## Checklist

- [ ] :ok_hand: website updates are Garden Designer approved (add the designer as a reviewer)
- [ ] :black_nib: copy updates are approved (add the content strategist as a reviewer)
- [ ] :link: considered opportunities for adding cross-reference URLs (grep for keywords)
- [ ] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [ ] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
