### PR TITLE
fix: re-adds pattern link to dnd pattern docs

### DIFF
--- a/src/pages/patterns/drag-and-drop.mdx
+++ b/src/pages/patterns/drag-and-drop.mdx
@@ -8,7 +8,7 @@ description: >
 
 ## Anatomy
 
-[Drag and drop](/components/draggable)
+[Drag and drop](https://zendeskgarden.github.io/react-components/?path=/story/packages-drag-drop-patterns--drag-and-drop)
 interaction is common in workflows where the user wants to change the order or of items.
 It is also often used to build something by moving items around the screen,
 for example, a layout, report, or dashboard.


### PR DESCRIPTION
## Description

Adds link to drag and drop pattern for dnd docs.

## Checklist

- [ ] :ok_hand: website updates are Garden Designer approved (add the designer as a reviewer)
- [ ] ~~:black_nib: copy updates are approved (add the content strategist as a reviewer)~~
- [ ] ~~:link: considered opportunities for adding cross-reference URLs (grep for keywords)~~
- [ ] ~~:wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver~~
- [ ] ~~:memo: tested in Chrome, Firefox, Safari, Edge, and IE11~~
