### PR TITLE
feat(examples): updates table overflow to demonstrate new menu

### DIFF
--- a/src/examples/table/TableOverflow.tsx
+++ b/src/examples/table/TableOverflow.tsx
@@ -6,7 +6,7 @@
  */
 
 import React, { ButtonHTMLAttributes } from 'react';
-import { Dropdown, Trigger, Menu, Item } from '@zendeskgarden/react-dropdowns';
+import { Menu, Item } from '@zendeskgarden/react-dropdowns.next';
 import { Tooltip } from '@zendeskgarden/react-tooltips';
 import {
   Body,
@@ -28,35 +28,15 @@ const TooltipOverflowButton = React.forwardRef(
 );
 
 const OverflowMenu = () => (
-  <Dropdown>
-    <Trigger>
-      <TooltipOverflowButton aria-label="Row actions" />
-    </Trigger>
-    <Menu
-      placement="bottom-end"
-      popperModifiers={{
-        preventOverflow: {
-          boundariesElement: 'viewport'
-        },
-        flip: {
-          enabled: false
-        },
-        offset: {
-          fn: data => {
-            /**
-             * Ensure correct placement relative to trigger
-             **/
-            data.offsets.popper.top -= 2;
-
-            return data;
-          }
-        }
-      }}
-    >
-      <Item value="item-1">Edit</Item>
-      <Item value="item-2">Delete</Item>
-    </Menu>
-  </Dropdown>
+  <Menu
+    button={props => <TooltipOverflowButton aria-label="Row actions" {...props} />}
+    placement="bottom-end"
+  >
+    <Item value="item-1">Edit</Item>
+    <Item value="item-2" type="danger">
+      Delete
+    </Item>
+  </Menu>
 );
 
 const Example = () => (


### PR DESCRIPTION
## Description

Table Overflow example has been using the old Dropdown/Menu. This PR replaces it with the new one.

Adds `danger` type to the "Delete" item for semantic emphasis.

## Checklist

- [ ] :ok_hand: website updates are Garden Designer approved (add the designer as a reviewer)
- ~~:black_nib: copy updates are approved (add the content strategist as a reviewer)~~
- ~~:link: considered opportunities for adding cross-reference URLs (grep for keywords)~~
- ~~:wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver~~
- ~~:memo: tested in Chrome, Firefox, Safari, Edge~~
