### PR TITLE
feat(modals): add h2 elements to Modal, Tooltip Modal, and Drawer component examples

### DIFF
--- a/src/examples/drawer/DrawerDefault.tsx
+++ b/src/examples/drawer/DrawerDefault.tsx
@@ -21,7 +21,7 @@ const Example = () => {
       <Col textAlign="center">
         <Button onClick={open}>Open Drawer</Button>
         <DrawerModal isOpen={isOpen} onClose={close}>
-          <DrawerModal.Header>Tending a garden</DrawerModal.Header>
+          <DrawerModal.Header tag="h2">Tending a garden</DrawerModal.Header>
           <DrawerModal.Body>
             <Paragraph>
               Turnip greens yarrow ricebean rutabaga endive cauliflower sea lettuce kohlrabi

--- a/src/examples/modal/ModalDanger.tsx
+++ b/src/examples/modal/ModalDanger.tsx
@@ -21,7 +21,9 @@ const Example = () => {
         </Button>
         {visible && (
           <Modal onClose={() => setVisible(false)}>
-            <Header isDanger>Remove plant food from your garden</Header>
+            <Header tag="h2" isDanger>
+              Remove plant food from your garden
+            </Header>
             <Body>
               Plant food helps gardens grow. Removing plant food negatively affects the plant
               health.

--- a/src/examples/modal/ModalDefault.tsx
+++ b/src/examples/modal/ModalDefault.tsx
@@ -19,7 +19,7 @@ const Example = () => {
         <Button onClick={() => setVisible(true)}>Open modal</Button>
         {visible && (
           <Modal onClose={() => setVisible(false)}>
-            <Header>Do you need plant food?</Header>
+            <Header tag="h2">Do you need plant food?</Header>
             <Body>
               To boost your plants chances of success, use a combination of top-quality soil and the
               right plant food. Try growing in containers filled with plant food, which can help

--- a/src/examples/modal/ModalSize.tsx
+++ b/src/examples/modal/ModalSize.tsx
@@ -20,7 +20,7 @@ const Example = () => {
         <Button onClick={() => setVisible(true)}>Open large modal</Button>
         {visible && (
           <Modal isLarge onClose={() => setVisible(false)}>
-            <Header>Do you need plant food?</Header>
+            <Header tag="h2">Do you need plant food?</Header>
             <Body>
               <Paragraph>
                 Plant nutrition is the study of the chemical elements and compounds necessary for

--- a/src/examples/tooltip-modal/TooltipModalDefault.tsx
+++ b/src/examples/tooltip-modal/TooltipModalDefault.tsx
@@ -30,7 +30,7 @@ const Example = () => {
           onClose={() => setReferenceElement(null)}
           placement="top"
         >
-          <TooltipModal.Title>Tooltip modal header</TooltipModal.Title>
+          <TooltipModal.Title tag="h2">Tooltip modal header</TooltipModal.Title>
           <TooltipModal.Body>
             Gumbo beet greens corn soko endive gumbo gourd. Parsley shallot courgette tatsoi pea
             sprouts fava bean collard greens dandelion okra wakame tomato. Dandelion cucumber

--- a/src/examples/tooltip-modal/TooltipModalPlacement.tsx
+++ b/src/examples/tooltip-modal/TooltipModalPlacement.tsx
@@ -81,7 +81,7 @@ const Example = () => {
           }
         ]}
       >
-        <TooltipModal.Title>Tooltip modal header</TooltipModal.Title>
+        <TooltipModal.Title tag="h2">Tooltip modal header</TooltipModal.Title>
         <TooltipModal.Body>
           Gumbo beet greens corn soko endive gumbo gourd. Parsley shallot courgette tatsoi pea
           sprouts fava bean collard greens dandelion okra wakame tomato. Dandelion cucumber earthnut


### PR DESCRIPTION
<!-- structure the Title above as the first line of a
  https://conventionalcommits.org/ message. example: "chore:
  add a new 'thing' component page". -->

## Description

<!-- a summary of the changes introduced by this PR. this description
     may populate the commit body if the PR is merged. -->

In order to render the Modal, Tooltip Modal, and Drawer titles as headings, this PR passes values to their title components' tag props. Headings help assistive tech users orient themselves and navigate around a web page.

## Detail

<!-- supporting details; screen shot, code, etc. -->

<!-- closes GITHUB_ISSUE -->

### Modal

#### Default 

<img width="1792" alt="Screenshot of Chrome DevTools showing that the Default Modal now has an h2 element as a title" src="https://user-images.githubusercontent.com/93289772/199553572-62decab9-e80a-4e00-88d6-a8d51200d8d2.png">

#### Danger

<img width="1792" alt="Screenshot of Chrome DevTools showing that the Danger Modal now has an h2 element as a title" src="https://user-images.githubusercontent.com/93289772/199553958-c61da5a0-cb1b-4dc6-ae34-872dba12c88c.png">

#### Size

<img width="1792" alt="Screenshot of Chrome DevTools showing that the Size Modal now has an h2 element as a title" src="https://user-images.githubusercontent.com/93289772/199554129-0f6fe78b-038d-4333-b746-35c63c76800e.png">

### Tooltip Modal

#### Default

<img width="1792" alt="Screenshot of Chrome DevTools showing that the Default Tooltip Modal now has an h2 element as a title" src="https://user-images.githubusercontent.com/93289772/199554481-83494fbe-df24-4b6b-bd9f-3c9b9a4638c9.png">

#### Placement

<img width="1792" alt="Screenshot of Chrome DevTools showing that the Placement Tooltip Modal now has an h2 element as a title" src="https://user-images.githubusercontent.com/93289772/199554679-77397553-8405-4e7b-b1e8-6018ae19c27c.png">

### Drawer

#### Default

<img width="1792" alt="Screenshot of Chrome DevTools showing that the Default Drawer now has an h2 element as a title" src="https://user-images.githubusercontent.com/93289772/199555152-b286b0b9-8665-45b4-b1c2-fac6f580184d.png">

## Checklist

- [x] :ok_hand: website updates are Garden Designer approved (add the designer as a reviewer)
- [x] :black_nib: copy updates are approved (add the content strategist as a reviewer)
- [x] :link: considered opportunities for adding cross-reference URLs (grep for keywords)
- [x] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
