### PR TITLE
Update `Input` `Placeholder` section

### DIFF
--- a/src/pages/components/input.mdx
+++ b/src/pages/components/input.mdx
@@ -123,6 +123,8 @@ import IconsCode from '!!raw-loader!../../examples/forms/inputs/MediaInput.tsx';
 ### Placeholder
 
 Placeholder text provides the user with example content or additional context.
+Use icon to provide a visual affordance when the [label is hidden](#hidden-label)
+(for example, Search).
 
 import Placeholder from '../../examples/forms/inputs/Placeholder.tsx';
 import PlaceholderCode from '!!raw-loader!../../examples/forms/inputs/Placeholder.tsx';


### PR DESCRIPTION
Expanding the documentation to address ZDGDN-514 issue.

## Description

Added one line explainer to make it more clear that `Inputs` with `Placeholder` should use an icon and a label hidden to provide a needed visual affordance (as the placeholder text color will not conform to 3:1 contrast ratio).