### PR TITLE
fix(examples): adds hidden prop to empty cell on draggable table rows example

### DIFF
--- a/src/examples/table/TableDraggable.tsx
+++ b/src/examples/table/TableDraggable.tsx
@@ -188,7 +188,7 @@ const Example = () => {
       <Table>
         <Head>
           <HeaderRow>
-            <HeaderCell isMinimum />
+            <HeaderCell isMinimum hidden />
             <HeaderCell>Fruit</HeaderCell>
             <HeaderCell>Sun exposure</HeaderCell>
             <HeaderCell>Soil</HeaderCell>

--- a/src/examples/table/TableDraggable.tsx
+++ b/src/examples/table/TableDraggable.tsx
@@ -188,7 +188,9 @@ const Example = () => {
       <Table>
         <Head>
           <HeaderRow>
-            <HeaderCell isMinimum hidden />
+            <HeaderCell isMinimum hidden>
+              Draggable grip
+            </HeaderCell>
             <HeaderCell>Fruit</HeaderCell>
             <HeaderCell>Sun exposure</HeaderCell>
             <HeaderCell>Soil</HeaderCell>


### PR DESCRIPTION
## Description

✅ `v8.63.1` on `main`, branch rebased

Applies new `hidden` prop to empty cell header on Tables' draggable row example.

## Checklist

- [ ] ~~:ok_hand: website updates are Garden Designer approved (add the designer as a reviewer)~~
- [ ] ~~:black_nib: copy updates are approved (add the content strategist as a reviewer)~~
- [ ] ~~:link: considered opportunities for adding cross-reference URLs (grep for keywords)~~
- [x] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
