### PR TITLE
feat(table): add section names to SortableCell, GroupRow, and OverflowButton example links

### DIFF
--- a/src/pages/components/table.mdx
+++ b/src/pages/components/table.mdx
@@ -302,7 +302,7 @@ within a [Tooltip](/components/tooltip) and provide an `aria-label` to ensure it
 <Component components={props.data.mdx.components} componentName="sortableCell" />
 
 A SortableCell displays an interactive header cell with accesssibility attributes applied to enable
-implementation of a sortable table. See [example](#sort).
+implementation of a sortable table. See [SortableCell example](#sort).
 
 <PropSheet components={props.data.mdx.components} componentName="sortableCell" />
 

--- a/src/pages/components/table.mdx
+++ b/src/pages/components/table.mdx
@@ -260,7 +260,7 @@ The Table component follows this structure:
 <Component components={props.data.mdx.components} componentName="groupRow" />
 
 The GroupRow component provides styles to show a title row for a group of rows. Nest it within the
-[Body](#body) component. See [GroupedRow example](#grouped-rows).
+[Body](#body) component. See [GroupRow example](#grouped-rows).
 
 <PropSheet components={props.data.mdx.components} componentName="groupRow" />
 

--- a/src/pages/components/table.mdx
+++ b/src/pages/components/table.mdx
@@ -233,7 +233,7 @@ The Table component follows this structure:
   [MDN Table Accessibility Practices](https://developer.mozilla.org/en-US/docs/Learn/HTML/Tables/Advanced#Tables_for_visually_impaired_users)
   guidelines to ensure the table data is accessible to screen-readers
 - Use the [SortableCell](#sortablecell) component in a sortable table to ensure that the header is interactive
-  and accessible. See [example](#sort).
+  and accessible. See [SortableCell example](#sort).
 
 <!-- markdownlint-enable line-length -->
 
@@ -260,7 +260,7 @@ The Table component follows this structure:
 <Component components={props.data.mdx.components} componentName="groupRow" />
 
 The GroupRow component provides styles to show a title row for a group of rows. Nest it within the
-[Body](#body) component. See [example](#grouped-rows).
+[Body](#body) component. See [GroupedRow example](#grouped-rows).
 
 <PropSheet components={props.data.mdx.components} componentName="groupRow" />
 
@@ -287,8 +287,7 @@ The GroupRow component provides styles to show a title row for a group of rows. 
 <Component components={props.data.mdx.components} componentName="overflowButton" />
 
 The OverflowButton component enables implementation of an overflow menu in a [Cell](#cell). Nest it
-within a [Tooltip](/components/tooltip) and provide an `aria-label` to ensure it is accessible. See
-[example](#overflow).
+within a [Tooltip](/components/tooltip) and provide an `aria-label` to ensure it is accessible. See [OverflowButton example](#overflow).
 
 <PropSheet components={props.data.mdx.components} componentName="overflowButton" />
 


### PR DESCRIPTION
<!-- structure the Title above as the first line of a
  https://conventionalcommits.org/ message. example: "chore:
  add a new 'thing' component page". -->

## Description

In Table component page's API documentation, we include links that connect the SortableCell, GroupRow, and OverflowButton notes to their corresponding page sections. Until now, these links were all labelled as "example." This PR adds the name of the page section to each link label:

- "example" ➡️ "SortableCell example"
- "example" ➡️ "GroupRow example"
- "example" ➡️ "OverflowButton example"

It's important that we communicate the purpose and/or destination of these links to users — especially users who rely on screen readers and other assistive technology — so that they understand exactly where they'll go, if they click on the link. 

<!-- a summary of the changes introduced by this PR. this description
     may populate the commit body if the PR is merged. -->

## Detail

<!-- supporting details; screen shot, code, etc. -->

### SortableCell example link, VoiceOver x Safari

https://user-images.githubusercontent.com/93289772/195148037-ec223799-df44-477c-bd90-11ff308f6c26.mov

### GroupRow example link, VoiceOver x Safari

https://user-images.githubusercontent.com/93289772/195148153-2180b854-a9e0-4fd0-9735-d64940b1251d.mov

### OverflowButton example link, VoiceOver x Safari

https://user-images.githubusercontent.com/93289772/195148224-c3b14885-b10b-4620-82b2-67cd2b69a3c0.mov

<!-- closes GITHUB_ISSUE -->

## Checklist

- [ ] :ok_hand: website updates are Garden Designer approved (add the designer as a reviewer)
- [x] :black_nib: copy updates are approved (add the content strategist as a reviewer)
- [ ] :link: considered opportunities for adding cross-reference URLs (grep for keywords)
- [x] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
