### PR TITLE
fix(examples): return focus to trigger when drawer modal is closed

### DIFF
--- a/src/examples/drawer/DrawerDefault.tsx
+++ b/src/examples/drawer/DrawerDefault.tsx
@@ -20,7 +20,7 @@ const Example = () => {
     <Row>
       <Col textAlign="center">
         <Button onClick={open}>Open Drawer</Button>
-        <DrawerModal isOpen={isOpen} onClose={close}>
+        <DrawerModal isOpen={isOpen} onClose={close} restoreFocus focusOnMount>
           <DrawerModal.Header tag="h2">Tending a garden</DrawerModal.Header>
           <DrawerModal.Body>
             <Paragraph>

--- a/src/examples/drawer/DrawerDefault.tsx
+++ b/src/examples/drawer/DrawerDefault.tsx
@@ -20,7 +20,7 @@ const Example = () => {
     <Row>
       <Col textAlign="center">
         <Button onClick={open}>Open Drawer</Button>
-        <DrawerModal isOpen={isOpen} onClose={close} restoreFocus focusOnMount>
+        <DrawerModal isOpen={isOpen} onClose={close} restoreFocus>
           <DrawerModal.Header tag="h2">Tending a garden</DrawerModal.Header>
           <DrawerModal.Body>
             <Paragraph>


### PR DESCRIPTION
## Description

Adds the `restoreFocus` and `focusOnMount` props to the default `DrawerModal` example to return focus to the trigger element.

## Checklist

- [ ] :ok_hand: ~website updates are Garden Designer approved (add the designer as a reviewer)~
- [ ] :black_nib: ~copy updates are approved (add the content strategist as a reviewer)~
- [ ] :link: ~considered opportunities for adding cross-reference URLs (grep for keywords)~
- [x] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
