### PR TITLE
feat(chrome): add heading tags to default example content titles

### DIFF
--- a/src/examples/chrome/ChromeDefault.tsx
+++ b/src/examples/chrome/ChromeDefault.tsx
@@ -90,11 +90,11 @@ const Example = () => {
         </Header>
         <Content id="example-main-content">
           <Main style={{ padding: 28 }}>
-            <XXL>Main Content</XXL>
+            <XXL tag="h1">Main Content</XXL>
             <MD>Beetroot water spinach okra water chestnut ricebean pea catsear.</MD>
           </Main>
           <Sidebar style={{ padding: 28 }}>
-            <XXL>Example Sidebar</XXL>
+            <XXL tag="h2">Example Sidebar</XXL>
             <MD>
               Beetroot water spinach okra water chestnut ricebean pea catsear courgette summer
               purslane. Water spinach arugula pea tatsoi aubergine spring onion bush tomato kale


### PR DESCRIPTION
<!-- structure the Title above as the first line of a
  https://conventionalcommits.org/ message. example: "chore:
  add a new 'thing' component page". -->

## Description

<!-- a summary of the changes introduced by this PR. this description
     may populate the commit body if the PR is merged. -->

In order to render the Chrome content titles as headings, this PR passes values to the Typography components' `tag` props. Headings help assistive tech users orient themselves and navigate around a web page. 

## Detail

<!-- supporting details; screen shot, code, etc. -->

<!-- closes GITHUB_ISSUE -->

![Screenshot of Chrome DevTools showing "Example Sidebar" title as an h2 and "Main Content" title as an h1](https://user-images.githubusercontent.com/93289772/197269745-9dd2364b-3728-4e4f-b332-85aa91517e8b.png)

![Screenshot showing Garden website code sample passing headings to XXL components](https://user-images.githubusercontent.com/93289772/197269759-29260986-e6b3-4592-96df-4cd12da0dbad.png)

## Checklist

- [x] :ok_hand: website updates are Garden Designer approved (add the designer as a reviewer)
- [x] :black_nib: copy updates are approved (add the content strategist as a reviewer)
- [x] :link: considered opportunities for adding cross-reference URLs (grep for keywords)
- [x] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
