### PR TITLE
feat: add nav tags and page alerts

### DIFF
--- a/src/components/MarkdownProvider/components/Alert.tsx
+++ b/src/components/MarkdownProvider/components/Alert.tsx
@@ -1,0 +1,29 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import React from 'react';
+import styled from 'styled-components';
+import {
+  Alert as GardenAlert,
+  IAlertProps as IGardenAlertProps,
+  Title
+} from '@zendeskgarden/react-notifications';
+
+const StyledAlert = styled(GardenAlert)`
+  margin-bottom: ${p => p.theme.space.xl};
+`;
+
+interface IAlertProps extends IGardenAlertProps {
+  title: string;
+}
+
+export const Alert = ({ children, title, ...props }: IAlertProps) => (
+  <StyledAlert {...props}>
+    {title && <Title>{title}</Title>}
+    {children}
+  </StyledAlert>
+);

--- a/src/components/MarkdownProvider/components/OverviewLinks.tsx
+++ b/src/components/MarkdownProvider/components/OverviewLinks.tsx
@@ -10,6 +10,7 @@ import styled from 'styled-components';
 import { ISidebarSection } from '../../../layouts/Sidebar';
 import { LG, UnorderedList } from '@zendeskgarden/react-typography';
 import { Link } from '../../../layouts/Root/components/StyledNavigationLink';
+import { NavItemTitle } from '../../../layouts/Sidebar/components/NavItemTitle';
 
 const StyledUnorderedList = styled(UnorderedList)`
   margin: 0 0 ${p => p.theme.space.sm} 0;
@@ -38,7 +39,9 @@ export const OverviewLinks: React.FC<{ nav: ISidebarSection[] }> = ({ nav }) => 
                       <UnorderedList>
                         {group.items.map(child => (
                           <UnorderedList.Item key={child.id}>
-                            <Link to={`${child.id}`}>{child.title}</Link>
+                            <Link to={`${child.id}`}>
+                              <NavItemTitle>{child.title}</NavItemTitle>
+                            </Link>
                           </UnorderedList.Item>
                         ))}
                       </UnorderedList>
@@ -48,7 +51,9 @@ export const OverviewLinks: React.FC<{ nav: ISidebarSection[] }> = ({ nav }) => 
 
                 return (
                   <StyledListItem key={group.title}>
-                    <Link to={`${group.id}`}>{group.title}</Link>
+                    <Link to={`${group.id}`}>
+                      <NavItemTitle>{group.title}</NavItemTitle>
+                    </Link>
                   </StyledListItem>
                 );
               })}

--- a/src/components/MarkdownProvider/index.tsx
+++ b/src/components/MarkdownProvider/index.tsx
@@ -7,6 +7,7 @@
 
 import React from 'react';
 import { MDXProvider } from '@mdx-js/react';
+import { Alert } from './components/Alert';
 import { Code } from '@zendeskgarden/react-typography';
 import { CodeExample } from './components/CodeExample';
 import { StyledCodeBlock as CodeBlock } from './components/CodeBlock';
@@ -33,6 +34,7 @@ export const MarkdownProvider: React.FC = ({ children }) => (
       /**
        * Helper components
        */
+      Alert,
       CodeExample,
       ColorPalette,
       Component,

--- a/src/layouts/Root/components/StyledNavigationLink.tsx
+++ b/src/layouts/Root/components/StyledNavigationLink.tsx
@@ -5,14 +5,14 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import React from 'react';
+import React, { ReactNode } from 'react';
 import styled from 'styled-components';
 import { Link as GatsbyLink } from 'gatsby';
 import { OutboundLink } from 'gatsby-plugin-google-gtag';
 import { focusStyles, getColor } from '@zendeskgarden/react-theming';
 
 interface ILink {
-  children: string;
+  children: ReactNode;
   to: string;
   activeClassName?: string;
 }

--- a/src/layouts/Sidebar/components/DesktopSidebar.tsx
+++ b/src/layouts/Sidebar/components/DesktopSidebar.tsx
@@ -12,6 +12,7 @@ import { getColor, mediaQuery } from '@zendeskgarden/react-theming';
 import { ISidebarSection } from '..';
 import { StyledNavigationLink } from 'layouts/Root/components/StyledNavigationLink';
 import { StyledSectionHeader } from 'layouts/Home/components/SectionCallout';
+import { NavItemTitle } from './NavItemTitle';
 
 const StyledSidebarLink = styled(StyledNavigationLink)`
   display: block;
