### PR TITLE
fix(examples): in prop sheet, use 'div' to wrap cell content in Default column

### DIFF
--- a/src/components/MarkdownProvider/components/PropSheet.tsx
+++ b/src/components/MarkdownProvider/components/PropSheet.tsx
@@ -102,7 +102,7 @@ export const PropSheet: React.FC<{
                       </MD>
                     </Cell>
                     <Cell>
-                      <MD tag="div" isMonospace={defaultMonospace}>
+                      <MD isMonospace={defaultMonospace}>
                         {prop.type === 'DefaultTheme' ? (
                           <Markdown>[DEFAULT_THEME](/components/theme-object)</Markdown>
                         ) : (

--- a/src/components/MarkdownProvider/components/PropSheet.tsx
+++ b/src/components/MarkdownProvider/components/PropSheet.tsx
@@ -102,7 +102,7 @@ export const PropSheet: React.FC<{
                       </MD>
                     </Cell>
                     <Cell>
-                      <MD tag="span" isMonospace={defaultMonospace}>
+                      <MD tag="div" isMonospace={defaultMonospace}>
                         {prop.type === 'DefaultTheme' ? (
                           <Markdown>[DEFAULT_THEME](/components/theme-object)</Markdown>
                         ) : (


### PR DESCRIPTION
## Description

Values in Default column cells can contain Tags, and DIVs shouldn't be inside SPANs.

## Detail

Before:

After:
<img width="926" alt="Screen Shot 2023-02-14 at 4 16 48 PM" src="https://user-images.githubusercontent.com/3946669/218875938-dd93d243-f04f-482d-81d1-f33bfd9d2940.png">

## Checklist
<img width="1022" alt="Screen Shot 2023-02-14 at 4 15 07 PM" src="https://user-images.githubusercontent.com/3946669/218875952-0e1daa85-f404-4091-9caf-d45506bc21d4.png">

- [ ] ~~:ok_hand: website updates are Garden Designer approved (add the designer as a reviewer)~~
- [ ] ~~:black_nib: copy updates are approved (add the content strategist as a reviewer)~~
- [ ] ~~:link: considered opportunities for adding cross-reference URLs (grep for keywords)~~
- [x] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [ ] ~~:memo: tested in Chrome, Firefox, Safari, Edge, and IE11~~
