### PR TITLE
feat(file-upload): add ARIA labels to component examples

### DIFF
--- a/src/examples/forms/file-upload/FileList.tsx
+++ b/src/examples/forms/file-upload/FileList.tsx
@@ -31,7 +31,7 @@ const Example = () => (
             <Tooltip content="Stop upload">
               <File.Close aria-label="close" onClick={handleClick} tabIndex={-1} />
             </Tooltip>
-            <Progress value={0} />
+            <Progress value={0} aria-hidden="true" />
           </File>
         </FileList.Item>
         <FileList.Item>
@@ -40,7 +40,7 @@ const Example = () => (
             <Tooltip content="Stop upload">
               <File.Close aria-label="close" onClick={handleClick} tabIndex={-1} />
             </Tooltip>
-            <Progress value={16} />
+            <Progress value={16} aria-label="Uploading Plant ecology.doc" />
           </File>
         </FileList.Item>
         <FileList.Item>
@@ -49,7 +49,7 @@ const Example = () => (
             <Tooltip content="Stop upload">
               <File.Close aria-label="close" onClick={handleClick} tabIndex={-1} />
             </Tooltip>
-            <Progress value={32} />
+            <Progress value={32} aria-label="Uploading Rose petals.jpg" />
           </File>
         </FileList.Item>
         <FileList.Item>
@@ -58,7 +58,7 @@ const Example = () => (
             <Tooltip content="Stop upload">
               <File.Close aria-label="close" onClick={handleClick} tabIndex={-1} />
             </Tooltip>
-            <Progress value={48} />
+            <Progress value={48} aria-label="Uploading Basics of gardening.pdf" />
           </File>
         </FileList.Item>
         <FileList.Item>
@@ -72,7 +72,7 @@ const Example = () => (
             <Tooltip content="Stop upload">
               <File.Close aria-label="close" onClick={handleClick} tabIndex={-1} />
             </Tooltip>
-            <Progress value={64} />
+            <Progress value={64} aria-label="Uploading Presentation bouquets.ppt" />
           </File>
         </FileList.Item>
         <FileList.Item>
@@ -86,7 +86,7 @@ const Example = () => (
             <Tooltip content="Stop upload">
               <File.Close aria-label="close" onClick={handleClick} tabIndex={-1} />
             </Tooltip>
-            <Progress value={80} />
+            <Progress value={80} aria-label="Uploading Seed inventory.xlsx" />
           </File>
         </FileList.Item>
         <FileList.Item>
@@ -95,7 +95,7 @@ const Example = () => (
             <Tooltip content="Remove file">
               <File.Delete aria-label="delete" onClick={handleClick} tabIndex={-1} />
             </Tooltip>
-            <Progress value={100} />
+            <Progress value={100} aria-label="Uploading Landscape.zip" />
           </File>
         </FileList.Item>
       </FileList>

--- a/src/examples/forms/file-upload/FileList.tsx
+++ b/src/examples/forms/file-upload/FileList.tsx
@@ -95,7 +95,7 @@ const Example = () => (
             <Tooltip content="Remove file">
               <File.Delete aria-label="delete" onClick={handleClick} tabIndex={-1} />
             </Tooltip>
-            <Progress value={100} aria-label="Uploading Landscape.zip" />
+            <Progress value={100} aria-hidden="true" />
           </File>
         </FileList.Item>
       </FileList>

--- a/src/examples/forms/file-upload/FileUpload.tsx
+++ b/src/examples/forms/file-upload/FileUpload.tsx
@@ -73,7 +73,7 @@ const FileItem: React.FC<{ name: string; onRemove: () => void }> = memo(({ name,
             <File.Close aria-label="close" onClick={onRemove} tabIndex={-1} />
           )}
         </Tooltip>
-        <Progress value={progress} />
+        <Progress value={progress} aria-label={`Uploading ${name}`} />
       </File>
     </FileList.Item>
   );

--- a/src/examples/forms/file-upload/FileUpload.tsx
+++ b/src/examples/forms/file-upload/FileUpload.tsx
@@ -73,7 +73,11 @@ const FileItem: React.FC<{ name: string; onRemove: () => void }> = memo(({ name,
             <File.Close aria-label="close" onClick={onRemove} tabIndex={-1} />
           )}
         </Tooltip>
-        <Progress value={progress} aria-label={`Uploading ${name}`} />
+        <Progress
+          value={progress}
+          aria-label={`Uploading ${name}`}
+          aria-hidden={progress === 100}
+        />
       </File>
     </FileList.Item>
   );


### PR DESCRIPTION
<!-- structure the Title above as the first line of a
  https://conventionalcommits.org/ message. example: "chore:
  add a new 'thing' component page". -->

## Description

<!-- a summary of the changes introduced by this PR. this description
     may populate the commit body if the PR is merged. -->

This PR adds ARIA labels to the File upload examples. These labels provide context for users who rely on screen readers and other assistive tech.

In places where the Progress component is not visible in the UI, `aria-hidden="true"` was applied, in order to hide the component from assistive tech. However, upon further inspection, it seems it may be cleaner to remove the Progress component from `FileList.tsx` on lines 34 and 98. What do you think, @zendeskgarden/maintainers? 

## Detail

<!-- supporting details; screen shot, code, etc. -->

<!-- closes GITHUB_ISSUE -->

### Files section

https://user-images.githubusercontent.com/93289772/196238996-0c90a5bf-5337-492b-8b05-ab604fade72c.mov

### Default section 

https://user-images.githubusercontent.com/93289772/196242409-a4cada98-38c1-4ceb-b27a-f6998bf05ff5.mov

## Checklist

- [x] :ok_hand: website updates are Garden Designer approved (add the designer as a reviewer)
- [x] :black_nib: copy updates are approved (add the content strategist as a reviewer)
- [ ] :link: considered opportunities for adding cross-reference URLs (grep for keywords)
- [x] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
