### PR TITLE
fix(examples): improve with more accessible examples

### DIFF
--- a/src/examples/breadcrumbs/BreadcrumbsDefault.tsx
+++ b/src/examples/breadcrumbs/BreadcrumbsDefault.tsx
@@ -15,8 +15,8 @@ const Example = () => (
   <Row justifyContent="center">
     <Col size="auto">
       <Breadcrumb>
-        <Anchor>Flowers</Anchor>
-        <Anchor>Roses</Anchor>
+        <Anchor href="#">Flowers</Anchor>
+        <Anchor href="#">Roses</Anchor>
         <Span>Floribunda</Span>
       </Breadcrumb>
     </Col>

--- a/src/examples/tooltip/TooltipDefault.tsx
+++ b/src/examples/tooltip/TooltipDefault.tsx
@@ -14,7 +14,7 @@ const Example = () => (
   <Row>
     <Col textAlign="center">
       <Tooltip content="Eat, drink, and be rosemary">
-        <Button>Hover for a tooltip</Button>
+        <Button isBasic>Hover for a tooltip</Button>
       </Tooltip>
     </Col>
   </Row>

--- a/src/examples/tooltip/TooltipDefault.tsx
+++ b/src/examples/tooltip/TooltipDefault.tsx
@@ -8,12 +8,13 @@
 import React from 'react';
 import { Tooltip } from '@zendeskgarden/react-tooltips';
 import { Row, Col } from '@zendeskgarden/react-grid';
+import { Button } from '@zendeskgarden/react-buttons';
 
 const Example = () => (
   <Row>
     <Col textAlign="center">
       <Tooltip content="Eat, drink, and be rosemary">
-        <span>Hover for a tooltip</span>
+        <Button>Hover for a tooltip</Button>
       </Tooltip>
     </Col>
   </Row>

--- a/src/examples/tooltip/TooltipPlacement.tsx
+++ b/src/examples/tooltip/TooltipPlacement.tsx
@@ -9,6 +9,7 @@ import React from 'react';
 import { Tooltip } from '@zendeskgarden/react-tooltips';
 import { GARDEN_PLACEMENT } from '@zendeskgarden/react-dropdowns';
 import { Row, Col } from '@zendeskgarden/react-grid';
+import { Button } from '@zendeskgarden/react-buttons';
 
 const PLACEMENTS: Record<string, GARDEN_PLACEMENT> = {
   auto: 'auto',
@@ -30,7 +31,7 @@ const Example = () => (
   <Row style={{ margin: 80 }}>
     <Col textAlign="center">
       <Tooltip placement={PLACEMENTS.topStart} content="Eat, drink, and be rosemary">
-        <span>Hover for a tooltip</span>
+        <Button>Hover for a tooltip</Button>
       </Tooltip>
     </Col>
   </Row>

--- a/src/examples/tooltip/TooltipPlacement.tsx
+++ b/src/examples/tooltip/TooltipPlacement.tsx
@@ -31,7 +31,7 @@ const Example = () => (
   <Row style={{ margin: 80 }}>
     <Col textAlign="center">
       <Tooltip placement={PLACEMENTS.topStart} content="Eat, drink, and be rosemary">
-        <Button>Hover for a tooltip</Button>
+        <Button isBasic>Hover for a tooltip</Button>
       </Tooltip>
     </Col>
   </Row>

--- a/src/examples/tooltip/TooltipSize.tsx
+++ b/src/examples/tooltip/TooltipSize.tsx
@@ -8,17 +8,18 @@
 import React from 'react';
 import { Tooltip, Title, Paragraph } from '@zendeskgarden/react-tooltips';
 import { Row, Col } from '@zendeskgarden/react-grid';
+import { Button } from '@zendeskgarden/react-buttons';
 
 const Example = () => (
   <Row>
     <Col textAlign="center">
       <Tooltip size="small" content="Eat, drink, and be rosemary" placement="top-start">
-        <span>Small</span>
+        <Button>Small</Button>
       </Tooltip>
     </Col>
     <Col textAlign="center">
       <Tooltip size="medium" content="I want to start gardening, but I haven’t botany plants.">
-        <span>Medium</span>
+        <Button>Medium</Button>
       </Tooltip>
     </Col>
     <Col textAlign="center">
@@ -35,7 +36,7 @@ const Example = () => (
           </>
         }
       >
-        <span>Large</span>
+        <Button>Large</Button>
       </Tooltip>
     </Col>
     <Col textAlign="center">
@@ -54,7 +55,7 @@ const Example = () => (
           </>
         }
       >
-        <span>Extra large</span>
+        <Button>Extra large</Button>
       </Tooltip>
     </Col>
   </Row>

--- a/src/examples/tooltip/TooltipSize.tsx
+++ b/src/examples/tooltip/TooltipSize.tsx
@@ -14,12 +14,12 @@ const Example = () => (
   <Row>
     <Col textAlign="center">
       <Tooltip size="small" content="Eat, drink, and be rosemary" placement="top-start">
-        <Button>Small</Button>
+        <Button size="small">Small</Button>
       </Tooltip>
     </Col>
     <Col textAlign="center">
       <Tooltip size="medium" content="I want to start gardening, but I haven’t botany plants.">
-        <Button>Medium</Button>
+        <Button size="medium">Medium</Button>
       </Tooltip>
     </Col>
     <Col textAlign="center">
@@ -36,7 +36,7 @@ const Example = () => (
           </>
         }
       >
-        <Button>Large</Button>
+        <Button size="large">Large</Button>
       </Tooltip>
     </Col>
     <Col textAlign="center">
@@ -55,7 +55,7 @@ const Example = () => (
           </>
         }
       >
-        <Button>Extra large</Button>
+        <Button size="large">Extra large</Button>
       </Tooltip>
     </Col>
   </Row>

--- a/src/examples/tooltip/TooltipType.tsx
+++ b/src/examples/tooltip/TooltipType.tsx
@@ -14,7 +14,9 @@ const Example = () => (
   <Row>
     <Col textAlign="center">
       <Tooltip type="dark" size="small" content="Eat, drink, and be rosemary">
-        <Button>Dark tooltip</Button>
+        <Button size="small" isPrimary>
+          Dark tooltip
+        </Button>
       </Tooltip>
     </Col>
     <Col textAlign="center">
@@ -32,7 +34,7 @@ const Example = () => (
           </>
         }
       >
-        <Button>Light tooltip</Button>
+        <Button isPrimary>Light tooltip</Button>
       </Tooltip>
     </Col>
   </Row>

--- a/src/examples/tooltip/TooltipType.tsx
+++ b/src/examples/tooltip/TooltipType.tsx
@@ -8,12 +8,13 @@
 import React from 'react';
 import { Tooltip, Title, Paragraph } from '@zendeskgarden/react-tooltips';
 import { Row, Col } from '@zendeskgarden/react-grid';
+import { Button } from '@zendeskgarden/react-buttons';
 
 const Example = () => (
   <Row>
     <Col textAlign="center">
       <Tooltip type="dark" size="small" content="Eat, drink, and be rosemary">
-        <span>Dark tooltip</span>
+        <Button>Dark tooltip</Button>
       </Tooltip>
     </Col>
     <Col textAlign="center">
@@ -31,7 +32,7 @@ const Example = () => (
           </>
         }
       >
-        <span>Light tooltip</span>
+        <Button>Light tooltip</Button>
       </Tooltip>
     </Col>
   </Row>


### PR DESCRIPTION
## Description

This PR adds some improvements to the examples by using more accessible examples.

## Detail

Changes were made to:
- `Breadcrumb` - added `href` to allow tabbing to occur
- `Tooltip` - replaced `<span />` element with a `<Button />` component to use interactive elements 

## Checklist

- [ ] :ok_hand: website updates are Garden Designer approved (add the designer as a reviewer)
- [ ] :black_nib: copy updates are approved (add the content strategist as a reviewer)
- [ ] :link: considered opportunities for adding cross-reference URLs (grep for keywords)
- [ ] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [ ] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
