### PR TITLE
feat(markdown/components): add img alt text prop for best practices e…

### DIFF
--- a/src/components/MarkdownProvider/components/BestPractice.tsx
+++ b/src/components/MarkdownProvider/components/BestPractice.tsx
@@ -119,10 +119,12 @@ interface ISectionProps extends ICaptionProps {
   imageIsSquare?: boolean;
   imageBackgroundColor?: string;
   imageIsFreeForm?: boolean;
+  imageAltText?: string;
 }
 
 const Section: React.FC<ISectionProps> = props => {
   if (props.imageSource) {
+    const imageAltText = props.imageAltText || '';
     const imageStyles = {
       width: props.imageWidth,
       height: props.imageHeight,
@@ -140,12 +142,12 @@ const Section: React.FC<ISectionProps> = props => {
                 justify-content: center;
               `}
             >
-              <img alt="" src={props.imageSource} style={imageStyles} />
+              <img alt={imageAltText} src={props.imageSource} style={imageStyles} />
             </div>
           ) : (
             <GatsbyImage
               image={props.imageSource}
-              alt=""
+              alt={imageAltText}
               style={{
                 display: 'block',
                 margin: '0 auto',


### PR DESCRIPTION
## Description

Add `imageAltText` prop for `BestPractice` components.

## Detail

Adding support for `alt` attribute in a `BestPractices` section for `Do` and `Dont` components. The prop that is exposed is `imageAltText` which is passed as the `alt` attribute for `img` or `<GatsbyImage>` component. The default value is an empty string if no value is provided as before.

## Checklist

- [ ] :ok_hand: ~website updates are Garden Designer approved (add the designer as a reviewer)~
- [ ] :black_nib: ~copy updates are approved (add the content strategist as a reviewer)~
- [ ] :link: ~considered opportunities for adding cross-reference URLs (grep for keywords)~
- [ ] :wheelchair: ~analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver~
- [ ] :memo: ~tested in Chrome, Firefox, Safari, Edge, and IE11~
