### PR TITLE
refactor: upgrade to `@zendeskgarden/react-theming@next`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -45,7 +45,7 @@
         "@zendeskgarden/react-tables": "8.76.3",
         "@zendeskgarden/react-tabs": "8.76.3",
         "@zendeskgarden/react-tags": "8.76.3",
-        "@zendeskgarden/react-theming": "8.76.3",
+        "@zendeskgarden/react-theming": "9.0.0-next.19",
         "@zendeskgarden/react-tooltips": "8.76.3",
         "@zendeskgarden/react-typography": "8.76.3",
         "@zendeskgarden/scripts": "2.4.0",
@@ -7361,14 +7361,14 @@
       }
     },
     "node_modules/@zendeskgarden/react-theming": {
-      "version": "8.76.3",
-      "resolved": "https://registry.npmjs.org/@zendeskgarden/react-theming/-/react-theming-8.76.3.tgz",
-      "integrity": "sha512-Fqvjkp+diJyeTVxs3UinOQL6eUkHdcscc5EASHPl9JXm5BVoNbQnBDEMbyIXw2iz79AoW0b1K7Rq+eaLxKqUbQ==",
+      "version": "9.0.0-next.19",
+      "resolved": "https://registry.npmjs.org/@zendeskgarden/react-theming/-/react-theming-9.0.0-next.19.tgz",
+      "integrity": "sha512-EabsRluqIYYrChuEY9G07vhLVvqLnhobkkLy+s7UP7HYeJiTIVG2dw7dLE5amRxbX3zQmyXLuGclD9XUkVc5gw==",
       "dev": true,
-      "license": "Apache-2.0",
       "dependencies": {
-        "@zendeskgarden/container-focusvisible": "^2.0.3",
-        "@zendeskgarden/container-utilities": "^2.0.0",
+        "@floating-ui/react-dom": "^2.0.0",
+        "color2k": "^2.0.3",
+        "lodash.get": "^4.4.2",
         "lodash.memoize": "^4.1.2",
         "polished": "^4.3.1",
         "prop-types": "^15.5.7"
@@ -7376,7 +7376,7 @@
       "peerDependencies": {
         "react": ">=16.8.0",
         "react-dom": ">=16.8.0",
-        "styled-components": "^4.2.0 || ^5.0.0"
+        "styled-components": "^4.2.0 || ^5.3.1"
       }
     },
     "node_modules/@zendeskgarden/react-tooltips": {
@@ -10668,6 +10668,12 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/color2k": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/color2k/-/color2k-2.0.3.tgz",
+      "integrity": "sha512-zW190nQTIoXcGCaU08DvVNFTmQhUpnJfVuAKfWqUQkflXKpaDdpaYoM0iluLS9lgJNHyBF58KKA2FBEwkD7wog==",
       "dev": true
     },
     "node_modules/colord": {

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "@zendeskgarden/react-tables": "8.76.3",
     "@zendeskgarden/react-tabs": "8.76.3",
     "@zendeskgarden/react-tags": "8.76.3",
-    "@zendeskgarden/react-theming": "8.76.3",
+    "@zendeskgarden/react-theming": "9.0.0-next.19",
     "@zendeskgarden/react-tooltips": "8.76.3",
     "@zendeskgarden/react-typography": "8.76.3",
     "@zendeskgarden/scripts": "2.4.0",

--- a/src/components/MarkdownProvider/components/BestPractice.tsx
+++ b/src/components/MarkdownProvider/components/BestPractice.tsx
@@ -10,8 +10,8 @@ import styled from 'styled-components';
 import { math } from 'polished';
 import { GatsbyImage, IGatsbyImageData } from 'gatsby-plugin-image';
 import { Well, Title } from '@zendeskgarden/react-notifications';
-import { getColorV8, mediaQuery } from '@zendeskgarden/react-theming';
 import { Row, Col } from '@zendeskgarden/react-grid';
+import { getColor, getColorV8, mediaQuery } from '@zendeskgarden/react-theming';
 import { ReactComponent as XStrokeIcon } from '@zendeskgarden/svg-icons/src/16/x-stroke.svg';
 import { ReactComponent as CheckLgStrokeIcon } from '@zendeskgarden/svg-icons/src/16/check-lg-stroke.svg';
 import { ReactComponent as AlertErrorStrokeIcon } from '@zendeskgarden/svg-icons/src/16/alert-error-stroke.svg';
@@ -61,7 +61,7 @@ const StyledCaption = styled(p => <Well isRecessed {...p} />).attrs<IStyledCapti
   border-top: ${p => `${p.theme.borders.md} ${getColorV8(p.hue, 500, p.theme)}`};
   border-radius: 0;
   padding-bottom: ${p => p.theme.space.base * 7}px;
-  color: ${p => p.theme.colors.foreground};
+  color: ${({ theme }) => getColor({ variable: 'foreground.default', theme })};
 
   & > ul {
     list-style-type: none;

--- a/src/components/MarkdownProvider/components/CodeExample/index.tsx
+++ b/src/components/MarkdownProvider/components/CodeExample/index.tsx
@@ -5,7 +5,7 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import React, { useRef, useState, useMemo, PropsWithChildren } from 'react';
+import React, { useState, useMemo, PropsWithChildren } from 'react';
 import { math, rgba } from 'polished';
 import styled, { css } from 'styled-components';
 import { ThemeProvider, DEFAULT_THEME, getColorV8, PALETTE } from '@zendeskgarden/react-theming';
@@ -44,7 +44,6 @@ export const CodeExample: React.FC<ICodeExampleProps> = ({ children, code }) => 
   const [isRtl, setIsRtl] = useState(false);
   const [isCodeVisible, setIsCodeVisible] = useState(false);
   const [color, setColor] = useState<string | IColor>(PALETTE.blue[600]);
-  const focusVisibleRef = useRef(null);
   const { addToast } = useToast();
   const COPYRIGHT_REGEXP = /\/\*\*\n\s\*\sCopyright[\s\S]*\*\/\n\n/gmu;
 
@@ -89,7 +88,7 @@ export const CodeExample: React.FC<ICodeExampleProps> = ({ children, code }) => 
         border-radius: ${p => p.theme.borderRadii.md};
       `}
     >
-      <ThemeProvider theme={exampleTheme} focusVisibleRef={focusVisibleRef}>
+      <ThemeProvider theme={exampleTheme}>
         <div
           css={css`
             padding: ${p => p.theme.space.md};

--- a/src/components/MarkdownProvider/components/ColorPalette.tsx
+++ b/src/components/MarkdownProvider/components/ColorPalette.tsx
@@ -8,7 +8,7 @@
 import React from 'react';
 import styled from 'styled-components';
 import { readableColor } from 'polished';
-import { mediaQuery, PALETTE } from '@zendeskgarden/react-theming';
+import { getColor, mediaQuery, PALETTE } from '@zendeskgarden/react-theming';
 import { Row, Col } from '@zendeskgarden/react-grid';
 
 const StyledColorHex = styled.figcaption`
@@ -26,7 +26,12 @@ const StyledColorSwatch = styled.figure<{ color: string }>`
   align-items: center;
   background-color: ${p => p.color};
   padding: ${p => p.theme.space.sm};
-  color: ${p => readableColor(p.color, p.theme.colors.foreground, p.theme.colors.background)};
+  color: ${p =>
+    readableColor(
+      p.color,
+      getColor({ theme: p.theme, variable: 'foreground.default' }),
+      getColor({ theme: p.theme, variable: 'background.default' })
+    )};
 `;
 
 const StyledColorTitle = styled.b`

--- a/src/components/Provider.tsx
+++ b/src/components/Provider.tsx
@@ -5,7 +5,7 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import React, { createRef, FC, PropsWithChildren } from 'react';
+import React, { FC, PropsWithChildren } from 'react';
 import { ThemeProvider, DEFAULT_THEME } from '@zendeskgarden/react-theming';
 import { ToastProvider } from '@zendeskgarden/react-notifications';
 import { MarkdownProvider } from './MarkdownProvider';
@@ -20,12 +20,9 @@ const toastPlacement = {
 };
 
 export const Provider: FC<PropsWithChildren> = ({ children }) => {
-  const focusVisibleRef = createRef<HTMLDivElement>();
-
   return (
-    <ThemeProvider focusVisibleRef={focusVisibleRef} theme={theme}>
+    <ThemeProvider theme={theme}>
       <div
-        ref={focusVisibleRef}
         css={`
           width: 100%;
           height: 100%;

--- a/src/examples/draggable/DropzoneDefault.tsx
+++ b/src/examples/draggable/DropzoneDefault.tsx
@@ -32,7 +32,7 @@ import {
 } from '@zendeskgarden/react-drag-drop';
 import { Row, Col } from '@zendeskgarden/react-grid';
 import { MD } from '@zendeskgarden/react-typography';
-import { mediaQuery } from '@zendeskgarden/react-theming';
+import { getColor, mediaQuery } from '@zendeskgarden/react-theming';
 
 interface IColumnItem {
   id: string;
@@ -166,7 +166,7 @@ const StyledDraggable = styled(DraggableItem)`
   cursor: default;
 
   &:hover {
-    background-color: ${p => p.theme.colors.background};
+    background-color: ${({ theme }) => getColor({ variable: 'background.default', theme })};
   }
 `;
 

--- a/src/examples/table/TableVerticalScrolling.tsx
+++ b/src/examples/table/TableVerticalScrolling.tsx
@@ -8,7 +8,7 @@
 import React from 'react';
 import { Body, Cell, Head, HeaderCell, HeaderRow, Row, Table } from '@zendeskgarden/react-tables';
 import { Paragraph } from '@zendeskgarden/react-typography';
-import { getColorV8 } from '@zendeskgarden/react-theming';
+import { getColor, getColorV8 } from '@zendeskgarden/react-theming';
 import styled from 'styled-components';
 
 const rowData = Array.from(Array(10)).map((row, index) => ({
@@ -29,7 +29,7 @@ const StyledHeaderRow = styled(HeaderRow)`
 const StyledHead = styled(Head)`
   position: sticky;
   top: 0;
-  background: ${props => props.theme.colors.background};
+  background-color: ${({ theme }) => getColor({ variable: 'background.default', theme })};
 `;
 
 const StyledParagraph = styled(Paragraph)`

--- a/src/examples/theme-provider/ThemeProviderBranding.tsx
+++ b/src/examples/theme-provider/ThemeProviderBranding.tsx
@@ -25,7 +25,7 @@ const Example = () => {
   });
 
   return (
-    <ThemeProvider focusVisibleRef={null} theme={theme as any}>
+    <ThemeProvider theme={theme as any}>
       <Row>
         <Col textAlign="center">
           <Button>Default</Button>

--- a/src/examples/theme-provider/ThemeProviderExtension.tsx
+++ b/src/examples/theme-provider/ThemeProviderExtension.tsx
@@ -36,7 +36,7 @@ const Example = () => {
   });
 
   return (
-    <ThemeProvider focusVisibleRef={null} theme={theme as any}>
+    <ThemeProvider theme={theme as any}>
       <Row>
         <Col textAlign="center">
           <Button isDanger>Default</Button>

--- a/src/examples/theme-provider/ThemeProviderNesting.tsx
+++ b/src/examples/theme-provider/ThemeProviderNesting.tsx
@@ -217,15 +217,15 @@ const Example = () => {
 
   return (
     <Row>
-      <ThemeProvider focusVisibleRef={null} theme={sizeTheme as any}>
+      <ThemeProvider theme={sizeTheme as any}>
         <Col>
           <FlowerPot />
         </Col>
-        <ThemeProvider focusVisibleRef={null} theme={colorTheme as any}>
+        <ThemeProvider theme={colorTheme as any}>
           <StyledCol>
             <FlowerPot />
           </StyledCol>
-          <ThemeProvider focusVisibleRef={null} theme={shapeTheme as any}>
+          <ThemeProvider theme={shapeTheme as any}>
             <StyledCol>
               <FlowerPot />
             </StyledCol>

--- a/src/examples/theme-provider/ThemeProviderTargeting.tsx
+++ b/src/examples/theme-provider/ThemeProviderTargeting.tsx
@@ -32,7 +32,7 @@ const Example = () => {
   });
 
   return (
-    <ThemeProvider focusVisibleRef={null} theme={theme as any}>
+    <ThemeProvider theme={theme as any}>
       <Tabs selectedItem={selectedTab} onChange={setSelectedTab}>
         <TabPanel item="tab-1">
           Elms are deciduous and semi-deciduous trees comprising the flowering plant genus Ulmus in

--- a/src/layouts/Home/components/News.tsx
+++ b/src/layouts/Home/components/News.tsx
@@ -8,7 +8,7 @@
 import React from 'react';
 import { useStaticQuery, graphql } from 'gatsby';
 import styled, { css } from 'styled-components';
-import { SELECTOR_FOCUS_VISIBLE, getColorV8 } from '@zendeskgarden/react-theming';
+import { SELECTOR_FOCUS_VISIBLE, getColor, getColorV8 } from '@zendeskgarden/react-theming';
 import { Grid, Row, Col } from '@zendeskgarden/react-grid';
 import { XXL } from '@zendeskgarden/react-typography';
 import { Anchor } from '@zendeskgarden/react-buttons';
@@ -74,7 +74,8 @@ export const News: React.FC = () => {
                       <StyledNewsAnchor
                         href={edge.node.url}
                         css={css`
-                          color: ${p => p.theme.colors.foreground};
+                          color: ${({ theme }) =>
+                            getColor({ variable: 'foreground.default', theme })};
                           font-weight: ${p => p.theme.fontWeights.semibold};
                         `}
                       >

--- a/src/layouts/Root/components/Footer.tsx
+++ b/src/layouts/Root/components/Footer.tsx
@@ -7,14 +7,19 @@
 
 import React from 'react';
 import styled, { css } from 'styled-components';
-import { SELECTOR_FOCUS_VISIBLE, getColorV8, mediaQuery } from '@zendeskgarden/react-theming';
+import {
+  SELECTOR_FOCUS_VISIBLE,
+  getColor,
+  getColorV8,
+  mediaQuery
+} from '@zendeskgarden/react-theming';
 import { ReactComponent as GardenIcon } from '@zendeskgarden/svg-icons/src/26/garden.svg';
 import { Link } from './StyledNavigationLink';
 import MaxWidthLayout from 'layouts/MaxWidth';
 
 const StyledFooterItem = styled(Link)`
   margin-right: ${p => p.theme.space.lg};
-  color: ${p => p.theme.palette.white};
+  color: ${({ theme }) => getColor({ hue: 'white', theme })};
 
   &:hover,
   &:focus {
@@ -44,7 +49,7 @@ const Footer: React.FC<IFooterProps> = ({ path }) => (
       background-color: ${p => getColorV8('kale', 700, p.theme)};
       padding: ${p => p.theme.space.md};
       line-height: ${p => p.theme.lineHeights.md};
-      color: ${p => p.theme.palette.white};
+      color: ${({ theme }) => getColor({ hue: 'white', theme })};
       font-size: ${p => p.theme.fontSizes.md};
     `}
   >

--- a/src/layouts/Root/components/Header.tsx
+++ b/src/layouts/Root/components/Header.tsx
@@ -8,7 +8,7 @@
 import React, { useState, HTMLAttributes, useRef, useEffect } from 'react';
 import styled, { css } from 'styled-components';
 import { Link } from 'gatsby';
-import { getColorV8, mediaQuery, PALETTE } from '@zendeskgarden/react-theming';
+import { getColor, getColorV8, mediaQuery, PALETTE } from '@zendeskgarden/react-theming';
 import { IconButton } from '@zendeskgarden/react-buttons';
 import { ReactComponent as SearchStroke } from '@zendeskgarden/svg-icons/src/16/search-stroke.svg';
 import { ReactComponent as OverflowVerticalStroke } from '@zendeskgarden/svg-icons/src/16/overflow-vertical-stroke.svg';
@@ -47,7 +47,7 @@ const StyledHeader = styled.header.attrs({ role: 'banner' })`
   height: ${p => headerHeight(p.theme)}px;
 
   &[data-show-navigation='true'] {
-    border-bottom-color: ${p => p.theme.palette.white};
+    border-bottom-color: ${({ theme }) => getColor({ hue: 'white', theme })};
   }
 
   ${p => mediaQuery('down', 'sm', p.theme)} {

--- a/src/layouts/Root/components/StyledNavigationLink.tsx
+++ b/src/layouts/Root/components/StyledNavigationLink.tsx
@@ -9,7 +9,7 @@ import React, { ReactNode } from 'react';
 import styled from 'styled-components';
 import { Link as GatsbyLink } from 'gatsby';
 import { OutboundLink } from 'gatsby-plugin-google-gtag';
-import { focusStyles, getColorV8 } from '@zendeskgarden/react-theming';
+import { focusStyles, getColor, getColorV8 } from '@zendeskgarden/react-theming';
 
 interface ILink {
   children: ReactNode;
@@ -40,7 +40,7 @@ export const StyledNavigationLink = styled(Link).attrs(p => ({
 }))`
   border-radius: ${p => p.theme.borderRadii.md};
   padding: ${p => p.theme.space.base * 1.5}px ${p => p.theme.space.xs};
-  color: ${p => p.theme.colors.foreground};
+  color: ${({ theme }) => getColor({ variable: 'foreground.default', theme })};
 
   &:hover,
   &:focus,

--- a/src/layouts/Sidebar/index.tsx
+++ b/src/layouts/Sidebar/index.tsx
@@ -7,8 +7,7 @@
 
 import React, { PropsWithChildren, useState } from 'react';
 import styled, { css } from 'styled-components';
-import { rgba } from 'polished';
-import { getColorV8, mediaQuery } from '@zendeskgarden/react-theming';
+import { getColor, getColorV8, mediaQuery } from '@zendeskgarden/react-theming';
 import { ReactComponent as OverflowStroke } from '@zendeskgarden/svg-icons/src/16/overflow-vertical-stroke.svg';
 import { ReactComponent as CloseStroke } from '@zendeskgarden/svg-icons/src/16/x-stroke.svg';
 import MaxWidthLayout from 'layouts/MaxWidth';
@@ -30,11 +29,12 @@ const StyledMobileNavButton = styled.button`
   justify-content: center;
   z-index: 1;
   /* stylelint-disable-next-line color-function-notation */
-  border: ${p => p.theme.borders.sm} ${p => rgba(p.theme.palette.white as string, 0.2)};
+  border: ${p => p.theme.borders.sm}
+    ${({ theme }) => getColor({ hue: 'white', transparency: 0.2, theme })};
   border-radius: 100px;
   background-color: ${p => getColorV8('kale', 800, p.theme)};
   padding: ${p => p.theme.space.xs};
-  color: ${p => p.theme.colors.background};
+  color: ${({ theme }) => getColor({ hue: 'white', theme })};
 
   &:focus {
     outline: none;
@@ -75,7 +75,8 @@ export const SidebarLayout: React.FC<ISidebarLayoutProps> = ({ children, sidebar
           <div
             css={css`
               flex-grow: 1;
-              background-color: ${p => p.theme.colors.background};
+              background-color: ${({ theme }) =>
+                getColor({ variable: 'background.default', theme })};
               padding: ${p => p.theme.space.lg} ${p => p.theme.space.md};
               max-width: 100vw;
 


### PR DESCRIPTION

## Description
Upgrades to `@zendeskgarden/react-theming@next` and limit refactoring to `src/components` and `src/layout`.

## Detail
- upgrade to `@zendeskgarden/react-theming@next`
- replace missing colors from V8 `theme.colors` with `getColor({ variable: {{variable}}, theme)`
- Refactor obvious colors assignments with `getColor`
- Remove deprecated `focusVisibleRef`
- Fix TS error everywhere, including `src/examples`, to successfully pass tests and build

![Screenshot 2024-07-30 at 1 23 12 PM](https://github.com/user-attachments/assets/e9f14273-e8a0-423e-9f5f-c80db6c7c9fb)

