### PR TITLE
chore: prepare theming upgrade with getColorV8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33610,6 +33610,48 @@
       "integrity": "sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA==",
       "dev": true
     },
+    "node_modules/netlify-cli/node_modules/@types/body-parser": {
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.2.tgz",
+      "integrity": "sha512-ALYone6pm6QmwZoAgeyNksccT9Q4AWZQ6PvfwR37GT6r6FWUPguq6sUmNGSMV2Wr761oQoBxwGGa6DR5o1DC9g==",
+      "extraneous": true,
+      "dependencies": {
+        "@types/connect": "*",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/netlify-cli/node_modules/@types/connect": {
+      "version": "3.4.35",
+      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.35.tgz",
+      "integrity": "sha512-cdeYyv4KWoEgpBISTxWvqYsVy444DOqehiF3fM3ne10AmJ62RSyNkUnxMJXHQWRQQX2eR94m5y1IZyDwBjV9FQ==",
+      "extraneous": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/netlify-cli/node_modules/@types/express": {
+      "version": "4.17.13",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.13.tgz",
+      "integrity": "sha512-6bSZTPaTIACxn48l50SR+axgrqm6qXFIxrdAKaG6PaJk3+zuUr35hBlgT7vOmJcum+OEaIBLtHV/qloEAFITeA==",
+      "extraneous": true,
+      "dependencies": {
+        "@types/body-parser": "*",
+        "@types/express-serve-static-core": "^4.17.18",
+        "@types/qs": "*",
+        "@types/serve-static": "*"
+      }
+    },
+    "node_modules/netlify-cli/node_modules/@types/express-serve-static-core": {
+      "version": "4.17.28",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.28.tgz",
+      "integrity": "sha512-P1BJAEAW3E2DJUlkgq4tOL3RyMunoWXqbSCygWo5ZIWTjUgN1YnaXWW4VWl/oc8vs/XoYibEGBKP0uZyF4AHig==",
+      "extraneous": true,
+      "dependencies": {
+        "@types/node": "*",
+        "@types/qs": "*",
+        "@types/range-parser": "*"
+      }
+    },
     "node_modules/netlify-cli/node_modules/@types/http-cache-semantics": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.4.tgz",
@@ -33649,6 +33691,12 @@
         "@types/istanbul-lib-report": "*"
       }
     },
+    "node_modules/netlify-cli/node_modules/@types/mime": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.2.tgz",
+      "integrity": "sha512-YATxVxgRqNH6nHEIsvg6k2Boc1JHI9ZbH5iWFFv/MTkchz3b1ieGDa5T0a9RznNdI0KhVbdbWSN+KWWrQZRxTw==",
+      "extraneous": true
+    },
     "node_modules/netlify-cli/node_modules/@types/node": {
       "version": "20.14.2",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.2.tgz",
@@ -33664,11 +33712,33 @@
       "integrity": "sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==",
       "dev": true
     },
+    "node_modules/netlify-cli/node_modules/@types/qs": {
+      "version": "6.9.7",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.7.tgz",
+      "integrity": "sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw==",
+      "extraneous": true
+    },
+    "node_modules/netlify-cli/node_modules/@types/range-parser": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.4.tgz",
+      "integrity": "sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw==",
+      "extraneous": true
+    },
     "node_modules/netlify-cli/node_modules/@types/retry": {
       "version": "0.12.1",
       "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.1.tgz",
       "integrity": "sha512-xoDlM2S4ortawSWORYqsdU+2rxdh4LRW9ytc3zmT37RIKQh6IHyKwwtKhKis9ah8ol07DCkZxPt8BBvPjC6v4g==",
       "dev": true
+    },
+    "node_modules/netlify-cli/node_modules/@types/serve-static": {
+      "version": "1.13.10",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.13.10.tgz",
+      "integrity": "sha512-nCkHGI4w7ZgAdNkrEu0bv+4xNV/XDqW+DydknebMOQwkpDGx8G+HTlj7R7ABI8i8nKxVw0wtKPi1D+lPOkh4YQ==",
+      "extraneous": true,
+      "dependencies": {
+        "@types/mime": "^1",
+        "@types/node": "*"
+      }
     },
     "node_modules/netlify-cli/node_modules/@types/shimmer": {
       "version": "1.0.5",
@@ -34054,6 +34124,22 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/netlify-cli/node_modules/ajv": {
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "extraneous": true,
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
       }
     },
     "node_modules/netlify-cli/node_modules/ajv-formats": {
@@ -37292,6 +37378,12 @@
         "node": ">=8.6.0"
       }
     },
+    "node_modules/netlify-cli/node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "extraneous": true
+    },
     "node_modules/netlify-cli/node_modules/fast-json-stringify": {
       "version": "5.15.1",
       "resolved": "https://registry.npmjs.org/fast-json-stringify/-/fast-json-stringify-5.15.1.tgz",
@@ -39064,6 +39156,15 @@
         "ipx": "bin/ipx.mjs"
       }
     },
+    "node_modules/netlify-cli/node_modules/ipx/node_modules/@netlify/blobs": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@netlify/blobs/-/blobs-6.5.0.tgz",
+      "integrity": "sha512-wRFlNnL/Qv3WNLZd3OT/YYqF1zb6iPSo8T31sl9ccL1ahBxW1fBqKgF4b1XL7Z+6mRIkatvcsVPkWBcO+oJMNA==",
+      "extraneous": true,
+      "engines": {
+        "node": "^14.16.0 || >=16.0.0"
+      }
+    },
     "node_modules/netlify-cli/node_modules/ipx/node_modules/lru-cache": {
       "version": "10.2.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.2.0.tgz",
@@ -39639,6 +39740,12 @@
       "dependencies": {
         "fast-deep-equal": "^3.1.3"
       }
+    },
+    "node_modules/netlify-cli/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "extraneous": true
     },
     "node_modules/netlify-cli/node_modules/jsonc-parser": {
       "version": "3.2.0",

--- a/src/components/MarkdownProvider/components/BestPractice.tsx
+++ b/src/components/MarkdownProvider/components/BestPractice.tsx
@@ -10,7 +10,7 @@ import styled from 'styled-components';
 import { math } from 'polished';
 import { GatsbyImage, IGatsbyImageData } from 'gatsby-plugin-image';
 import { Well, Title } from '@zendeskgarden/react-notifications';
-import { getColor, mediaQuery } from '@zendeskgarden/react-theming';
+import { getColorV8, mediaQuery } from '@zendeskgarden/react-theming';
 import { Row, Col } from '@zendeskgarden/react-grid';
 import { ReactComponent as XStrokeIcon } from '@zendeskgarden/svg-icons/src/16/x-stroke.svg';
 import { ReactComponent as CheckLgStrokeIcon } from '@zendeskgarden/svg-icons/src/16/check-lg-stroke.svg';
@@ -42,7 +42,7 @@ const StyledFigure = styled.figure`
 `;
 
 const StyledImgContainer = styled.div`
-  border: ${p => `${p.theme.borders.sm} ${getColor('neutralHue', 300, p.theme)}`};
+  border: ${p => `${p.theme.borders.sm} ${getColorV8('neutralHue', 300, p.theme)}`};
   border-bottom: none;
   border-top-left-radius: ${p => p.theme.borderRadii.md};
   border-top-right-radius: ${p => p.theme.borderRadii.md};
@@ -58,7 +58,7 @@ const StyledCaption = styled(p => <Well isRecessed {...p} />).attrs<IStyledCapti
   forwardedAs: p.tag
 }))<IStyledCaptionProps>`
   border: none;
-  border-top: ${p => `${p.theme.borders.md} ${getColor(p.hue, 500, p.theme)}`};
+  border-top: ${p => `${p.theme.borders.md} ${getColorV8(p.hue, 500, p.theme)}`};
   border-radius: 0;
   padding-bottom: ${p => p.theme.space.base * 7}px;
   color: ${p => p.theme.colors.foreground};
@@ -70,7 +70,7 @@ const StyledCaption = styled(p => <Well isRecessed {...p} />).attrs<IStyledCapti
 
     & > li:not(:first-child) {
       margin-top: ${p => p.theme.space.xs};
-      border-top: ${p => `${p.theme.borders.sm} ${getColor('neutralHue', 300, p.theme)}`};
+      border-top: ${p => `${p.theme.borders.sm} ${getColorV8('neutralHue', 300, p.theme)}`};
       padding-top: ${p => p.theme.space.xs};
     }
   }
