### PR TITLE
fix(deps): revert dependency gatsby-plugin-mdx to v2.14.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "gatsby-plugin-google-gtag": "3.14.0",
     "gatsby-plugin-image": "1.14.2",
     "gatsby-plugin-manifest": "3.14.0",
-    "gatsby-plugin-mdx": "2.14.1",
+    "gatsby-plugin-mdx": "2.14.0",
     "gatsby-plugin-netlify": "5.0.0",
     "gatsby-plugin-offline": "4.14.0",
     "gatsby-plugin-react-helmet": "4.14.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9539,10 +9539,10 @@ gatsby-plugin-manifest@3.14.0:
     semver "^7.3.5"
     sharp "^0.29.0"
 
-gatsby-plugin-mdx@2.14.1:
-  version "2.14.1"
-  resolved "https://registry.yarnpkg.com/gatsby-plugin-mdx/-/gatsby-plugin-mdx-2.14.1.tgz#2f9c18b2f0020cde4c323c734532575b15315ff6"
-  integrity sha512-5F5Quv3kp9jdoTM3xZlpSPTeWJd+BbuLxf9VAlBXnXpItT1ANy3d3clPj8mMVe10ttQQ0OTZ7F+TIk293+t2GA==
+gatsby-plugin-mdx@2.14.0:
+  version "2.14.0"
+  resolved "https://registry.yarnpkg.com/gatsby-plugin-mdx/-/gatsby-plugin-mdx-2.14.0.tgz#adbbe14820de493eb926ee490019c43df4c7d3f3"
+  integrity sha512-aEAx4KrfSL/A4LFhh5nlOWUZZ2FA70X5xl+j5PiBRFEVTCgSOb8D0XPrHvtwNFYlAhdl/cuH3NcqlbRPJkX+Uw==
   dependencies:
     "@babel/core" "^7.15.5"
     "@babel/generator" "^7.15.4"


### PR DESCRIPTION
## Description

Reverts #409 which has problems rendering frontmatter. A repeat of #397 🤦.

## Detail

<img width="1032" alt="Screen Shot 2022-10-06 at 9 09 01 AM" src="https://user-images.githubusercontent.com/143773/194321164-35d3c28c-61b7-4a82-bd92-19ef15367501.png">
