### PR TITLE
fix: restore SVG `viewBox` attributes

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -337,8 +337,12 @@ module.exports = {
         svgoConfig: {
           plugins: [
             {
-              name: 'removeViewBox',
-              active: false
+              name: 'preset-default',
+              params: {
+                overrides: {
+                  removeViewBox: false
+                }
+              }
             },
             {
               name: 'addAttributesToSVGElement',


### PR DESCRIPTION
## Description

The latest SVGO requires updated syntax.

## Detail

Broke with #500
