### PR TITLE
fix: show patterns link on mobile

### DIFF
--- a/src/layouts/Root/components/Header.tsx
+++ b/src/layouts/Root/components/Header.tsx
@@ -180,7 +180,7 @@ const MobileNav: React.FC = () => {
       <StyledMobileNavLink to="/content">Content</StyledMobileNavLink>
       <StyledMobileNavLink to="/design">Design</StyledMobileNavLink>
       <StyledMobileNavLink to="/components">Components</StyledMobileNavLink>
-      {/* <StyledMobileNavLink to="/patterns">Patterns</StyledMobileNavLink> */}
+      <StyledMobileNavLink to="/patterns">Patterns</StyledMobileNavLink>
     </div>
   );
 };


### PR DESCRIPTION
## Description

Shows `/patterns` link on mobile navigation menu.

## Detail

Since we've added patterns, the mobile link has been commented out - this PR uncomments to show patterns on mobile navigation menu.

## Checklist

- [ ] :ok_hand: website updates are Garden Designer approved (add the designer as a reviewer)
- [ ] :black_nib: copy updates are approved (add the content strategist as a reviewer)
- [ ] :link: considered opportunities for adding cross-reference URLs (grep for keywords)
- [ ] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [ ] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
