### PR TITLE
fix(components): correct table draggable icon handle color

### DIFF
--- a/src/examples/table/TableDraggable.tsx
+++ b/src/examples/table/TableDraggable.tsx
@@ -10,6 +10,7 @@ import styled from 'styled-components';
 import { DragDropContext, Droppable, Draggable, DropResult } from 'react-beautiful-dnd';
 import { Table, Row, Cell, Head, HeaderCell, HeaderRow, Body } from '@zendeskgarden/react-tables';
 import { ReactComponent as GripIcon } from '@zendeskgarden/svg-icons/src/12/grip.svg';
+import { getColor } from '@zendeskgarden/react-theming';
 
 const DraggableRow = styled(Row)<{ isDraggingOver: boolean }>`
   ${props =>
@@ -23,7 +24,13 @@ const DraggableRow = styled(Row)<{ isDraggingOver: boolean }>`
 `;
 
 const DraggableContainer = styled.div`
-  :focus {
+  color: ${props => getColor('primaryHue', 600, props.theme)};
+
+  &:hover {
+    color: ${props => getColor('primaryHue', 700, props.theme)};
+  }
+
+  &:focus {
     outline: none;
   }
 `;


### PR DESCRIPTION
## Description

Corrects the color for the draggable `Table` component example - uses the 600 and 700 shades of the `primaryHue`.

## Checklist

- [ ] :ok_hand: website updates are Garden Designer approved (add the designer as a reviewer)
- [ ] :black_nib: copy updates are approved (add the content strategist as a reviewer)
- [ ] :link: considered opportunities for adding cross-reference URLs (grep for keywords)
- [ ] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [ ] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
