### PR TITLE
Revert "chore(deps-dev): bump gatsby-plugin-mdx from 2.14.0 to 2.14.1…

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "gatsby-plugin-google-gtag": "3.14.0",
     "gatsby-plugin-image": "1.14.2",
     "gatsby-plugin-manifest": "3.14.0",
-    "gatsby-plugin-mdx": "2.14.1",
+    "gatsby-plugin-mdx": "2.14.0",
     "gatsby-plugin-netlify": "4.3.0",
     "gatsby-plugin-offline": "4.14.0",
     "gatsby-plugin-react-helmet": "4.14.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9361,10 +9361,10 @@ gatsby-plugin-manifest@3.14.0:
     semver "^7.3.5"
     sharp "^0.29.0"
 
-gatsby-plugin-mdx@2.14.1:
-  version "2.14.1"
-  resolved "https://registry.yarnpkg.com/gatsby-plugin-mdx/-/gatsby-plugin-mdx-2.14.1.tgz#2f9c18b2f0020cde4c323c734532575b15315ff6"
-  integrity sha512-5F5Quv3kp9jdoTM3xZlpSPTeWJd+BbuLxf9VAlBXnXpItT1ANy3d3clPj8mMVe10ttQQ0OTZ7F+TIk293+t2GA==
+gatsby-plugin-mdx@2.14.0:
+  version "2.14.0"
+  resolved "https://registry.yarnpkg.com/gatsby-plugin-mdx/-/gatsby-plugin-mdx-2.14.0.tgz#adbbe14820de493eb926ee490019c43df4c7d3f3"
+  integrity sha512-aEAx4KrfSL/A4LFhh5nlOWUZZ2FA70X5xl+j5PiBRFEVTCgSOb8D0XPrHvtwNFYlAhdl/cuH3NcqlbRPJkX+Uw==
   dependencies:
     "@babel/core" "^7.15.5"
     "@babel/generator" "^7.15.4"


### PR DESCRIPTION
## Description

This reverts commit 3432af6a02c67541063645eae3acc91ab4b5f013.

## Checklist

- [ ] :ok_hand: website updates are Garden Designer approved (add the designer as a reviewer)
- [ ] :black_nib: copy updates are approved (add the content strategist as a reviewer)
- [ ] :link: considered opportunities for adding cross-reference URLs (grep for keywords)
- [ ] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [ ] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
