### PR TITLE
chore(chrome): clarify nav `hue` copy

### DIFF
--- a/src/pages/components/chrome.mdx
+++ b/src/pages/components/chrome.mdx
@@ -74,8 +74,10 @@ import StandaloneHeaderCode from '!!raw-loader!../../examples/chrome/ChromeStand
 ### Navigation panel
 
 The panel can be expanded to display labels alongside nav icons. A subnav can be
-shown for additional items. The `hue` can be modified to change the color while
-still maintaining accessible contrast levels.
+shown for additional items. The `hue` can be modified to change the nav
+background color. Note this may result in inaccessible contrast levels on nav
+buttons. Always test the resulting contrast values to ensure they're compliant
+with WCAG guidelines.
 
 import Navigation from '../../examples/chrome/ChromeNavigation.tsx';
 import NavigationCode from '!!raw-loader!../../examples/chrome/ChromeNavigation.tsx';


### PR DESCRIPTION
## Description

Updated copy with noted a11y clarification.

## Checklist

- [x] :ok_hand: website updates are Garden Designer approved (add the designer as a reviewer)
- [x] :black_nib: copy updates are approved (add the content strategist as a reviewer)
- [ ] :link: ~considered opportunities for adding cross-reference URLs (grep for keywords)~
- [ ] :wheelchair: ~analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver~
- [ ] :memo: ~tested in Chrome, Firefox, Safari, Edge~
