### PR TITLE
chore(chrome): add GlobalAlert example

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -19,4 +19,4 @@
 - [ ] :black_nib: copy updates are approved (add the content strategist as a reviewer)
 - [ ] :link: considered opportunities for adding cross-reference URLs (grep for keywords)
 - [ ] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
-- [ ] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
+- [ ] :memo: tested in Chrome, Firefox, Safari, Edge

--- a/src/examples/chrome/GlobalAlert.tsx
+++ b/src/examples/chrome/GlobalAlert.tsx
@@ -5,7 +5,8 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import React, { useLayoutEffect, useRef, useState } from 'react';
+import React, { useState } from 'react';
+import useResizeObserver from 'use-resize-observer';
 import { ReactComponent as ProductIcon } from '@zendeskgarden/svg-icons/src/26/garden.svg';
 import { ReactComponent as HomeIcon } from '@zendeskgarden/svg-icons/src/26/home-fill.svg';
 import { ReactComponent as EmailIcon } from '@zendeskgarden/svg-icons/src/26/email-fill.svg';
@@ -29,26 +30,17 @@ import {
 import { GlobalAlert } from '@zendeskgarden/react-notifications';
 import { Button } from '@zendeskgarden/react-buttons';
 
+const HEIGHT = 400; // Chrome's 100vh height adjusted for demo
+
 const Example = () => {
-  const HEIGHT = 400;
-  const [height, setHeight] = useState(HEIGHT); // 100vh height adjusted for demo
+  const { height = 0, ref } = useResizeObserver({ box: 'border-box' });
   const [showGlobalAlert, setShowGlobalAlert] = useState(true);
   const [nav, setNav] = useState('nav-1');
-  const globalAlertRef = useRef<HTMLDivElement>(null);
-
-  useLayoutEffect(() => {
-    // Compensate for the addition of a Global alert
-    setHeight(
-      showGlobalAlert && globalAlertRef.current
-        ? HEIGHT - globalAlertRef.current.offsetHeight
-        : HEIGHT
-    );
-  }, [showGlobalAlert]);
 
   return (
-    <>
+    <div style={{ minWidth: 600 }}>
       {showGlobalAlert && (
-        <GlobalAlert type="info" ref={globalAlertRef}>
+        <GlobalAlert type="info" ref={ref}>
           <GlobalAlert.Content>
             <GlobalAlert.Title>Info</GlobalAlert.Title>
             Gumbo beet greens corn soko endive gumbo gourd.
@@ -59,7 +51,7 @@ const Example = () => {
           />
         </GlobalAlert>
       )}
-      <Chrome isFluid style={{ height, minWidth: 600 }}>
+      <Chrome isFluid style={{ height: showGlobalAlert ? HEIGHT - height : HEIGHT }}>
         <SkipNav targetId="example-global-alert-main-content">Skip to main content</SkipNav>
         <Nav aria-label="chrome example nav">
           <NavItem hasLogo>
@@ -110,7 +102,7 @@ const Example = () => {
           </Footer>
         </Body>
       </Chrome>
-    </>
+    </div>
   );
 };
 

--- a/src/examples/chrome/GlobalAlert.tsx
+++ b/src/examples/chrome/GlobalAlert.tsx
@@ -1,0 +1,117 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import React, { useLayoutEffect, useRef, useState } from 'react';
+import { ReactComponent as ProductIcon } from '@zendeskgarden/svg-icons/src/26/garden.svg';
+import { ReactComponent as HomeIcon } from '@zendeskgarden/svg-icons/src/26/home-fill.svg';
+import { ReactComponent as EmailIcon } from '@zendeskgarden/svg-icons/src/26/email-fill.svg';
+import { ReactComponent as SettingsIcon } from '@zendeskgarden/svg-icons/src/26/settings-fill.svg';
+import { ReactComponent as ZendeskIcon } from '@zendeskgarden/svg-icons/src/26/zendesk.svg';
+import { PALETTE } from '@zendeskgarden/react-theming';
+import {
+  Body,
+  Chrome,
+  Content,
+  Footer,
+  FooterItem,
+  Header,
+  Main,
+  Nav,
+  NavItem,
+  NavItemIcon,
+  NavItemText,
+  SkipNav
+} from '@zendeskgarden/react-chrome';
+import { GlobalAlert } from '@zendeskgarden/react-notifications';
+import { Button } from '@zendeskgarden/react-buttons';
+
+const Example = () => {
+  const HEIGHT = 400;
+  const [height, setHeight] = useState(HEIGHT); // 100vh height adjusted for demo
+  const [showGlobalAlert, setShowGlobalAlert] = useState(true);
+  const [nav, setNav] = useState('nav-1');
+  const globalAlertRef = useRef<HTMLDivElement>(null);
+
+  useLayoutEffect(() => {
+    // Compensate for the addition of a Global alert
+    setHeight(
+      showGlobalAlert && globalAlertRef.current
+        ? HEIGHT - globalAlertRef.current.offsetHeight
+        : HEIGHT
+    );
+  }, [showGlobalAlert]);
+
+  return (
+    <>
+      {showGlobalAlert && (
+        <GlobalAlert type="info" ref={globalAlertRef}>
+          <GlobalAlert.Content>
+            <GlobalAlert.Title>Info</GlobalAlert.Title>
+            Gumbo beet greens corn soko endive gumbo gourd.
+          </GlobalAlert.Content>
+          <GlobalAlert.Close
+            aria-label="Close Global Alert"
+            onClick={() => setShowGlobalAlert(false)}
+          />
+        </GlobalAlert>
+      )}
+      <Chrome isFluid style={{ height, minWidth: 600 }}>
+        <SkipNav targetId="example-global-alert-main-content">Skip to main content</SkipNav>
+        <Nav aria-label="chrome example nav">
+          <NavItem hasLogo>
+            <NavItemIcon>
+              <ProductIcon style={{ color: PALETTE.green[400] }} />
+            </NavItemIcon>
+            <NavItemText>Zendesk Garden</NavItemText>
+          </NavItem>
+          <NavItem isCurrent={nav === 'nav-1'} onClick={() => setNav('nav-1')}>
+            <NavItemIcon>
+              <HomeIcon />
+            </NavItemIcon>
+            <NavItemText>Home</NavItemText>
+          </NavItem>
+          <NavItem isCurrent={nav === 'nav-2'} onClick={() => setNav('nav-2')}>
+            <NavItemIcon>
+              <EmailIcon />
+            </NavItemIcon>
+            <NavItemText>Email</NavItemText>
+          </NavItem>
+          <NavItem isCurrent={nav === 'nav-3'} onClick={() => setNav('nav-3')}>
+            <NavItemIcon>
+              <SettingsIcon />
+            </NavItemIcon>
+            <NavItemText>Settings</NavItemText>
+          </NavItem>
+          <NavItem hasBrandmark title="Zendesk">
+            <NavItemIcon>
+              <ZendeskIcon />
+            </NavItemIcon>
+            <NavItemText>Zendesk</NavItemText>
+          </NavItem>
+        </Nav>
+        <Body hasFooter>
+          <Header />
+          <Content id="example-global-alert-main-content">
+            <Main style={{ padding: 28 }} />
+          </Content>
+          <Footer>
+            <FooterItem>
+              <Button isBasic>Cancel</Button>
+            </FooterItem>
+            <FooterItem>
+              <Button isPrimary onClick={() => setShowGlobalAlert(true)}>
+                Save
+              </Button>
+            </FooterItem>
+          </Footer>
+        </Body>
+      </Chrome>
+    </>
+  );
+};
+
+export default Example;

--- a/src/pages/components/chrome.mdx
+++ b/src/pages/components/chrome.mdx
@@ -51,7 +51,7 @@ import DefaultCode from '!!raw-loader!../../examples/chrome/ChromeDefault.tsx';
 
 ### Global alert
 
-Remember to adjust Chrome height with the addition of Global alerts.
+Remember to adjust Chrome height with the addition of [Global alerts](/components/global-alert).
 
 import GlobalAlert from '../../examples/chrome/GlobalAlert.tsx';
 import GlobalAlertCode from '!!raw-loader!../../examples/chrome/GlobalAlert.tsx';

--- a/src/pages/components/chrome.mdx
+++ b/src/pages/components/chrome.mdx
@@ -49,6 +49,17 @@ import DefaultCode from '!!raw-loader!../../examples/chrome/ChromeDefault.tsx';
   <Default />
 </CodeExample>
 
+### Global alert
+
+Remember to adjust Chrome height with the addition of Global alerts.
+
+import GlobalAlert from '../../examples/chrome/GlobalAlert.tsx';
+import GlobalAlertCode from '!!raw-loader!../../examples/chrome/GlobalAlert.tsx';
+
+<CodeExample code={GlobalAlertCode}>
+  <GlobalAlert />
+</CodeExample>
+
 ### Standalone header
 
 A Header component can be used in isolation while still displaying Zendesk product logos.


### PR DESCRIPTION
## Description

Adds new "Global alert" example to the Chrome component page.

## Checklist

- [x] :ok_hand: website updates are Garden Designer approved (add the designer as a reviewer)
- [ ] :black_nib: ~copy updates are approved (add the content strategist as a reviewer)~
- [x] :link: considered opportunities for adding cross-reference URLs (grep for keywords)
- [x] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [x] :memo: tested in Chrome, Firefox, Safari, Edge
