### PR TITLE
chore: add empty project .eslintrc to disable Gatsby's eslint loaders 

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,16 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+/**
+ * Disables Gatsby's built-in eslint-loader called by `gatsby develop`.
+ * @see https://www.gatsbyjs.com/docs/how-to/custom-configuration/eslint/#disabling-eslint
+ * Rules required by Gatsby for fast-refresh are automatcally applied.
+ * @see https://github.com/gatsbyjs/gatsby/blob/gatsby%405.13.6/packages/gatsby/src/utils/webpack.config.js#L269
+ * @see https://github.com/gatsbyjs/gatsby/blob/gatsby%405.13.6/packages/gatsby/src/utils/webpack-utils.ts#L820-L846
+ * This does not interfere with this project ESLint V9's flat config.
+ */
+module.exports = {};

--- a/package-lock.json
+++ b/package-lock.json
@@ -5785,9 +5785,9 @@
       "dev": true
     },
     "node_modules/@types/eslint": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-7.29.0.tgz",
-      "integrity": "sha512-VNcvioYDH8/FxaeTKkM4/TiTwt6pBV9E3OfGmvaw8tPl0rrHCJ4Ll15HRT+pMiFAf/MLQvAzC+6RzUMEL9Ceng==",
+      "version": "8.56.11",
+      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.56.11.tgz",
+      "integrity": "sha512-sVBpJMf7UPo/wGecYOpk2aQya2VUGeHhe38WG7/mN5FufNSubf5VT9Uh9Uyp8/eLJpu1/tuhJ/qTo4mhSB4V4Q==",
       "dev": true,
       "dependencies": {
         "@types/estree": "*",
@@ -13293,69 +13293,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/eslint-webpack-plugin": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/eslint-webpack-plugin/-/eslint-webpack-plugin-2.7.0.tgz",
-      "integrity": "sha512-bNaVVUvU4srexGhVcayn/F4pJAz19CWBkKoMx7aSQ4wtTbZQCnG5O9LHCE42mM+JSKOUp7n6vd5CIwzj7lOVGA==",
-      "dev": true,
-      "dependencies": {
-        "@types/eslint": "^7.29.0",
-        "arrify": "^2.0.1",
-        "jest-worker": "^27.5.1",
-        "micromatch": "^4.0.5",
-        "normalize-path": "^3.0.0",
-        "schema-utils": "^3.1.1"
-      },
-      "engines": {
-        "node": ">= 10.13.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/webpack"
-      },
-      "peerDependencies": {
-        "eslint": "^7.0.0 || ^8.0.0",
-        "webpack": "^4.0.0 || ^5.0.0"
-      }
-    },
-    "node_modules/eslint-webpack-plugin/node_modules/has-flag": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/eslint-webpack-plugin/node_modules/jest-worker": {
-      "version": "27.5.1",
-      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.5.1.tgz",
-      "integrity": "sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==",
-      "dev": true,
-      "dependencies": {
-        "@types/node": "*",
-        "merge-stream": "^2.0.0",
-        "supports-color": "^8.0.0"
-      },
-      "engines": {
-        "node": ">= 10.13.0"
-      }
-    },
-    "node_modules/eslint-webpack-plugin/node_modules/supports-color": {
-      "version": "8.1.1",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
-      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
-      "dev": true,
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/supports-color?sponsor=1"
-      }
-    },
     "node_modules/eslint/node_modules/ansi-styles": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -16959,6 +16896,16 @@
       "dev": true,
       "license": "BSD-3-Clause"
     },
