### PR TITLE
fix(examples): update default checkbox example with fieldset component

### DIFF
--- a/src/examples/forms/checkbox/Default.tsx
+++ b/src/examples/forms/checkbox/Default.tsx
@@ -18,7 +18,7 @@ const Example = () => {
     <Row justifyContent="center">
       <Col size="auto">
         <Fieldset>
-          <Fieldset.Legend>plant preference</Fieldset.Legend>
+          <Fieldset.Legend>Plant preference</Fieldset.Legend>
           <Field>
             <Checkbox checked={pest} onChange={() => setPest(!pest)}>
               <Label>Pest resistant</Label>

--- a/src/examples/forms/checkbox/Default.tsx
+++ b/src/examples/forms/checkbox/Default.tsx
@@ -6,7 +6,7 @@
  */
 
 import React, { useState } from 'react';
-import { Field, Label, Checkbox } from '@zendeskgarden/react-forms';
+import { Field, Label, Checkbox, Fieldset } from '@zendeskgarden/react-forms';
 import { Row, Col } from '@zendeskgarden/react-grid';
 
 const Example = () => {
@@ -17,21 +17,24 @@ const Example = () => {
   return (
     <Row justifyContent="center">
       <Col size="auto">
-        <Field>
-          <Checkbox checked={pest} onChange={() => setPest(!pest)}>
-            <Label>Pest resistant</Label>
-          </Checkbox>
-        </Field>
-        <Field>
-          <Checkbox checked={light} onChange={() => setLight(!light)}>
-            <Label>Needs direct light</Label>
-          </Checkbox>
-        </Field>
-        <Field>
-          <Checkbox checked={drought} onChange={() => setDrought(!drought)}>
-            <Label>Drought-tolerant</Label>
-          </Checkbox>
-        </Field>
+        <Fieldset>
+          <Fieldset.Legend>plant preference</Fieldset.Legend>
+          <Field>
+            <Checkbox checked={pest} onChange={() => setPest(!pest)}>
+              <Label>Pest resistant</Label>
+            </Checkbox>
+          </Field>
+          <Field>
+            <Checkbox checked={light} onChange={() => setLight(!light)}>
+              <Label>Needs direct light</Label>
+            </Checkbox>
+          </Field>
+          <Field>
+            <Checkbox checked={drought} onChange={() => setDrought(!drought)}>
+              <Label>Drought-tolerant</Label>
+            </Checkbox>
+          </Field>
+        </Fieldset>
       </Col>
     </Row>
   );


### PR DESCRIPTION
## Description

Wraps the default `Checkbox` component example with `Fieldset` and `Fieldset.Legend` component.

## Checklist

- [ ] :ok_hand: website updates are Garden Designer approved (add the designer as a reviewer)
- [ ] :black_nib: copy updates are approved (add the content strategist as a reviewer)
- [ ] :link: considered opportunities for adding cross-reference URLs (grep for keywords)
- [ ] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [ ] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
