### PR TITLE
fix(components): fix icons installation url

### DIFF
--- a/src/pages/components/theme-object.mdx
+++ b/src/pages/components/theme-object.mdx
@@ -180,7 +180,7 @@ values are weights used by Garden components.
 ### iconSizes
 
 The icon sizes object corresponds with the small, medium, and large icons
-provided by Garden's [SVG Icon](/design/icons/installation) library.
+provided by Garden's [SVG Icon](/design/icons#installation) library.
 
 ### lineHeights
 


### PR DESCRIPTION
## Description

URL was pointing to a non-existent page. Fixes to point to the `#installation` anchor on  `design/icons` page.

## Checklist

- [x] ~~:ok_hand: website updates are Garden Designer approved (add the designer as a reviewer)~~
- [x] ~~:black_nib: copy updates are approved (add the content strategist as a reviewer)~~
- [x] ~~:link: considered opportunities for adding cross-reference URLs (grep for keywords)~~
- [x] ~~:wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver~~
- [x] ~~:memo: tested in Chrome, Firefox, Safari, Edge, and IE11~~