+    "node_modules/gatsby/node_modules/@types/eslint": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-7.29.0.tgz",
+      "integrity": "sha512-VNcvioYDH8/FxaeTKkM4/TiTwt6pBV9E3OfGmvaw8tPl0rrHCJ4Ll15HRT+pMiFAf/MLQvAzC+6RzUMEL9Ceng==",
+      "dev": true,
+      "dependencies": {
+        "@types/estree": "*",
+        "@types/json-schema": "*"
+      }
+    },
     "node_modules/gatsby/node_modules/@typescript-eslint/eslint-plugin": {
       "version": "5.62.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.62.0.tgz",
@@ -17352,6 +17299,31 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/gatsby/node_modules/eslint-webpack-plugin": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/eslint-webpack-plugin/-/eslint-webpack-plugin-2.7.0.tgz",
+      "integrity": "sha512-bNaVVUvU4srexGhVcayn/F4pJAz19CWBkKoMx7aSQ4wtTbZQCnG5O9LHCE42mM+JSKOUp7n6vd5CIwzj7lOVGA==",
+      "dev": true,
+      "dependencies": {
+        "@types/eslint": "^7.29.0",
+        "arrify": "^2.0.1",
+        "jest-worker": "^27.5.1",
+        "micromatch": "^4.0.5",
+        "normalize-path": "^3.0.0",
+        "schema-utils": "^3.1.1"
+      },
+      "engines": {
+        "node": ">= 10.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      },
+      "peerDependencies": {
+        "eslint": "^7.0.0 || ^8.0.0",
+        "webpack": "^4.0.0 || ^5.0.0"
+      }
+    },
     "node_modules/gatsby/node_modules/eslint/node_modules/@babel/code-frame": {
       "version": "7.12.11",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.11.tgz",
@@ -17515,6 +17487,35 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/gatsby/node_modules/jest-worker": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.5.1.tgz",
+      "integrity": "sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*",
+        "merge-stream": "^2.0.0",
+        "supports-color": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 10.13.0"
+      }
+    },
+    "node_modules/gatsby/node_modules/jest-worker/node_modules/supports-color": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
     "node_modules/gatsby/node_modules/js-yaml": {


### PR DESCRIPTION
## Description
Following the [ESLint v9 update](https://github.com/zendeskgarden/website/pull/585), running `gatsby develop` via `npm start` prevented development and threw the following error:

```
ERROR #98123  WEBPACK.DEVELOP

Generating development JavaScript bundle failed

Invalid Options:
- Unknown options: extensions, useEslintrc, resolvePluginsRelativeTo, rulePaths
- 'extensions' has been removed.
- 'resolvePluginsRelativeTo' has been removed.
- 'rulePaths' has been removed. Please define your rules using plugins.

failed Building development bundle - 39.711s
ERROR in Invalid Options:
- Unknown options: extensions, useEslintrc, resolvePluginsRelativeTo, rulePaths
- 'extensions' has been removed.
- 'resolvePluginsRelativeTo' has been removed.
- 'rulePaths' has been removed. Please define your rules using plugins.

develop compiled with 1 error
success Writing page-data.json and slice-data.json files to public directory - 0.175s - 2/94 536.22/s
success Generating GraphQL and TypeScript types - 0.296s
```

This PR fixes the issue by disabling Gatsby's build-in ESLint checks.

## Detail
After investigating, I found that the latest release of `gatsby@5.13.6` is still on [eslint@^7.32.0](https://github.com/gatsbyjs/gatsby/blob/gatsby%405.13.6/packages/gatsby/package.json#L76). When running `gatsby develop`, `webpack` calls `eslint` using [eslint-webpack-plugin](https://github.com/gatsbyjs/gatsby/blob/gatsby%405.13.6/packages/gatsby/src/utils/webpack-utils.ts#L13) with Gatsby’s own “non-flat” [config](https://github.com/gatsbyjs/gatsby/blob/gatsby%405.13.6/packages/gatsby/src/utils/eslint-config.ts). However, because the resolved version of ESLint is the project's (`eslint@9.6.0`) rather than Gatsby's, ESLint fails parsing the legacy config, throws an error, and interrupts the compilation.

While I considered using [gatsby-plugin-eslint](https://www.gatsbyjs.com/plugins/gatsby-plugin-eslint/) to gain control of Gatsby's ESLint config, I concluded it was simpler to [disable](https://www.gatsbyjs.com/docs/how-to/custom-configuration/eslint/#disabling-eslint) ESLint. Doing so still [enforces](https://github.com/gatsbyjs/gatsby/blob/gatsby%405.13.6/packages/gatsby/src/utils/webpack.config.js#L269) the required checks in dev mode, while keeping this project on ESLint V9.