@@ -84,7 +84,7 @@ const StyledTitle = styled(p => <Title {...p} />).attrs(p => ({ forwardedAs: p.t
   display: flex;
   align-items: center;
   margin-left: -${p => math(`${p.theme.iconSizes.md} + ${p.theme.space.xs}`)};
-  color: ${p => getColor(p.hue, 600, p.theme)};
+  color: ${p => getColorV8(p.hue, 600, p.theme)};
 
   /* stylelint-disable-next-line no-descending-specificity */
   & + p,

--- a/src/components/MarkdownProvider/components/CodeExample/index.tsx
+++ b/src/components/MarkdownProvider/components/CodeExample/index.tsx
@@ -8,7 +8,7 @@
 import React, { useRef, useState, useMemo, PropsWithChildren } from 'react';
 import { math, rgba } from 'polished';
 import styled, { css } from 'styled-components';
-import { ThemeProvider, DEFAULT_THEME, getColor, PALETTE } from '@zendeskgarden/react-theming';
+import { ThemeProvider, DEFAULT_THEME, getColorV8, PALETTE } from '@zendeskgarden/react-theming';
 import { Close, Notification, Title, useToast } from '@zendeskgarden/react-notifications';
 import { Tooltip } from '@zendeskgarden/react-tooltips';
 import { CodeBlock } from '@zendeskgarden/react-typography';
@@ -85,7 +85,7 @@ export const CodeExample: React.FC<ICodeExampleProps> = ({ children, code }) => 
     <div
       css={css`
         margin-bottom: ${p => p.theme.space.xl};
-        border: ${p => p.theme.borders.sm} ${p => getColor('grey', 300, p.theme)};
+        border: ${p => p.theme.borders.sm} ${p => getColorV8('grey', 300, p.theme)};
         border-radius: ${p => p.theme.borderRadii.md};
       `}
     >
@@ -103,10 +103,10 @@ export const CodeExample: React.FC<ICodeExampleProps> = ({ children, code }) => 
         css={css`
           display: flex;
           justify-content: flex-end;
-          border-top: ${p => p.theme.borders.sm} ${p => getColor('grey', 300, p.theme)};
+          border-top: ${p => p.theme.borders.sm} ${p => getColorV8('grey', 300, p.theme)};
           border-bottom-left-radius: ${p => p.theme.borderRadii.md};
           border-bottom-right-radius: ${p => p.theme.borderRadii.md};
-          background-color: ${p => getColor('grey', 100, p.theme)};
+          background-color: ${p => getColorV8('grey', 100, p.theme)};
           padding: ${p => p.theme.space.xxs} ${p => p.theme.space.sm};
         `}
       >

--- a/src/components/MarkdownProvider/components/Configuration.tsx
+++ b/src/components/MarkdownProvider/components/Configuration.tsx
@@ -8,7 +8,7 @@
 import React from 'react';
 import styled from 'styled-components';
 import { UnorderedList, Span } from '@zendeskgarden/react-typography';
-import { getColor } from '@zendeskgarden/react-theming';
+import { getColorV8 } from '@zendeskgarden/react-theming';
 import { IComponentData } from '../../../components/types';
 import { StyledAnchor } from './Anchor';
 
@@ -19,7 +19,7 @@ interface IPackage {
 
 const StyledUnorderedList = styled(UnorderedList)`
   margin: 0 0 ${p => p.theme.space.xl};
-  border-bottom: ${p => `${p.theme.borders.sm} ${getColor('grey', 200, p.theme)}`};
+  border-bottom: ${p => `${p.theme.borders.sm} ${getColorV8('grey', 200, p.theme)}`};
   list-style: none;
 `;
 
@@ -27,7 +27,7 @@ const StyledListItem = styled(UnorderedList.Item)`
   display: flex;
   align-items: baseline;
   margin: ${p => p.theme.space.base * 2.5}px 0;
-  border-top: ${p => `${p.theme.borders.sm} ${getColor('grey', 200, p.theme)}`};
+  border-top: ${p => `${p.theme.borders.sm} ${getColorV8('grey', 200, p.theme)}`};
   /* stylelint-disable-next-line declaration-no-important */
   padding-top: ${p => p.theme.space.base * 2.5}px !important;
 `;
@@ -38,11 +38,11 @@ const StyledListItemLabel = styled(Span)`
 
 const StyledDot = styled(Span)`
   margin: 0 ${p => p.theme.space.xs};
-  color: ${p => getColor('grey', 600, p.theme)};
+  color: ${p => getColorV8('grey', 600, p.theme)};
 `;
 
 const StyledMono = styled(Span).attrs({ isMonospace: true })`
-  color: ${p => getColor('grey', 700, p.theme)};
+  color: ${p => getColorV8('grey', 700, p.theme)};
 `;
 
 export const Configuration: React.FC<{

--- a/src/components/MarkdownProvider/components/ImageFigure.tsx
+++ b/src/components/MarkdownProvider/components/ImageFigure.tsx
@@ -8,12 +8,12 @@
 import React, { useContext } from 'react';
 import styled, { ThemeContext } from 'styled-components';
 import { GatsbyImage, IGatsbyImageData } from 'gatsby-plugin-image';
-import { getColor } from '@zendeskgarden/react-theming';
+import { getColorV8 } from '@zendeskgarden/react-theming';
 
 const StyledCaption = styled.figcaption`
   margin-bottom: ${props => props.theme.space.md};
   text-align: center;
-  color: ${props => getColor('neutralHue', 600, props.theme)};
+  color: ${props => getColorV8('neutralHue', 600, props.theme)};
 `;
 
 interface IImageFigure {
@@ -31,7 +31,7 @@ export const ImageFigure: React.FC<IImageFigure> = props => {
         alt={props.imageAlt}
         image={props.imageSource}
         style={{
-          border: `${theme.borders.sm} ${getColor('neutralHue', 300, theme)}`,
+          border: `${theme.borders.sm} ${getColorV8('neutralHue', 300, theme)}`,
           marginBottom: theme.space.xs,
           borderRadius: theme.borderRadii.md
         }}

--- a/src/components/MarkdownProvider/components/PropSheet.tsx
+++ b/src/components/MarkdownProvider/components/PropSheet.tsx
@@ -7,7 +7,7 @@
 
 import React, { ReactElement } from 'react';
 import { css } from 'styled-components';
-import { getColor } from '@zendeskgarden/react-theming';
+import { getColorV8 } from '@zendeskgarden/react-theming';
 import { SM, MD, Ellipsis, Code } from '@zendeskgarden/react-typography';
 import { Table, Head, Body, HeaderRow, HeaderCell, Row, Cell } from '@zendeskgarden/react-tables';
 import { IComponentData } from '../../../components/types';
@@ -83,7 +83,7 @@ export const PropSheet: React.FC<{
                       <MD
                         isMonospace
                         css={css`
-                          color: ${p => getColor('neutralHue', 700, p.theme)};
+                          color: ${p => getColorV8('neutralHue', 700, p.theme)};
                         `}
                       >
                         <Ellipsis>{name}</Ellipsis>
@@ -95,7 +95,7 @@ export const PropSheet: React.FC<{
                         isMonospace
                         css={css`
                           word-break: break-word;
-                          color: ${p => getColor('red', 700, p.theme)};
+                          color: ${p => getColorV8('red', 700, p.theme)};
                         `}
                       >
                         {type}

--- a/src/components/MarkdownProvider/components/Typography.tsx
+++ b/src/components/MarkdownProvider/components/Typography.tsx
@@ -6,7 +6,7 @@
  */
 
 import styled, { css, ThemeProps } from 'styled-components';
-import { getColor, getLineHeight } from '@zendeskgarden/react-theming';
+import { getColorV8, getLineHeight } from '@zendeskgarden/react-theming';
 import {
   XXXL,
   XXL,
@@ -22,7 +22,7 @@ import { StyledAnchor } from './Anchor';
 const headerStyles = (p: ThemeProps<any>) => {
   return css`
     margin-bottom: ${p.theme.space.sm};
-    color: ${getColor('chromeHue', 700, p.theme)};
+    color: ${getColorV8('chromeHue', 700, p.theme)};
     font-weight: ${p.theme.fontWeights.semibold};
 
     &:hover ${StyledAnchor} {
@@ -73,13 +73,13 @@ export const StyledH6 = styled(MD).attrs({ tag: 'h6' })`
 
 export const StyledBlockquote = styled(Blockquote)`
   margin-left: ${p => p.theme.space.base * 4}px;
-  color: ${p => getColor('grey', 600, p.theme)};
+  color: ${p => getColorV8('grey', 600, p.theme)};
   font-size: ${p => p.theme.space.base * 4}px;
 `;
 
 export const StyledHr = styled.hr`
   margin: ${p => p.theme.space.md} 0;
-  border-top: ${p => p.theme.borders.sm} ${p => getColor('grey', 200, p.theme)};
+  border-top: ${p => p.theme.borders.sm} ${p => getColorV8('grey', 200, p.theme)};
 `;
 
 export const StyledParagraph = styled(Paragraph)`

--- a/src/examples/chrome/SheetDefault.tsx
+++ b/src/examples/chrome/SheetDefault.tsx
@@ -11,7 +11,7 @@ import { Sheet } from '@zendeskgarden/react-chrome';
 import { Grid, Row, Col } from '@zendeskgarden/react-grid';
 import { Button } from '@zendeskgarden/react-buttons';
 import { Field, Toggle, Label } from '@zendeskgarden/react-forms';
-import { getColor, mediaQuery } from '@zendeskgarden/react-theming';
+import { getColorV8, mediaQuery } from '@zendeskgarden/react-theming';
 
 const StyledField = styled(Field)`
   margin: ${props => props.theme.space.md};
@@ -19,7 +19,7 @@ const StyledField = styled(Field)`
 
 const StyledRow = styled(Row)`
   border: ${props => props.theme.borderWidths.sm} dashed;
-  border-color: ${props => getColor('neutralHue', 400, props.theme)};
+  border-color: ${props => getColorV8('neutralHue', 400, props.theme)};
 `;
 
 const StyledSheet = styled(Sheet)`

--- a/src/examples/chrome/SheetFooters.tsx
+++ b/src/examples/chrome/SheetFooters.tsx
@@ -10,7 +10,7 @@ import styled from 'styled-components';
 import { Sheet } from '@zendeskgarden/react-chrome';
 import { Row, Col } from '@zendeskgarden/react-grid';
 import { Anchor, Button } from '@zendeskgarden/react-buttons';
-import { getColor, mediaQuery } from '@zendeskgarden/react-theming';
+import { getColorV8, mediaQuery } from '@zendeskgarden/react-theming';
 
 const StyledCol = styled(Col)`
   height: 480px;
@@ -28,7 +28,7 @@ const StyledSheet = styled(Sheet)`
   border: ${props => props.theme.borderWidths.sm} dashed;
   ${props => (props.theme.rtl ? 'border-right' : 'border-left')}: ${props =>
     props.theme.borderWidths.sm} solid;
-  border-color: ${props => getColor('neutralHue', 400, props.theme)};
+  border-color: ${props => getColorV8('neutralHue', 400, props.theme)};
 `;
 
 const StyledSheetFooterItem = styled(Sheet.FooterItem)`

--- a/src/examples/chrome/SheetHeaders.tsx
+++ b/src/examples/chrome/SheetHeaders.tsx
@@ -9,7 +9,7 @@ import React from 'react';
 import styled from 'styled-components';
 import { Sheet } from '@zendeskgarden/react-chrome';
 import { Row, Col } from '@zendeskgarden/react-grid';
-import { getColor, mediaQuery } from '@zendeskgarden/react-theming';
+import { getColorV8, mediaQuery } from '@zendeskgarden/react-theming';
 
 const StyledCol = styled(Col)`
   height: 480px;
@@ -27,7 +27,7 @@ const StyledSheet = styled(Sheet)`
   border: ${props => props.theme.borderWidths.sm} dashed;
   ${props => (props.theme.rtl ? 'border-right' : 'border-left')}: ${props =>
     props.theme.borderWidths.sm} solid;
-  border-color: ${props => getColor('neutralHue', 400, props.theme)};
+  border-color: ${props => getColorV8('neutralHue', 400, props.theme)};
 `;
 
 const Example = () => (

--- a/src/examples/chrome/SheetPlacement.tsx
+++ b/src/examples/chrome/SheetPlacement.tsx
@@ -11,7 +11,7 @@ import { Sheet } from '@zendeskgarden/react-chrome';
 import { Grid, Row, Col } from '@zendeskgarden/react-grid';
 import { Button } from '@zendeskgarden/react-buttons';
 import { Field, Toggle, Label } from '@zendeskgarden/react-forms';
-import { getColor, mediaQuery } from '@zendeskgarden/react-theming';
+import { getColorV8, mediaQuery } from '@zendeskgarden/react-theming';
 
 const StyledField = styled(Field)`
   margin: ${props => props.theme.space.md};
@@ -19,7 +19,7 @@ const StyledField = styled(Field)`
 
 const StyledRow = styled(Row)`
   border: ${props => props.theme.borderWidths.sm} dashed;
-  border-color: ${props => getColor('neutralHue', 400, props.theme)};
+  border-color: ${props => getColorV8('neutralHue', 400, props.theme)};
 `;
 
 const StyledSheet = styled(Sheet)`

--- a/src/examples/chrome/SheetSize.tsx
+++ b/src/examples/chrome/SheetSize.tsx
@@ -11,7 +11,7 @@ import { Sheet } from '@zendeskgarden/react-chrome';
 import { Grid, Row, Col } from '@zendeskgarden/react-grid';
 import { Button } from '@zendeskgarden/react-buttons';
 import { Fieldset, Field, Radio, Label } from '@zendeskgarden/react-forms';
-import { getColor } from '@zendeskgarden/react-theming';
+import { getColorV8 } from '@zendeskgarden/react-theming';
 
 const StyledFieldset = styled(Fieldset)`
   margin: ${props => props.theme.space.md};
@@ -19,7 +19,7 @@ const StyledFieldset = styled(Fieldset)`
 
 const StyledRow = styled(Row)`
   border: ${props => props.theme.borderWidths.sm} dashed;
-  border-color: ${props => getColor('neutralHue', 400, props.theme)};
+  border-color: ${props => getColorV8('neutralHue', 400, props.theme)};
   overflow: auto;
 `;
 

--- a/src/examples/design/icons/IconShowcase.tsx
+++ b/src/examples/design/icons/IconShowcase.tsx
@@ -8,7 +8,7 @@
 import React from 'react';
 import styled from 'styled-components';
 import { Row, Col } from '@zendeskgarden/react-grid';
-import { getColor } from '@zendeskgarden/react-theming';
+import { getColorV8 } from '@zendeskgarden/react-theming';
 import { ReactComponent as LeafIcon } from '@zendeskgarden/svg-icons/src/16/leaf-stroke.svg';
 import { ReactComponent as LightBulbIcon } from '@zendeskgarden/svg-icons/src/16/lightbulb-stroke.svg';
 import { ReactComponent as LightningBoltIcon } from '@zendeskgarden/svg-icons/src/16/lightning-bolt-stroke.svg';
@@ -17,7 +17,7 @@ import { ReactComponent as SmileyIcon } from '@zendeskgarden/svg-icons/src/16/sm
 
 const StyledCol = styled(Col)`
   text-align: center;
-  color: ${p => getColor('neutralHue', 600, p.theme)};
+  color: ${p => getColorV8('neutralHue', 600, p.theme)};
 `;
 
 const Example = () => (

--- a/src/examples/design/icons/IconStyles.tsx
+++ b/src/examples/design/icons/IconStyles.tsx
@@ -11,11 +11,11 @@ import { MD } from '@zendeskgarden/react-typography';
 import { Row, Col } from '@zendeskgarden/react-grid';
 import { ReactComponent as LeafStrokeIcon } from '@zendeskgarden/svg-icons/src/16/leaf-stroke.svg';
 import { ReactComponent as LeafFillIcon } from '@zendeskgarden/svg-icons/src/16/leaf-fill.svg';
-import { getColor } from '@zendeskgarden/react-theming';
+import { getColorV8 } from '@zendeskgarden/react-theming';
 
 const StyledCol = styled(Col)`
   text-align: center;
-  color: ${p => getColor('neutralHue', 600, p.theme)};
+  color: ${p => getColorV8('neutralHue', 600, p.theme)};
 `;
 
 const Example = () => {

--- a/src/examples/draggable/DraggableContent.tsx
+++ b/src/examples/draggable/DraggableContent.tsx
@@ -6,7 +6,7 @@
  */
 
 import React from 'react';
-import { PALETTE, getColor } from '@zendeskgarden/react-theming';
+import { PALETTE, getColorV8 } from '@zendeskgarden/react-theming';
 import { Row, Col } from '@zendeskgarden/react-grid';
 import { Draggable } from '@zendeskgarden/react-drag-drop';
 import { IconButton } from '@zendeskgarden/react-buttons';
@@ -18,7 +18,7 @@ import styled from 'styled-components';
 
 const StyledDecorator = styled.div`
   display: flex;
-  color: ${p => getColor('neutralHue', 600, p.theme)};
+  color: ${p => getColorV8('neutralHue', 600, p.theme)};
   padding-inline-end: ${p => p.theme.space.xs};
 `;
 

--- a/src/examples/pane/PaneHorizontal.tsx
+++ b/src/examples/pane/PaneHorizontal.tsx
@@ -9,13 +9,13 @@ import React from 'react';
 import { PaneProvider, Pane } from '@zendeskgarden/react-grid';
 import useResizeObserver from 'use-resize-observer';
 import { XL, Paragraph } from '@zendeskgarden/react-typography';
-import { getColor } from '@zendeskgarden/react-theming';
+import { getColorV8 } from '@zendeskgarden/react-theming';
 import styled from 'styled-components';
 
 const StyledPaneContent = styled(Pane.Content)<{ isSecondary?: boolean }>`
   padding: ${p => p.theme.space.base * 6}px ${p => p.theme.space.base * 6}px
     ${p => p.theme.space.base * 4}px;
-  ${p => p.isSecondary && `background-color: ${getColor('neutralHue', 100, p.theme)}`};
+  ${p => p.isSecondary && `background-color: ${getColorV8('neutralHue', 100, p.theme)}`};
 `;
 
 const StyledParagraph = styled(Paragraph)`

--- a/src/examples/pane/PaneHorizontalCollapse.tsx
+++ b/src/examples/pane/PaneHorizontalCollapse.tsx
@@ -9,7 +9,7 @@ import React from 'react';
 import { PaneProvider, Pane } from '@zendeskgarden/react-grid';
 import useResizeObserver from 'use-resize-observer';
 import { XL, Paragraph } from '@zendeskgarden/react-typography';
-import { getColor } from '@zendeskgarden/react-theming';
+import { getColorV8 } from '@zendeskgarden/react-theming';
 import styled from 'styled-components';
 
 const StyledDiv = styled.div`
@@ -23,7 +23,7 @@ const StyledParagraph = styled(Paragraph)`
 `;
 
 const StyledPane = styled(Pane)<{ isSecondary?: boolean }>`
-  ${p => p.isSecondary && `background-color: ${getColor('neutralHue', 100, p.theme)}`};
+  ${p => p.isSecondary && `background-color: ${getColorV8('neutralHue', 100, p.theme)}`};
 `;
 
 const Example = () => {

--- a/src/examples/pane/PaneVertical.tsx
+++ b/src/examples/pane/PaneVertical.tsx
@@ -9,13 +9,13 @@ import React from 'react';
 import { PaneProvider, Pane } from '@zendeskgarden/react-grid';
 import useResizeObserver from 'use-resize-observer';
 import { XL, Paragraph } from '@zendeskgarden/react-typography';
-import { getColor } from '@zendeskgarden/react-theming';
+import { getColorV8 } from '@zendeskgarden/react-theming';
 import styled from 'styled-components';
 
 const StyledPaneContent = styled(Pane.Content)<{ isSecondary?: boolean }>`
   padding: ${p => p.theme.space.base * 6}px;
   height: 240px;
-  ${p => p.isSecondary && `background-color: ${getColor('neutralHue', 100, p.theme)}`};
+  ${p => p.isSecondary && `background-color: ${getColorV8('neutralHue', 100, p.theme)}`};
 `;
 
 const StyledParagraph = styled(Paragraph)`

--- a/src/examples/pane/PaneVerticalCollapse.tsx
+++ b/src/examples/pane/PaneVerticalCollapse.tsx
@@ -9,7 +9,7 @@ import React from 'react';
 import { PaneProvider, Pane } from '@zendeskgarden/react-grid';
 import useResizeObserver from 'use-resize-observer';
 import { XL, Paragraph } from '@zendeskgarden/react-typography';
-import { getColor } from '@zendeskgarden/react-theming';
+import { getColorV8 } from '@zendeskgarden/react-theming';
 import styled from 'styled-components';
 
 const StyledParagraph = styled(Paragraph)`
@@ -22,7 +22,7 @@ const StyledPaneContent = styled(Pane.Content)`
 
 const StyledPane = styled(Pane)<{ isSecondary?: boolean }>`
   padding: ${p => p.theme.space.base * 6}px;
-  ${p => p.isSecondary && `background-color: ${getColor('neutralHue', 100, p.theme)}`};
+  ${p => p.isSecondary && `background-color: ${getColorV8('neutralHue', 100, p.theme)}`};
 `;
 
 const Example = () => {

--- a/src/examples/pane/SplitterButtonPosition.tsx
+++ b/src/examples/pane/SplitterButtonPosition.tsx
@@ -10,7 +10,7 @@ import { PaneProvider, Pane } from '@zendeskgarden/react-grid';
 import useResizeObserver from 'use-resize-observer';
 import { XL, XXL, Paragraph } from '@zendeskgarden/react-typography';
 import styled from 'styled-components';
-import { getColor } from '@zendeskgarden/react-theming';
+import { getColorV8 } from '@zendeskgarden/react-theming';
 
 const StyledDiv = styled.div`
   padding: ${p => p.theme.space.base * 6}px;
@@ -31,7 +31,7 @@ const StyledPaneContent = styled(Pane.Content)`
 
 const StyledPanesContainer = styled.div`
   & > :first-child {
-    background-color: ${p => getColor('neutralHue', 100, p.theme)};
+    background-color: ${p => getColorV8('neutralHue', 100, p.theme)};
   }
 
   &:not(:last-child) {

--- a/src/examples/table/TableDraggable.tsx
+++ b/src/examples/table/TableDraggable.tsx
@@ -10,7 +10,7 @@ import styled from 'styled-components';
 import { DragDropContext, Droppable, Draggable, DropResult } from 'react-beautiful-dnd';
 import { Table, Row, Cell, Head, HeaderCell, HeaderRow, Body } from '@zendeskgarden/react-tables';
 import { ReactComponent as GripIcon } from '@zendeskgarden/svg-icons/src/12/grip.svg';
-import { getColor } from '@zendeskgarden/react-theming';
+import { getColorV8 } from '@zendeskgarden/react-theming';
 
 const DraggableRow = styled(Row)<{ isDraggingOver: boolean }>`
   ${props =>
@@ -24,10 +24,10 @@ const DraggableRow = styled(Row)<{ isDraggingOver: boolean }>`
 `;
 
 const DraggableContainer = styled.div`
-  color: ${props => getColor('primaryHue', 600, props.theme)};
+  color: ${props => getColorV8('primaryHue', 600, props.theme)};
 
   &:hover {
-    color: ${props => getColor('primaryHue', 700, props.theme)};
+    color: ${props => getColorV8('primaryHue', 700, props.theme)};
   }
 
   &:focus {

--- a/src/examples/table/TableVerticalScrolling.tsx
+++ b/src/examples/table/TableVerticalScrolling.tsx
@@ -8,7 +8,7 @@
 import React from 'react';
 import { Body, Cell, Head, HeaderCell, HeaderRow, Row, Table } from '@zendeskgarden/react-tables';
 import { Paragraph } from '@zendeskgarden/react-typography';
-import { getColor } from '@zendeskgarden/react-theming';
+import { getColorV8 } from '@zendeskgarden/react-theming';
 import styled from 'styled-components';
 
 const rowData = Array.from(Array(10)).map((row, index) => ({
@@ -19,7 +19,7 @@ const rowData = Array.from(Array(10)).map((row, index) => ({
 }));
 
 const StyledHeaderCell = styled(HeaderCell)`
-  box-shadow: inset 0 -1px 0 ${props => getColor('neutralHue', 300, props.theme)};
+  box-shadow: inset 0 -1px 0 ${props => getColorV8('neutralHue', 300, props.theme)};
 `;
 
 const StyledHeaderRow = styled(HeaderRow)`

--- a/src/examples/theme-provider/ThemeProviderTargeting.tsx
+++ b/src/examples/theme-provider/ThemeProviderTargeting.tsx
@@ -8,7 +8,7 @@
 import React, { useState } from 'react';
 import { css, DefaultTheme } from 'styled-components';
 import { Tabs, TabList, Tab, TabPanel } from '@zendeskgarden/react-tabs';
-import { getColor, ThemeProvider } from '@zendeskgarden/react-theming';
+import { getColorV8, ThemeProvider } from '@zendeskgarden/react-theming';
 
 /* Each Garden example is wrapped by a <ThemeProvider> */
 const Example = () => {
@@ -25,7 +25,7 @@ const Example = () => {
         margin-top: ${p => p.theme.space.md};
         margin-bottom: 0;
         border-top: ${p => p.theme.borderWidths.sm} ${p => p.theme.borderStyles.solid}
-          ${p => getColor('neutralHue', 300, p.theme)};
+          ${p => getColorV8('neutralHue', 300, p.theme)};
         border-bottom: none;
       `
     }

--- a/src/examples/utilities/MenuArrowStyles.tsx
+++ b/src/examples/utilities/MenuArrowStyles.tsx
@@ -10,7 +10,7 @@ import styled from 'styled-components';
 import { Row, Col } from '@zendeskgarden/react-grid';
 import { IconButton } from '@zendeskgarden/react-buttons';
 import { ReactComponent as ArrowIcon } from '@zendeskgarden/svg-icons/src/16/arrow-left-stroke.svg';
-import { arrowStyles, getColor, menuStyles } from '@zendeskgarden/react-theming';
+import { arrowStyles, getColorV8, menuStyles } from '@zendeskgarden/react-theming';
 
 type ARROW_POSITION =
   | 'top'
@@ -41,7 +41,7 @@ const StyledMenu = styled.div<{
 
   & > div {
     background-clip: content-box;
-    background-color: ${p => getColor('neutralHue', 100, p.theme)};
+    background-color: ${p => getColorV8('neutralHue', 100, p.theme)};
     padding: ${p => p.theme.space.xs};
     height: 100%;
   }

--- a/src/examples/utilities/components.ts
+++ b/src/examples/utilities/components.ts
@@ -100,7 +100,7 @@ const components = [
     }
   },
   {
-    name: 'getColor',
+    name: 'getColorV8',
     props: {
       hue: {
         required: true,

--- a/src/layouts/Home/components/News.tsx
+++ b/src/layouts/Home/components/News.tsx
@@ -8,7 +8,7 @@
 import React from 'react';
 import { useStaticQuery, graphql } from 'gatsby';
 import styled, { css } from 'styled-components';
-import { SELECTOR_FOCUS_VISIBLE, getColor } from '@zendeskgarden/react-theming';
+import { SELECTOR_FOCUS_VISIBLE, getColorV8 } from '@zendeskgarden/react-theming';
 import { Grid, Row, Col } from '@zendeskgarden/react-grid';
 import { XXL } from '@zendeskgarden/react-typography';
 import { Anchor } from '@zendeskgarden/react-buttons';
@@ -16,11 +16,11 @@ import MaxWidthLayout from 'layouts/MaxWidth';
 
 const StyledNewsAnchor = styled(Anchor)`
   ${SELECTOR_FOCUS_VISIBLE} {
-    color: ${p => getColor('primaryHue', 700, p.theme)};
+    color: ${p => getColorV8('primaryHue', 700, p.theme)};
   }
 
   &:active {
-    color: ${p => getColor('primaryHue', 800, p.theme)};
+    color: ${p => getColorV8('primaryHue', 800, p.theme)};
   }
 `;
 
@@ -48,7 +48,7 @@ export const News: React.FC = () => {
     <div
       css={css`
         position: relative;
-        background-color: ${p => getColor('grey', 200, p.theme)};
+        background-color: ${p => getColorV8('grey', 200, p.theme)};
       `}
     >
       <MaxWidthLayout>
@@ -82,7 +82,7 @@ export const News: React.FC = () => {
                       </StyledNewsAnchor>
                       <p
                         css={css`
-                          color: ${p => getColor('grey', 700, p.theme)};
+                          color: ${p => getColorV8('grey', 700, p.theme)};
                         `}
                       >
                         Article by{' '}

--- a/src/layouts/Home/components/SectionCallout.tsx
+++ b/src/layouts/Home/components/SectionCallout.tsx
@@ -7,14 +7,14 @@
 
 import React, { HTMLAttributes } from 'react';
 import styled, { css } from 'styled-components';
-import { getColor } from '@zendeskgarden/react-theming';
+import { getColorV8 } from '@zendeskgarden/react-theming';
 import { XXL, LG } from '@zendeskgarden/react-typography';
 
 export const StyledSectionHeader = styled.div`
   text-transform: uppercase;
   line-height: ${p => p.theme.lineHeights.sm};
   letter-spacing: 0.5px;
-  color: ${p => getColor('neutralHue', 600, p.theme)};
+  color: ${p => getColorV8('neutralHue', 600, p.theme)};
   font-size: ${p => p.theme.fontSizes.xs};
   font-weight: ${p => p.theme.fontWeights.semibold};
 `;
@@ -46,7 +46,7 @@ export const SectionCallout: React.FC<
     <LG
       tag="p"
       css={css`
-        color: ${p => getColor('grey', 700, p.theme)};
+        color: ${p => getColorV8('grey', 700, p.theme)};
       `}
     >
       {description}

--- a/src/layouts/Root/components/Footer.tsx
+++ b/src/layouts/Root/components/Footer.tsx
@@ -7,7 +7,7 @@
 
 import React from 'react';
 import styled, { css } from 'styled-components';
-import { SELECTOR_FOCUS_VISIBLE, getColor, mediaQuery } from '@zendeskgarden/react-theming';
+import { SELECTOR_FOCUS_VISIBLE, getColorV8, mediaQuery } from '@zendeskgarden/react-theming';
 import { ReactComponent as GardenIcon } from '@zendeskgarden/svg-icons/src/26/garden.svg';
 import { Link } from './StyledNavigationLink';
 import MaxWidthLayout from 'layouts/MaxWidth';
@@ -41,7 +41,7 @@ interface IFooterProps {
 const Footer: React.FC<IFooterProps> = ({ path }) => (
   <footer
     css={css`
-      background-color: ${p => getColor('kale', 700, p.theme)};
+      background-color: ${p => getColorV8('kale', 700, p.theme)};
       padding: ${p => p.theme.space.md};
       line-height: ${p => p.theme.lineHeights.md};
       color: ${p => p.theme.palette.white};
@@ -77,7 +77,7 @@ const Footer: React.FC<IFooterProps> = ({ path }) => (
             css={css`
               width: ${p => p.theme.iconSizes.lg};
               height: ${p => p.theme.iconSizes.lg};
-              color: ${p => getColor('green', 400, p.theme)};
+              color: ${p => getColorV8('green', 400, p.theme)};
             `}
           />
         </div>
@@ -92,7 +92,7 @@ const Footer: React.FC<IFooterProps> = ({ path }) => (
       <div
         css={css`
           display: flex;
-          border-top: ${p => p.theme.borders.sm} ${p => getColor('kale', 500, p.theme)};
+          border-top: ${p => p.theme.borders.sm} ${p => getColorV8('kale', 500, p.theme)};
           padding-top: ${p => p.theme.space.md};
           padding-bottom: ${p => p.theme.space.lg};
 

--- a/src/layouts/Root/components/Header.tsx
+++ b/src/layouts/Root/components/Header.tsx
@@ -8,7 +8,7 @@
 import React, { useState, HTMLAttributes, useRef, useEffect } from 'react';
 import styled, { css } from 'styled-components';
 import { Link } from 'gatsby';
-import { getColor, mediaQuery, PALETTE } from '@zendeskgarden/react-theming';
+import { getColorV8, mediaQuery, PALETTE } from '@zendeskgarden/react-theming';
 import { IconButton } from '@zendeskgarden/react-buttons';
 import { ReactComponent as SearchStroke } from '@zendeskgarden/svg-icons/src/16/search-stroke.svg';
 import { ReactComponent as OverflowVerticalStroke } from '@zendeskgarden/svg-icons/src/16/overflow-vertical-stroke.svg';
@@ -23,7 +23,7 @@ export const headerBoxShadow = (theme: any) =>
   theme.shadows.lg(
     `${theme.space.base * 4}px`,
     `${theme.space.base * 6}px`,
-    getColor('neutralHue', 800, theme, 0.05)!
+    getColorV8('neutralHue', 800, theme, 0.05)!
   );
 
 export const headerHeight = (theme: any) => theme.space.base * 20;

--- a/src/layouts/Root/components/SearchInput.tsx
+++ b/src/layouts/Root/components/SearchInput.tsx
@@ -8,7 +8,7 @@
 import React, { HTMLAttributes, useEffect } from 'react';
 import { css, ThemeProps } from 'styled-components';
 import { math } from 'polished';
-import { getColor, mediaQuery, menuStyles } from '@zendeskgarden/react-theming';
+import { getColorV8, mediaQuery, menuStyles } from '@zendeskgarden/react-theming';
 import { MediaInput } from '@zendeskgarden/react-forms';
 import { ReactComponent as SearchStroke } from '@zendeskgarden/svg-icons/src/16/search-stroke.svg';
 
@@ -17,11 +17,11 @@ const searchStyles = (props: ThemeProps<any>) => {
   const positionTop = math(`${theme.space.base * 3.5} + ${theme.borderWidths.sm}`);
   const positionLeft = math(`${theme.space.base * -9} - ${theme.borderWidths.sm}`);
   const positionRight = math(`${theme.space.base * -3} - ${theme.borderWidths.sm}`);
-  const highlightBackgroundColor = getColor('primaryHue', 800, theme, 0.08);
-  const hoverBackgroundColor = getColor('primaryHue', 600, theme, 0.08);
-  const hoverSeparatorColor = getColor('neutralHue', 250, theme);
-  const metaColor = getColor('neutralHue', 600, theme);
-  const separatorColor = getColor('neutralHue', 200, theme);
+  const highlightBackgroundColor = getColorV8('primaryHue', 800, theme, 0.08);
+  const hoverBackgroundColor = getColorV8('primaryHue', 600, theme, 0.08);
+  const hoverSeparatorColor = getColorV8('neutralHue', 250, theme);
+  const metaColor = getColorV8('neutralHue', 600, theme);
+  const separatorColor = getColorV8('neutralHue', 200, theme);
 
   return css`
     ${p =>

--- a/src/layouts/Root/components/StyledNavigationLink.tsx
+++ b/src/layouts/Root/components/StyledNavigationLink.tsx
@@ -9,7 +9,7 @@ import React, { ReactNode } from 'react';
 import styled from 'styled-components';
 import { Link as GatsbyLink } from 'gatsby';
 import { OutboundLink } from 'gatsby-plugin-google-gtag';
-import { focusStyles, getColor } from '@zendeskgarden/react-theming';
+import { focusStyles, getColorV8 } from '@zendeskgarden/react-theming';
 
 interface ILink {
   children: ReactNode;
@@ -50,16 +50,16 @@ export const StyledNavigationLink = styled(Link).attrs(p => ({
   }
 
   &.is-current {
-    background-color: ${p => getColor('grey', 800, p.theme, 0.1)};
+    background-color: ${p => getColorV8('grey', 800, p.theme, 0.1)};
   }
 
   &:hover {
-    background-color: ${p => getColor('grey', 800, p.theme, 0.05)};
+    background-color: ${p => getColorV8('grey', 800, p.theme, 0.05)};
   }
 
   ${props => focusStyles({ theme: props.theme })}
 
   &:active {
-    background-color: ${p => getColor('grey', 800, p.theme, 0.2)};
+    background-color: ${p => getColorV8('grey', 800, p.theme, 0.2)};
   }
 `;

--- a/src/layouts/Sidebar/components/DesktopSidebar.tsx
+++ b/src/layouts/Sidebar/components/DesktopSidebar.tsx
@@ -8,7 +8,7 @@
 import React from 'react';
 import styled, { css } from 'styled-components';
 import { useLocation } from '@reach/router';
-import { getColor, mediaQuery } from '@zendeskgarden/react-theming';
+import { getColorV8, mediaQuery } from '@zendeskgarden/react-theming';
 import { ISidebarSection } from '..';
 import { StyledNavigationLink } from 'layouts/Root/components/StyledNavigationLink';
 import { StyledSectionHeader } from 'layouts/Home/components/SectionCallout';
@@ -32,7 +32,7 @@ export const DesktopSidebar: React.FC<{ sidebar: ISidebarSection[] }> = ({ sideb
       <StyledSectionHeader
         css={css`
           margin-bottom: ${p => p.theme.space.xxs};
-          color: ${p => getColor('kale', 600, p.theme)};
+          color: ${p => getColorV8('kale', 600, p.theme)};
         `}
       >
         {section.title}

--- a/src/layouts/Sidebar/components/MobileSidebar.tsx
+++ b/src/layouts/Sidebar/components/MobileSidebar.tsx
@@ -8,7 +8,7 @@
 import React, { useEffect } from 'react';
 import styled, { css } from 'styled-components';
 import { useLocation } from '@reach/router';
-import { getColor, mediaQuery } from '@zendeskgarden/react-theming';
+import { getColorV8, mediaQuery } from '@zendeskgarden/react-theming';
 import { StyledNavigationLink } from 'layouts/Root/components/StyledNavigationLink';
 import { StyledSectionHeader } from 'layouts/Home/components/SectionCallout';
 import { ISidebarSection } from '..';
@@ -44,7 +44,7 @@ export const MobileSidebar: React.FC<{ sidebar: ISidebarSection[] }> = ({ sideba
       >
         <StyledSectionHeader
           css={css`
-            color: ${p => getColor('kale', 600, p.theme)};
+            color: ${p => getColorV8('kale', 600, p.theme)};
           `}
         >
           {section.title}

--- a/src/layouts/Sidebar/index.tsx
+++ b/src/layouts/Sidebar/index.tsx
@@ -8,7 +8,7 @@
 import React, { PropsWithChildren, useState } from 'react';
 import styled, { css } from 'styled-components';
 import { rgba } from 'polished';
-import { getColor, mediaQuery } from '@zendeskgarden/react-theming';
+import { getColorV8, mediaQuery } from '@zendeskgarden/react-theming';
 import { ReactComponent as OverflowStroke } from '@zendeskgarden/svg-icons/src/16/overflow-vertical-stroke.svg';
 import { ReactComponent as CloseStroke } from '@zendeskgarden/svg-icons/src/16/x-stroke.svg';
 import MaxWidthLayout from 'layouts/MaxWidth';
@@ -32,7 +32,7 @@ const StyledMobileNavButton = styled.button`
   /* stylelint-disable-next-line color-function-notation */
   border: ${p => p.theme.borders.sm} ${p => rgba(p.theme.palette.white as string, 0.2)};
   border-radius: 100px;
-  background-color: ${p => getColor('kale', 800, p.theme)};
+  background-color: ${p => getColorV8('kale', 800, p.theme)};
   padding: ${p => p.theme.space.xs};
   color: ${p => p.theme.colors.background};
 

--- a/src/layouts/Titled/components/Subtitle.tsx
+++ b/src/layouts/Titled/components/Subtitle.tsx
@@ -6,11 +6,11 @@
  */
 
 import styled from 'styled-components';
-import { getColor } from '@zendeskgarden/react-theming';
+import { getColorV8 } from '@zendeskgarden/react-theming';
 import { LG } from '@zendeskgarden/react-typography';
 
 export const Subtitle = styled(LG).attrs({ tag: 'p' })`
   max-width: 540px;
-  color: ${p => getColor('neutralHue', 600, p.theme)};
+  color: ${p => getColorV8('neutralHue', 600, p.theme)};
   font-size: ${p => p.theme.space.base * 4}px;
 `;

--- a/src/layouts/Titled/components/TOC.tsx
+++ b/src/layouts/Titled/components/TOC.tsx
@@ -9,7 +9,7 @@ import React, { useState, useCallback, useEffect, HTMLAttributes } from 'react';
 import styled, { css } from 'styled-components';
 import throttle from 'lodash/throttle';
 import { math } from 'polished';
-import { getColor } from '@zendeskgarden/react-theming';
+import { getColorV8 } from '@zendeskgarden/react-theming';
 import { Anchor } from '@zendeskgarden/react-buttons';
 import { StyledSectionHeader } from 'layouts/Home/components/SectionCallout';
 import { StyledHr } from 'components/MarkdownProvider/components/Typography';
@@ -64,7 +64,7 @@ const StyledAnchor = styled(Anchor)<{ isCurrent: boolean }>`
   &::before {
     position: absolute;
     left: -${p => math(`(${p.theme.space.xxs} + 1px)`)};
-    border-left: ${p => p.isCurrent && `${p.theme.borders.sm} ${getColor('grey', 800, p.theme)}`};
+    border-left: ${p => p.isCurrent && `${p.theme.borders.sm} ${getColorV8('grey', 800, p.theme)}`};
     height: 100%;
     content: '';
   }
@@ -149,7 +149,7 @@ export const TOC: React.FC<{ data: IHeading[] }> = ({ data }) => {
       </StyledSectionHeader>
       <ul
         css={css`
-          border-left: ${p => p.theme.borders.sm} ${p => getColor('grey', 200, p.theme)};
+          border-left: ${p => p.theme.borders.sm} ${p => getColorV8('grey', 200, p.theme)};
         `}
       >
         {data.map(heading => (

--- a/src/pages/404.tsx
+++ b/src/pages/404.tsx
@@ -12,7 +12,7 @@ import { useStaticQuery, graphql, HeadProps } from 'gatsby';
 import { GatsbyImage } from 'gatsby-plugin-image';
 import RootLayout from 'layouts/Root';
 import MaxWidthLayout from 'layouts/MaxWidth';
-import { getColor, mediaQuery } from '@zendeskgarden/react-theming';
+import { getColorV8, mediaQuery } from '@zendeskgarden/react-theming';
 import { Grid, Row, Col } from '@zendeskgarden/react-grid';
 import { XL, LG } from '@zendeskgarden/react-typography';
 import { StyledH1 } from 'components/MarkdownProvider/components/Typography';
@@ -78,7 +78,7 @@ const NotFoundPage: React.FC = () => {
                     margin-top: ${p => p.theme.space.md};
                     margin-bottom: ${p => p.theme.space.xs};
                     text-transform: uppercase;
-                    color: ${p => getColor('neutralHue', 600, p.theme)};
+                    color: ${p => getColorV8('neutralHue', 600, p.theme)};
                     font-size: ${p => p.theme.space.base * 4}px;
 
                     ${p => mediaQuery('down', 'xs', p.theme)} {
@@ -102,7 +102,7 @@ const NotFoundPage: React.FC = () => {
                 </StyledH1>
                 <XL
                   css={css`
-                    color: ${p => getColor('neutralHue', 600, p.theme)};
+                    color: ${p => getColorV8('neutralHue', 600, p.theme)};
 
                     ${p => mediaQuery('down', 'xs', p.theme)} {
                       line-height: ${p => p.theme.lineHeights.md};

--- a/src/pages/components/palette.mdx
+++ b/src/pages/components/palette.mdx
@@ -25,7 +25,7 @@ export function Head(props) {
     - To style custom components with Garden, access the palette through the
     [`theme.palette`](/components/theme-object#palette) API instead
     - To extend Garden with reusable components that respond to theming, use the
-    [`getColor`](/components/utilities#getcolor) utility with the
+    [`getColorV8`](/components/utilities#getcolor) utility with the
     [`theme.colors`](/components/theme-object#colors) API instead
 
   </Misuse>

--- a/src/pages/components/utilities.mdx
+++ b/src/pages/components/utilities.mdx
@@ -6,7 +6,7 @@ description: >
 package: '@zendeskgarden/react-theming'
 components:
   - theming/src/utils/arrowStyles.ts
-  - theming/src/utils/getColor.ts
+  - theming/src/utils/getColorV8.ts
   - theming/src/utils/getLineHeight.ts
   - theming/src/utils/mediaQuery.ts
   - theming/src/utils/menuStyles.ts
@@ -58,12 +58,12 @@ to determine the color of the focus ring.
 
 <PropSheet components={COMPONENTS} componentName="focusStyles" headerName="Parameter" />
 
-### getColor
+### getColorV8
 
 Get a color for the given hue, shade, and theme. The algorithm returns a
 valid color even if the particular shade doesn't exist in the current theme.
 
-<PropSheet components={COMPONENTS} componentName="getColor" headerName="Parameter" />
+<PropSheet components={COMPONENTS} componentName="getColorV8" headerName="Parameter" />
 
 ### getFocusBoxShadow
 


### PR DESCRIPTION
## Description

Prepare for the v9 (specifically theming) upgrade by moving to `getColorV8`. We will need to eventually mark the utilities section for `getColorV8` deprecated, and add in a new section for `getColor` for V9 theming.
