### PR TITLE
fix(layouts): update footer link outline color

### DIFF
--- a/src/layouts/Root/components/Footer.tsx
+++ b/src/layouts/Root/components/Footer.tsx
@@ -22,6 +22,10 @@ const StyledFooterItem = styled(Link)`
   }
 
   ${SELECTOR_FOCUS_VISIBLE} {
+    /*
+      updates the default outline-color from
+      css-bedrock for the darker footer background
+    */
     outline-color: currentcolor;
   }
 


### PR DESCRIPTION
<!-- structure the Title above as the first line of a
  https://conventionalcommits.org/ message. example: "chore:
  add a new 'thing' component page". -->

## Description

Updates the website footer links focus indicator with compliant WCAG color contrast.

## Details

Before:
![before](https://github.com/zendeskgarden/website/assets/12474067/5fc7b5a9-6306-4e9b-9c07-ac569b34cbbe)
After:
![after](https://github.com/zendeskgarden/website/assets/12474067/46ec6c66-ff47-4af9-b0c7-cd69061245ad)

## Checklist

- [x] :ok_hand: website updates are Garden Designer approved (add the designer as a reviewer)
- [ ] :black_nib: ~copy updates are approved (add the content strategist as a reviewer)~
- [ ] :link: ~considered opportunities for adding cross-reference URLs (grep for keywords)~
- [ ] :wheelchair: ~analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver~
- [ ] :memo: ~tested in Chrome, Firefox, Safari, Edge, and IE11~
