### PR TITLE
fix(examples): add lang to datepicker localization example

### DIFF
--- a/src/examples/date-picker/DatepickerLocalization.tsx
+++ b/src/examples/date-picker/DatepickerLocalization.tsx
@@ -19,8 +19,8 @@ const Example = () => {
         <Field>
           <Label>Select a date</Label>
           <Hint>Arabic localization</Hint>
-          <Datepicker value={state} onChange={setState} locale="ar-SA">
-            <Input />
+          <Datepicker value={state} onChange={setState} locale="ar-EG">
+            <Input lang="ar-EG" />
           </Datepicker>
         </Field>
       </Col>


### PR DESCRIPTION
## Description

Adds a `lang` prop to the `Input` component for the `Datepicker` localization example.

## Detail

A change to `ar-EG` is based on colloquial speech most common understood in the middle east, compared to the formal speech of `ar-SA`.

## Checklist

- [ ] :ok_hand: website updates are Garden Designer approved (add the designer as a reviewer)
- [ ] :black_nib: copy updates are approved (add the content strategist as a reviewer)
- [ ] :link: considered opportunities for adding cross-reference URLs (grep for keywords)
- [ ] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [ ] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
