### PR TITLE
fix(seo): add detail to open graph preview cards

### DIFF
--- a/src/components/SEO.tsx
+++ b/src/components/SEO.tsx
@@ -8,9 +8,7 @@
 import React from 'react';
 import { Helmet } from 'react-helmet';
 import { useStaticQuery, graphql } from 'gatsby';
-
-/* eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires */
-const { PALETTE } = require('@zendeskgarden/react-theming');
+import { PALETTE } from '@zendeskgarden/react-theming';
 
 const SEO: React.FC<{
   description?: string;
@@ -32,6 +30,7 @@ const SEO: React.FC<{
     `
   );
 
+  const metaTitle = title || site.siteMetadata.title;
   const metaDescription = description || site.siteMetadata.description;
 
   return (
@@ -39,7 +38,7 @@ const SEO: React.FC<{
       htmlAttributes={{
         lang
       }}
-      title={title || site.siteMetadata.title}
+      title={metaTitle}
       titleTemplate={title ? `%s / ${site.siteMetadata.title}` : undefined}
       meta={[
         {
@@ -56,11 +55,11 @@ const SEO: React.FC<{
         },
         {
           property: 'og:title',
-          content: site.siteMetadata.title
+          content: metaTitle
         },
         {
           property: 'og:description',
-          content: site.siteMetadata.description
+          content: metaDescription
         },
         {
           property: 'og:image',


### PR DESCRIPTION
<!-- structure the Title above as the first line of a
  https://conventionalcommits.org/ message. example: "chore:
  add a new 'thing' component page". -->

## Description

This PR adds more detail to the open graph preview with details specific to a page; whether a design, component, pattern or content page.

## Detail

For the `og:title` meta tag, we use the page title to create a preview when a link is shared. The same has been done `og:description` to display the page description.

## Checklist

- [ ] :ok_hand: website updates are Garden Designer approved (add the designer as a reviewer)
- [ ] :black_nib: copy updates are approved (add the content strategist as a reviewer)
- [ ] :link: considered opportunities for adding cross-reference URLs (grep for keywords)
- [ ] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [ ] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
