### PR TITLE
feat: add section names to example links across multiple component pages

### DIFF
--- a/src/pages/components/avatar.mdx
+++ b/src/pages/components/avatar.mdx
@@ -108,7 +108,7 @@ The Avatar component follows this structure:
 <PropSheet components={props.data.mdx.subcomponents} componentName="avatar.text" />
 
 The Text component applies appropriate styles to child text. Nest it within an [Avatar](#avatar) component.
-See [Type example](#type).
+See [type example](#type).
 
 import { graphql } from 'gatsby';
 

--- a/src/pages/components/avatar.mdx
+++ b/src/pages/components/avatar.mdx
@@ -108,7 +108,7 @@ The Avatar component follows this structure:
 <PropSheet components={props.data.mdx.subcomponents} componentName="avatar.text" />
 
 The Text component applies appropriate styles to child text. Nest it within an [Avatar](#avatar) component.
-See [example](#type).
+See [Type example](#type).
 
 import { graphql } from 'gatsby';
 

--- a/src/pages/components/button.mdx
+++ b/src/pages/components/button.mdx
@@ -142,7 +142,7 @@ The Button component applies appropriate styles based on its usage and the props
 <Component components={props.data.mdx.subcomponents} componentName="button.endIcon" />
 
 The EndIcon component appropriately positions its child icon within the button. Nest it within the
-[Button](#button) component as the last child. See [Media example](#media).
+[Button](#button) component as the last child. See [media example](#media).
 
 <PropSheet components={props.data.mdx.subcomponents} componentName="button.endIcon" />
 
@@ -151,7 +151,7 @@ The EndIcon component appropriately positions its child icon within the button. 
 <Component components={props.data.mdx.subcomponents} componentName="button.startIcon" />
 
 The StartIcon component appropriately positions its child icon within the button. Nest it within the
-[Button](#button) component as the first child. See [Media example](#media).
+[Button](#button) component as the first child. See [media example](#media).
 
 <PropSheet components={props.data.mdx.subcomponents} componentName="button.startIcon" />
 

--- a/src/pages/components/button.mdx
+++ b/src/pages/components/button.mdx
@@ -142,7 +142,7 @@ The Button component applies appropriate styles based on its usage and the props
 <Component components={props.data.mdx.subcomponents} componentName="button.endIcon" />
 
 The EndIcon component appropriately positions its child icon within the button. Nest it within the
-[Button](#button) component as the last child. See [example](#media).
+[Button](#button) component as the last child. See [Media example](#media).
 
 <PropSheet components={props.data.mdx.subcomponents} componentName="button.endIcon" />
 
@@ -151,7 +151,7 @@ The EndIcon component appropriately positions its child icon within the button. 
 <Component components={props.data.mdx.subcomponents} componentName="button.startIcon" />
 
 The StartIcon component appropriately positions its child icon within the button. Nest it within the
-[Button](#button) component as the first child. See [example](#media).
+[Button](#button) component as the first child. See [Media example](#media).
 
 <PropSheet components={props.data.mdx.subcomponents} componentName="button.startIcon" />
 

--- a/src/pages/components/file-upload.mdx
+++ b/src/pages/components/file-upload.mdx
@@ -179,7 +179,7 @@ Nest the Hint within a [Field](#field) component.
 
 <Component components={props.data.mdx.components} componentName="input" />
 
-Nest the Input within the [FileUpload](#fileupload) component. See an [example](#default) usage.
+Nest the Input within the [FileUpload](#fileupload) component. See [Default example](#default) usage.
 
 <PropSheet components={props.data.mdx.components} componentName="input" />
 

--- a/src/pages/components/file-upload.mdx
+++ b/src/pages/components/file-upload.mdx
@@ -179,7 +179,7 @@ Nest the Hint within a [Field](#field) component.
 
 <Component components={props.data.mdx.components} componentName="input" />
 
-Nest the Input within the [FileUpload](#fileupload) component. See [Default example](#default) usage.
+Nest the Input within the [FileUpload](#fileupload) component. See [default example](#default) usage.
 
 <PropSheet components={props.data.mdx.components} componentName="input" />
 

--- a/src/pages/components/icon-button.mdx
+++ b/src/pages/components/icon-button.mdx
@@ -135,7 +135,8 @@ The IconButton component follows this structure:
 
 <Component components={props.data.mdx.components} componentName="iconButton" />
 
-Nest the IconButton within a [Tooltip](/components/tooltip) and provide an `aria-label` to ensure it is accessible. See [example](#default).
+Nest the IconButton within a [Tooltip](/components/tooltip) and provide an `aria-label` to ensure it is accessible.
+See [Default example](#default).
 
 <PropSheet components={props.data.mdx.components} componentName="iconButton" />
 

--- a/src/pages/components/icon-button.mdx
+++ b/src/pages/components/icon-button.mdx
@@ -136,7 +136,7 @@ The IconButton component follows this structure:
 <Component components={props.data.mdx.components} componentName="iconButton" />
 
 Nest the IconButton within a [Tooltip](/components/tooltip) and provide an `aria-label` to ensure it is accessible.
-See [Default example](#default).
+See [default example](#default).
 
 <PropSheet components={props.data.mdx.components} componentName="iconButton" />
 

--- a/src/pages/components/radio.mdx
+++ b/src/pages/components/radio.mdx
@@ -139,7 +139,7 @@ with the corresponding [Label](#label) and [Hint](#hint).
 <Component components={props.data.mdx.components} componentName="fieldset" />
 
 The Fieldset component provides styles for grouping child form inputs. Wrap related [Field](#field)
-components and a [Legend](#fieldsetlegend) together within a Fieldset component. See [Validation example](#validation) usage.
+components and a [Legend](#fieldsetlegend) together within a Fieldset component. See [validation example](#validation) usage.
 
 <PropSheet components={props.data.mdx.components} componentName="fieldset" />
 

--- a/src/pages/components/radio.mdx
+++ b/src/pages/components/radio.mdx
@@ -139,7 +139,7 @@ with the corresponding [Label](#label) and [Hint](#hint).
 <Component components={props.data.mdx.components} componentName="fieldset" />
 
 The Fieldset component provides styles for grouping child form inputs. Wrap related [Field](#field)
-components and a [Legend](#fieldsetlegend) together within a Fieldset component. See an [example](#validation) usage.
+components and a [Legend](#fieldsetlegend) together within a Fieldset component. See [Validation example](#validation) usage.
 
 <PropSheet components={props.data.mdx.components} componentName="fieldset" />
 

--- a/src/pages/components/stepper.mdx
+++ b/src/pages/components/stepper.mdx
@@ -79,7 +79,7 @@ The Stepper component follows this structure:
 <!-- markdownlint-enable no-emphasis-as-heading -->
 
 - Define the content for a vertical stepper using the `Stepper.Content` for each step
-- Render the content for a horizontal stepper externally. See [example](#layout) for details.
+- Render the content for a horizontal stepper externally. See [Layout example](#layout) for details.
 
 ### Stepper
 

--- a/src/pages/components/stepper.mdx
+++ b/src/pages/components/stepper.mdx
@@ -79,7 +79,7 @@ The Stepper component follows this structure:
 <!-- markdownlint-enable no-emphasis-as-heading -->
 
 - Define the content for a vertical stepper using the `Stepper.Content` for each step
-- Render the content for a horizontal stepper externally. See [Layout example](#layout) for details.
+- Render the content for a horizontal stepper externally. See [layout example](#layout) for details.
 
 ### Stepper
 

--- a/src/pages/components/toggle-icon-button.mdx
+++ b/src/pages/components/toggle-icon-button.mdx
@@ -146,7 +146,7 @@ The ToggleIconButton component follows this structure:
 <Component components={props.data.mdx.components} componentName="toggleIconButton" />
 
 Nest the ToggleIconButton within a [Tooltip](/components/tooltip) and provide an `aria-label` to ensure it is
-accessible. See [example](#default).
+accessible. See [Default example](#default).
 
 <PropSheet components={props.data.mdx.components} componentName="toggleIconButton" />
 

--- a/src/pages/components/toggle-icon-button.mdx
+++ b/src/pages/components/toggle-icon-button.mdx
@@ -146,7 +146,7 @@ The ToggleIconButton component follows this structure:
 <Component components={props.data.mdx.components} componentName="toggleIconButton" />
 
 Nest the ToggleIconButton within a [Tooltip](/components/tooltip) and provide an `aria-label` to ensure it is
-accessible. See [Default example](#default).
+accessible. See [default example](#default).
 
 <PropSheet components={props.data.mdx.components} componentName="toggleIconButton" />
 


### PR DESCRIPTION
<!-- structure the Title above as the first line of a
  https://conventionalcommits.org/ message. example: "chore:
  add a new 'thing' component page". -->

## Description

<!-- a summary of the changes introduced by this PR. this description
     may populate the commit body if the PR is merged. -->

On several component pages, we include links that navigate the user to sections within those pages. Until now, these links were all labelled as "example." This PR adds the name of the page section to each link label.

It's important that we communicate the purpose and/or destination of these links to users — especially users who rely on screen readers and other assistive technology — so that they understand exactly where they'll go, if they click on the link.

## Detail

<!-- supporting details; screen shot, code, etc. -->

<!-- closes GITHUB_ISSUE -->

### Avatar

<img width="1792" alt="Screenshot of new example link label on the Avatar component page" src="https://user-images.githubusercontent.com/93289772/196556214-df9c7779-72ef-4743-ae7f-0a4fcba31d0b.png">

### Button

<img width="1792" alt="Screenshot of new example link labels on the Button component page" src="https://user-images.githubusercontent.com/93289772/196556280-2676343b-95bc-4baf-b376-1ab5d3c270c0.png">

### File upload

<img width="1792" alt="Screenshot of new example link label on the File upload component page" src="https://user-images.githubusercontent.com/93289772/196556321-fc984caa-2d7d-41e7-a882-4f92ab6169f3.png">

### Icon button

<img width="1792" alt="Screenshot of new example link label on the Icon button component page" src="https://user-images.githubusercontent.com/93289772/196556351-31cc9575-da59-4d0e-a394-e536b9aaa720.png">

### Radio

<img width="1791" alt="Screenshot of new example link label on the Radio component page" src="https://user-images.githubusercontent.com/93289772/196556377-f5d73742-74f6-4f85-af01-6c276ae85b6a.png">

### Stepper

<img width="1792" alt="Screenshot of new example link label on the Stepper component page" src="https://user-images.githubusercontent.com/93289772/196556398-2b3b2e00-6d88-4ceb-a664-6d54aa398a64.png">

### Toggle icon button

<img width="1792" alt="Screenshot of new example link label on the Toggle icon button component page" src="https://user-images.githubusercontent.com/93289772/196556421-756c7d85-8f90-4725-87ed-746a76e00433.png">


## Checklist

- [x] :ok_hand: website updates are Garden Designer approved (add the designer as a reviewer)
- [ ] :black_nib: copy updates are approved (add the content strategist as a reviewer)
- [x] :link: considered opportunities for adding cross-reference URLs (grep for keywords)
- [x] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
