### PR TITLE
feat(notifications): add type name to each Type demo's close button label, for both Alerts & Notifications

### DIFF
--- a/src/examples/notifications/alerts/AlertType.tsx
+++ b/src/examples/notifications/alerts/AlertType.tsx
@@ -18,25 +18,25 @@ const Example = () => (
     <Alert type="info">
       <Title>Info</Title>
       Turnip greens yarrow endive cauliflower sea lettuce kohlrabi amaranth water
-      <Close aria-label="Close Alert" />
+      <Close aria-label="Close Info Alert" />
     </Alert>
     <StyledSpacer />
     <Alert type="warning">
       <Title>Warning</Title>
       Corn amaranth salsify bunya nuts nori azuki bean chickweed potato bell pepper artichoke
-      <Close aria-label="Close Alert" />
+      <Close aria-label="Close Warning Alert" />
     </Alert>
     <StyledSpacer />
     <Alert type="error">
       <Title>Error</Title>
       Celery quandong swiss chard chicory earthnut pea potato. Salsify taro catsear garlic
-      <Close aria-label="Close Alert" />
+      <Close aria-label="Close Error Alert" />
     </Alert>
     <StyledSpacer />
     <Alert type="success">
       <Title>Success</Title>
       Corn amaranth salsify bunya nuts nori azuki bean chickweed potato bell pepper artichoke
-      <Close aria-label="Close Alert" />
+      <Close aria-label="Close Success Alert" />
     </Alert>
   </>
 );

--- a/src/examples/notifications/notifications/NotificationType.tsx
+++ b/src/examples/notifications/notifications/NotificationType.tsx
@@ -18,25 +18,25 @@ const Example = () => (
     <Notification type="info">
       <Title>Info</Title>
       Turnip greens yarrow ricebean cauliflower sea lettuce kohlrabi amaranth water
-      <Close aria-label="Close Notification" />
+      <Close aria-label="Close Info Notification" />
     </Notification>
     <StyledSpacer />
     <Notification type="warning">
       <Title>Warning</Title>
       Corn amaranth salsify bunya nuts nori azuki bean potato bell pepper artichoke
-      <Close aria-label="Close Notification" />
+      <Close aria-label="Close Warning Notification" />
     </Notification>
     <StyledSpacer />
     <Notification type="error">
       <Title>Error</Title>
       Celery quandong swiss chard chicory earthnut pea potato. Salsify taro catsear garlic
-      <Close aria-label="Close Notification" />
+      <Close aria-label="Close Error Notification" />
     </Notification>
     <StyledSpacer />
     <Notification type="success">
       <Title>Success</Title>
       Corn amaranth salsify bunya nuts nori azuki bean chickweed potato bell pepper artichoke
-      <Close aria-label="Close Notification" />
+      <Close aria-label="Close Success Notification" />
     </Notification>
   </>
 );


### PR DESCRIPTION
<!-- structure the Title above as the first line of a
  https://conventionalcommits.org/ message. example: "chore:
  add a new 'thing' component page". -->

## Description

<!-- a summary of the changes introduced by this PR. this description
     may populate the commit body if the PR is merged. -->

This PR adds the name of each Alert or Notification and type to all of the close button labels in the Types section. This ensures each close button's text label is unique, which helps AT users navigate the page more easily.

e.g., 
* Before: `Close Alert`
* After: `Close Info Alert`

e.g.,
* Before: `Close Notification`
* After: `Close Info Notification`

## Detail

<!-- supporting details; screen shot, code, etc. -->

### Alerts

<img width="1792" alt="Screenshot of all of the updated ARIA labels in the Alerts' Types section" src="https://user-images.githubusercontent.com/93289772/203134261-6b55a44c-dd63-4d61-b16f-47212a458626.png">

#### Info Alert

<img width="1792" alt="Screenshot of the new ARIA label for the Info Alert's close button" src="https://user-images.githubusercontent.com/93289772/203134017-ef392da3-f13e-47a5-b23b-e244176af778.png">

#### Warning Alert

<img width="1792" alt="Screenshot of the new ARIA label for the Warning Alert's close button" src="https://user-images.githubusercontent.com/93289772/203134048-644dba37-3aa0-4a5f-a316-77d66ad007ba.png">

#### Error Alert

<img width="1792" alt="Screenshot of the new ARIA label for the Error Alert's close button" src="https://user-images.githubusercontent.com/93289772/203134063-ffa0fc36-dc14-418a-a070-3132a28b6e9d.png">

#### Success Alert

<img width="1792" alt="Screenshot of the new ARIA label for the Sucess Alert's close button" src="https://user-images.githubusercontent.com/93289772/203134099-d5f6b725-fd2c-4fc8-954f-44003b43aca7.png">

### Notifications

<img width="1792" alt="Screenshot of all of the updated ARIA labels in the Notifications' Types section" src="https://user-images.githubusercontent.com/93289772/203137498-37deabe8-6f07-4e31-94d8-f9ef974ee6bd.png">

#### Info Notification

<img width="1792" alt="Screenshot of the new ARIA label for the Info Notification's close button" src="https://user-images.githubusercontent.com/93289772/203138140-d8076818-2116-494c-86b0-8e2833ffbe70.png">

#### Warning Notification

<img width="1792" alt="Screenshot of the new ARIA label for the Warning Notification's close button" src="https://user-images.githubusercontent.com/93289772/203138181-9d43a9e2-a3a0-435d-bbd5-4c8af2810042.png">

#### Error Notification

<img width="1792" alt="Screenshot of the new ARIA label for the Error Notification's close button" src="https://user-images.githubusercontent.com/93289772/203138238-efa36bbf-8afe-4bb9-821b-728ace2effb1.png">

#### Success Notification

<img width="1792" alt="Screenshot of the new ARIA label for the Success Notification's close button" src="https://user-images.githubusercontent.com/93289772/203138267-3b9a4005-d6a3-4d30-bdd7-3e20c9ee4a56.png">

<!-- closes GITHUB_ISSUE -->

## Checklist

- [ ] ~~:ok_hand: website updates are Garden Designer approved (add the designer as a reviewer)~~
- [ ] :black_nib: copy updates are approved (add the content strategist as a reviewer)
- [ ] ~~:link: considered opportunities for adding cross-reference URLs (grep for keywords)~~
- [x] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [ ] ~~:memo: tested in Chrome, Firefox, Safari, Edge, and IE11~~