@@ -58,7 +59,7 @@ export const DesktopSidebar: React.FC<{ sidebar: ISidebarSection[] }> = ({ sideb
                   to={item.id ? item.id : item.items![0].id!}
                   activeClassName={item.id ? undefined : 'active-heading'}
                 >
-                  {item.title}
+                  <NavItemTitle>{item.title}</NavItemTitle>
                 </StyledSidebarLink>
                 {isExpanded && (
                   <ul
@@ -74,7 +75,7 @@ export const DesktopSidebar: React.FC<{ sidebar: ISidebarSection[] }> = ({ sideb
                         `}
                       >
                         <StyledSidebarLink to={nestedItem.id!}>
-                          {nestedItem.title}
+                          <NavItemTitle>{nestedItem.title}</NavItemTitle>
                         </StyledSidebarLink>
                       </li>
                     ))}

--- a/src/layouts/Sidebar/components/MobileSidebar.tsx
+++ b/src/layouts/Sidebar/components/MobileSidebar.tsx
@@ -12,6 +12,7 @@ import { getColor, mediaQuery } from '@zendeskgarden/react-theming';
 import { StyledNavigationLink } from 'layouts/Root/components/StyledNavigationLink';
 import { StyledSectionHeader } from 'layouts/Home/components/SectionCallout';
 import { ISidebarSection } from '..';
+import { NavItemTitle } from './NavItemTitle';
 
 const StyledSidebarLink = styled(StyledNavigationLink)`
   display: block;
@@ -63,7 +64,7 @@ export const MobileSidebar: React.FC<{ sidebar: ISidebarSection[] }> = ({ sideba
               to={item.id ? item.id : item.items![0].id!}
               activeClassName={item.id ? undefined : 'active-heading'}
             >
-              {item.title}
+              <NavItemTitle>{item.title}</NavItemTitle>
             </StyledSidebarLink>
             {isExpanded && (
               <ul
@@ -78,7 +79,9 @@ export const MobileSidebar: React.FC<{ sidebar: ISidebarSection[] }> = ({ sideba
                       margin-top: ${p => p.theme.space.xxs};
                     `}
                   >
-                    <StyledSidebarLink to={nestedItem.id!}>{nestedItem.title}</StyledSidebarLink>
+                    <StyledSidebarLink to={nestedItem.id!}>
+                      <NavItemTitle>{nestedItem.title}</NavItemTitle>
+                    </StyledSidebarLink>
                   </li>
                 ))}
               </ul>

--- a/src/layouts/Sidebar/components/NavItemTitle.tsx
+++ b/src/layouts/Sidebar/components/NavItemTitle.tsx
@@ -5,8 +5,9 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import { Tag } from '@zendeskgarden/react-tags';
 import React from 'react';
+import { PALETTE } from '@zendeskgarden/react-theming';
+import { Tag } from '@zendeskgarden/react-tags';
 
 interface INavItemTitleProps {
   children: string;
@@ -14,7 +15,7 @@ interface INavItemTitleProps {
 
 export const NavItemTitle = ({ children }: INavItemTitleProps) => {
   const tags: string[] = [];
-  const regex = /\s*?\[(?<tag>.*?)\]/gmu;
+  const regex = /\s*?\((?<tag>.*?)\)/gmu;
   const title = children.replace(regex, (_, tag) => {
     tags.push(tag);
 
@@ -29,7 +30,7 @@ export const NavItemTitle = ({ children }: INavItemTitleProps) => {
 
         switch (tag) {
           case 'deprecated':
-            hue = 'yellow';
+            hue = PALETTE.yellow[200];
             break;
 
           case 'new':
@@ -39,7 +40,7 @@ export const NavItemTitle = ({ children }: INavItemTitleProps) => {
 
         return (
           <Tag key={index} hue={hue} size="small">
-            {tag}
+            {tag.charAt(0).toUpperCase() + tag.slice(1)}
           </Tag>
         );
       })}

--- a/src/layouts/Sidebar/components/NavItemTitle.tsx
+++ b/src/layouts/Sidebar/components/NavItemTitle.tsx
@@ -15,7 +15,7 @@ interface INavItemTitleProps {
 
 export const NavItemTitle = ({ children }: INavItemTitleProps) => {
   const tags: string[] = [];
-  const regex = /\s*?\((?<tag>.*?)\)/gmu;
+  const regex = /\s*?\[(?<tag>.*?)\]/gmu;
   const title = children.replace(regex, (_, tag) => {
     tags.push(tag);
 

--- a/src/layouts/Sidebar/components/NavItemTitle.tsx
+++ b/src/layouts/Sidebar/components/NavItemTitle.tsx
@@ -38,7 +38,7 @@ export const NavItemTitle = ({ children }: INavItemTitleProps) => {
         }
 
         return (
-          <Tag key={index} hue={hue}>
+          <Tag key={index} hue={hue} size="small">
             {tag}
           </Tag>
         );

--- a/src/layouts/Sidebar/components/NavItemTitle.tsx
+++ b/src/layouts/Sidebar/components/NavItemTitle.tsx
@@ -1,0 +1,48 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import { Tag } from '@zendeskgarden/react-tags';
+import React from 'react';
+
+interface INavItemTitleProps {
+  children: string;
+}
+
+export const NavItemTitle = ({ children }: INavItemTitleProps) => {
+  const tags: string[] = [];
+  const regex = /\s*?\[(?<tag>.*?)\]/gmu;
+  const title = children.replace(regex, (_, tag) => {
+    tags.push(tag);
+
+    return '';
+  });
+
+  return (
+    <>
+      {title}{' '}
+      {tags.map((tag, index) => {
+        let hue;
+
+        switch (tag) {
+          case 'deprecated':
+            hue = 'yellow';
+            break;
+
+          case 'new':
+            hue = 'green';
+            break;
+        }
+
+        return (
+          <Tag key={index} hue={hue}>
+            {tag}
+          </Tag>
+        );
+      })}
+    </>
+  );
+};

--- a/src/nav/components.yml
+++ b/src/nav/components.yml
@@ -37,7 +37,7 @@
         - id: /components/button
           title: Button
         - id: /components/button-group
-          title: Button group
+          title: Button group [deprecated]
         - id: /components/icon-button
           title: Icon button
         - id: /components/split-button

--- a/src/nav/components.yml
+++ b/src/nav/components.yml
@@ -37,7 +37,7 @@
         - id: /components/button
           title: Button
         - id: /components/button-group
-          title: Button group (deprecated)
+          title: Button group [deprecated]
         - id: /components/icon-button
           title: Icon button
         - id: /components/split-button

--- a/src/nav/components.yml
+++ b/src/nav/components.yml
@@ -37,7 +37,7 @@
         - id: /components/button
           title: Button
         - id: /components/button-group
-          title: Button group [deprecated]
+          title: Button group (deprecated)
         - id: /components/icon-button
           title: Icon button
         - id: /components/split-button

--- a/src/pages/components/button-group.mdx
+++ b/src/pages/components/button-group.mdx
@@ -8,8 +8,9 @@ components:
   - buttons/src/elements/ButtonGroup.tsx
 ---
 
-This is a legacy component and may be deprecated in the future. Garden does not presently
-recommend the use of Button groups.
+<Alert title="Deprecated" type="warning">
+  Garden does not presently recommend the use of Button groups
+</Alert>
 
 <Usage>
   <Use>


### PR DESCRIPTION
## Description

This PR is a prerequisite for the new `Combobox` page as I want the ability to tag deprecated dropdowns and alert folks to the new, replacement component. The basic gist is that `(tag)` type notation can be added to [components.yml](https://github.com/zendeskgarden/website/blob/main/src/nav/components.yml) in order to render Garden tags in the navigation UI. The words "deprecated" and "new" get special hue treatment (see below). Otherwise, the standard neutral tag color is applied.

In addition, a new `Alert` markdown component was added in order to render Garden alerts at the top of a (deprecated) component page.

## Detail

Here are a few tag examples (only Button group is committed with this PR):

<img width="223" alt="Screenshot 2023-07-11 at 10 12 00 AM" src="https://github.com/zendeskgarden/website/assets/143773/e135e958-5119-44da-bbf7-5f7ea8495e3a">

<img width="220" alt="Screenshot 2023-07-10 at 3 01 57 PM" src="https://github.com/zendeskgarden/website/assets/143773/52adef32-7caa-4e21-95cc-abb198e3d22d">

<img width="123" alt="Screenshot 2023-07-10 at 3 02 07 PM" src="https://github.com/zendeskgarden/website/assets/143773/43a95bbd-f735-4960-a057-d76251474bb2">

And here's the before/after on the Button group page showing use of the `<Alert>`:

**before**

<img width="747" alt="Screenshot 2023-07-10 at 3 05 05 PM" src="https://github.com/zendeskgarden/website/assets/143773/6f31bd90-127f-40c9-95d2-b366fad6b62e">

**after**

<img width="751" alt="Screenshot 2023-07-10 at 3 04 53 PM" src="https://github.com/zendeskgarden/website/assets/143773/ed24168e-a1ad-4b4d-9e8d-091203b7587e">

## Checklist

- [x] :ok_hand: website updates are Garden Designer approved (add the designer as a reviewer)
- [ ] :black_nib: ~copy updates are approved (add the content strategist as a reviewer)~
- [ ] :link: ~considered opportunities for adding cross-reference URLs (grep for keywords)~
- [x] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [ ] :memo: ~tested in Chrome, Firefox, Safari, Edge, and IE11~
