### PR TITLE
fix(components): update table draggable example to be more a11y friendly

### DIFF
--- a/src/examples/table/TableDraggable.tsx
+++ b/src/examples/table/TableDraggable.tsx
@@ -205,7 +205,11 @@ const Example = () => {
                         {...provided.draggableProps}
                       >
                         <DraggableCell isDragOccurring={snapshot.isDragging}>
-                          <DraggableContainer id={item.id} {...provided.dragHandleProps}>
+                          <DraggableContainer
+                            id={item.id}
+                            aria-label={item.name}
+                            {...provided.dragHandleProps}
+                          >
                             <GripIcon />
                           </DraggableContainer>
                         </DraggableCell>


### PR DESCRIPTION
## Description

This PR adds the subject item for the interactive control (button) that is used for dragging the rows. The experience will allow the drag and drop to announce the controls while announcing the name for each row.

## Checklist

- [ ] :ok_hand: website updates are Garden Designer approved (add the designer as a reviewer)
- [ ] :black_nib: copy updates are approved (add the content strategist as a reviewer)
- [ ] :link: considered opportunities for adding cross-reference URLs (grep for keywords)
- [ ] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [ ] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
