### PR TITLE
feat(tiles): add section name to each example's ARIA label

### DIFF
--- a/src/examples/forms/tiles/TilesDefault.tsx
+++ b/src/examples/forms/tiles/TilesDefault.tsx
@@ -21,7 +21,7 @@ const StyledCol = styled(Col)`
 `;
 
 const Example = () => (
-  <Tiles name="example" aria-label="Tiles component example">
+  <Tiles name="example" aria-label="Default Tiles component example">
     <Row>
       <Col sm={4}>
         <Tiles.Tile value="leaf">

--- a/src/examples/forms/tiles/TilesDescription.tsx
+++ b/src/examples/forms/tiles/TilesDescription.tsx
@@ -21,7 +21,7 @@ const StyledCol = styled(Col)`
 `;
 
 const Example = () => (
-  <Tiles name="example" aria-label="Tiles component example">
+  <Tiles name="example" aria-label="Description Tiles component example">
     <Row>
       <Col sm={4}>
         <Tiles.Tile value="leaf">

--- a/src/examples/forms/tiles/TilesDisabled.tsx
+++ b/src/examples/forms/tiles/TilesDisabled.tsx
@@ -21,7 +21,7 @@ const StyledCol = styled(Col)`
 `;
 
 const Example = () => (
-  <Tiles name="example" aria-label="Tiles component example">
+  <Tiles name="example" aria-label="Disabled Tiles component example">
     <Row>
       <Col sm={4}>
         <Tiles.Tile value="leaf" disabled>

--- a/src/examples/forms/tiles/TilesLayout.tsx
+++ b/src/examples/forms/tiles/TilesLayout.tsx
@@ -21,7 +21,7 @@ const StyledCol = styled(Col)`
 const Example = () => (
   <Row>
     <Col sm={6}>
-      <Tiles name="example-centered" aria-label="Tiles component example">
+      <Tiles name="example-centered" aria-label="Layout Tiles component example">
         <Tiles.Tile value="leaf-centered">
           <Tiles.Icon>
             <LeafIcon />


### PR DESCRIPTION
<!-- structure the Title above as the first line of a
  https://conventionalcommits.org/ message. example: "chore:
  add a new 'thing' component page". -->

## Description

<!-- a summary of the changes introduced by this PR. this description
     may populate the commit body if the PR is merged. -->

The ARIA label for each Tiles component example now includes that example's section name. This ensures each label is unique, which will make navigation and wayfinding easier for folks who rely on assistive tech.

## Detail

<!-- supporting details; screen shot, code, etc. -->

<!-- closes GITHUB_ISSUE -->

### Default

![Screenshot of Chrome DevTools showcasing new aria-label for Default Tiles component example](https://user-images.githubusercontent.com/93289772/200956583-3b8c7506-67cb-41bf-910b-f4223ab19643.png)

### Description

![Screenshot of Chrome DevTools showcasing new aria-label for Description Tiles component example](https://user-images.githubusercontent.com/93289772/200956618-7c2a89b9-56c2-47da-b61f-87ec45a48675.png)

### Disabled

![Screenshot of Chrome DevTools showcasing new aria-label for Disabled Tiles component example](https://user-images.githubusercontent.com/93289772/200956646-1daee60e-26f1-4e55-ba24-fef8a2c10aec.png)

### Layout

![Screenshot of Chrome DevTools showcasing new aria-label for Layout Tiles component example](https://user-images.githubusercontent.com/93289772/200956680-054a0d65-585c-4333-bfae-8ee0d5037bca.png)

## Checklist

- [ ] ~~:ok_hand: website updates are Garden Designer approved (add the designer as a reviewer)~~
- [ ] :black_nib: copy updates are approved (add the content strategist as a reviewer)
- [ ] ~~:link: considered opportunities for adding cross-reference URLs (grep for keywords)~~
- [x] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [ ] ~~:memo: tested in Chrome, Firefox, Safari, Edge, and IE11~~
