### PR TITLE
fix: correct external URLs to NPM and Github

### DIFF
--- a/plugins/gatsby-source-garden-docgen/README.md
+++ b/plugins/gatsby-source-garden-docgen/README.md
@@ -6,7 +6,6 @@ query {
     version
     name
     description
-    packageName
   }
   components: gardenReactComponent {
     name

--- a/src/components/MarkdownProvider/components/Configuration.tsx
+++ b/src/components/MarkdownProvider/components/Configuration.tsx
@@ -56,14 +56,12 @@ export const Configuration: React.FC<{
       {reactPackage.version}
       <StyledDot>•</StyledDot>
       <StyledAnchor
-        href={`https://github.com/zendeskgarden/react-components/tree/main/packages/${reactPackage.packageName}`}
+        href={`https://github.com/zendeskgarden/react-components/tree/main/packages/${reactPackage.packageName.replace('@zendeskgarden/react-', '')}`}
       >
         View source
       </StyledAnchor>
       <StyledDot>•</StyledDot>
-      <StyledAnchor
-        href={`https://www.npmjs.com/package/@zendeskgarden/react-${reactPackage.packageName}`}
-      >
+      <StyledAnchor href={`https://www.npmjs.com/package/${reactPackage.packageName}`}>
         View on npm
       </StyledAnchor>
     </StyledListItem>

--- a/src/components/MarkdownProvider/components/Configuration.tsx
+++ b/src/components/MarkdownProvider/components/Configuration.tsx
@@ -15,7 +15,6 @@ import { StyledAnchor } from './Anchor';
 interface IPackage {
   version: string;
   name: string;
-  packageName: string;
 }
 
 const StyledUnorderedList = styled(UnorderedList)`
@@ -56,12 +55,12 @@ export const Configuration: React.FC<{
       {reactPackage.version}
       <StyledDot>•</StyledDot>
       <StyledAnchor
-        href={`https://github.com/zendeskgarden/react-components/tree/main/packages/${reactPackage.packageName.replace('@zendeskgarden/react-', '')}`}
+        href={`https://github.com/zendeskgarden/react-components/tree/main/packages/${reactPackage.name.replace('@zendeskgarden/react-', '')}`}
       >
         View source
       </StyledAnchor>
       <StyledDot>•</StyledDot>
-      <StyledAnchor href={`https://www.npmjs.com/package/${reactPackage.packageName}`}>
+      <StyledAnchor href={`https://www.npmjs.com/package/${reactPackage.name}`}>
         View on npm
       </StyledAnchor>
     </StyledListItem>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -48,7 +48,6 @@ export const SidebarPageFragment = graphql`
         version
         name
         description
-        packageName: name
       }
       components: reactComponents {
         name


### PR DESCRIPTION
## Description

Fix external URLs to NPM and Github

## Detail
- Fix external URLs to NPM and Github
- Improves type safety
- Remove redundant packageName aliased field from query


## Checklist

- [ ] ~~:ok_hand: website updates are Garden Designer approved (add the designer as a reviewer)~~
- [ ] ~~:black_nib: copy updates are approved (add the content strategist as a reviewer)~~
- [ ] ~~:link: considered opportunities for adding cross-reference URLs (grep for keywords)~~
- [ ] ~~:wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver~~
- [x] :memo: tested in Chrome, Firefox, Safari, Edge
