### PR TITLE
chore: updates components submodule to v9

### DIFF
--- a/src/layouts/Titled/components/TOC.tsx
+++ b/src/layouts/Titled/components/TOC.tsx
@@ -29,7 +29,9 @@ export const TOCBlock: React.FC<{ data: IHeading[] } & HTMLAttributes<HTMLDivEle
     <ul>
       {data.map(heading => (
         <li key={heading.url}>
-          <Anchor href={heading.url}>{heading.title}</Anchor>
+          <Anchor isUnderlined={false} href={heading.url}>
+            {heading.title}
+          </Anchor>
           {!!heading.items && (
             <ul
               css={css`
@@ -38,7 +40,9 @@ export const TOCBlock: React.FC<{ data: IHeading[] } & HTMLAttributes<HTMLDivEle
             >
               {heading.items!.map(subHeading => (
                 <li key={subHeading.url}>
-                  <Anchor href={subHeading.url}>{subHeading.title}</Anchor>
+                  <Anchor isUnderlined={false} href={subHeading.url}>
+                    {subHeading.title}
+                  </Anchor>
                 </li>
               ))}
             </ul>

--- a/src/pages/components/autocomplete.mdx
+++ b/src/pages/components/autocomplete.mdx
@@ -3,15 +3,15 @@ title: Autocomplete
 description: >
   Autocomplete is an input field that filters results as users type. This helps users find
   something quickly in a large list of options.
-package: '@zendeskgarden/react-dropdowns'
+package: '@zendeskgarden/react-dropdowns.legacy'
 components:
-  - dropdowns/src/elements/Autocomplete/Autocomplete.tsx
-  - dropdowns/src/elements/Dropdown/Dropdown.tsx
-  - dropdowns/src/elements/Fields/Field.tsx
-  - dropdowns/src/elements/Fields/Hint.tsx
-  - dropdowns/src/elements/Menu/Items/Item.tsx
-  - dropdowns/src/elements/Fields/Label.tsx
-  - dropdowns/src/elements/Menu/Menu.tsx
+  - dropdowns.legacy/src/elements/Autocomplete/Autocomplete.tsx
+  - dropdowns.legacy/src/elements/Dropdown/Dropdown.tsx
+  - dropdowns.legacy/src/elements/Fields/Field.tsx
+  - dropdowns.legacy/src/elements/Fields/Hint.tsx
+  - dropdowns.legacy/src/elements/Menu/Items/Item.tsx
+  - dropdowns.legacy/src/elements/Fields/Label.tsx
+  - dropdowns.legacy/src/elements/Menu/Menu.tsx
 ---
 
 import { SEO } from '../../components';

--- a/src/pages/components/chrome.mdx
+++ b/src/pages/components/chrome.mdx
@@ -7,7 +7,6 @@ package: '@zendeskgarden/react-chrome'
 components:
   - chrome/src/elements/body/Body.tsx
   - chrome/src/elements/Chrome.tsx
-  - chrome/src/elements/subnav/CollapsibleSubNavItem.tsx
   - chrome/src/elements/body/Content.tsx
   - chrome/src/elements/footer/Footer.tsx
   - chrome/src/elements/footer/FooterItem.tsx
@@ -23,9 +22,6 @@ components:
   - chrome/src/elements/nav/NavItemText.tsx
   - chrome/src/elements/body/Sidebar.tsx
   - chrome/src/elements/SkipNav.tsx
-  - chrome/src/elements/subnav/SubNav.tsx
-  - chrome/src/elements/subnav/SubNavItem.tsx
-  - chrome/src/elements/subnav/SubNavItemText.tsx
 ---
 
 import { SEO } from '../../components';
@@ -114,12 +110,6 @@ Chrome uses [26px sized icons](/design/icons/chrome-icons) made specifically for
 
 <PropSheet components={props.data.mdx.components} componentName="chrome" />
 
-### CollapsibleSubNavItem
-
-<Component components={props.data.mdx.components} componentName="collapsibleSubNavItem" />
-
-<PropSheet components={props.data.mdx.components} componentName="collapsibleSubNavItem" />
-
 ### Content
 
 <Component components={props.data.mdx.components} componentName="content" />
@@ -198,35 +188,11 @@ Chrome uses [26px sized icons](/design/icons/chrome-icons) made specifically for
 
 <PropSheet components={props.data.mdx.components} componentName="navItemText" />
 
-### Sidebar
-
-<Component components={props.data.mdx.components} componentName="sidebar" />
-
-<PropSheet components={props.data.mdx.components} componentName="sidebar" />
-
 ### SkipNav
 
 <Component components={props.data.mdx.components} componentName="skipNav" />
 
 <PropSheet components={props.data.mdx.components} componentName="skipNav" />
-
-### SubNav
-
-<Component components={props.data.mdx.components} componentName="subNav" />
-
-<PropSheet components={props.data.mdx.components} componentName="subNav" />
-
-### SubNavItem
-
-<Component components={props.data.mdx.components} componentName="subNavItem" />
-
-<PropSheet components={props.data.mdx.components} componentName="subNavItem" />
-
-### SubNavItemText
-
-<Component components={props.data.mdx.components} componentName="subNavItemText" />
-
-<PropSheet components={props.data.mdx.components} componentName="subNavItemText" />
 
 import { graphql } from 'gatsby';
 

--- a/src/pages/components/color-picker.mdx
+++ b/src/pages/components/color-picker.mdx
@@ -4,8 +4,8 @@ description: >
   The Color picker allows users to choose colors using sliders and input fields.
 package: '@zendeskgarden/react-colorpickers'
 components:
-  - colorpickers/src/elements/Colorpicker/index.tsx
-  - colorpickers/src/elements/ColorpickerDialog/index.tsx
+  - colorpickers/src/elements/ColorPicker/index.tsx
+  - colorpickers/src/elements/ColorPickerDialog/index.tsx
 ---
 
 import { SEO } from '../../components';

--- a/src/pages/components/combobox.mdx
+++ b/src/pages/components/combobox.mdx
@@ -1,19 +1,19 @@
 ---
 title: Combobox
 description: Combobox is an input plus a listbox that appears beneath it. It searches and filters down options, allowing the user to select.
-package: '@zendeskgarden/react-dropdowns.next'
+package: '@zendeskgarden/react-dropdowns'
 components:
-  - 'dropdowns.next/src/elements/combobox/Combobox.tsx'
-  - 'dropdowns.next/src/elements/combobox/Field.tsx'
-  - 'dropdowns.next/src/elements/combobox/Hint.tsx'
-  - 'dropdowns.next/src/elements/combobox/Label.tsx'
-  - 'dropdowns.next/src/elements/combobox/Message.tsx'
-  - 'dropdowns.next/src/elements/combobox/OptGroup.tsx'
-  - 'dropdowns.next/src/elements/combobox/Option.tsx'
-  - 'dropdowns.next/src/elements/combobox/Tag.tsx'
+  - 'dropdowns/src/elements/combobox/Combobox.tsx'
+  - 'dropdowns/src/elements/combobox/Field.tsx'
+  - 'dropdowns/src/elements/combobox/Hint.tsx'
+  - 'dropdowns/src/elements/combobox/Label.tsx'
+  - 'dropdowns/src/elements/combobox/Message.tsx'
+  - 'dropdowns/src/elements/combobox/OptGroup.tsx'
+  - 'dropdowns/src/elements/combobox/Option.tsx'
+  - 'dropdowns/src/elements/combobox/Tag.tsx'
 subcomponents:
-  - 'dropdowns.next/src/elements/combobox/OptionMeta.tsx'
-  - 'dropdowns.next/src/elements/combobox/TagAvatar.tsx'
+  - 'dropdowns/src/elements/combobox/OptionMeta.tsx'
+  - 'dropdowns/src/elements/combobox/TagAvatar.tsx'
 ---
 
 import { SEO } from '../../components';

--- a/src/pages/components/date-picker.mdx
+++ b/src/pages/components/date-picker.mdx
@@ -4,12 +4,12 @@ description: >
   A Date picker lets users select a date by showing them a calendar. It works in combination with a text input.
 package: '@zendeskgarden/react-datepickers'
 components:
-  - datepickers/src/elements/Datepicker/Datepicker.tsx
-  - datepickers/src/elements/DatepickerRange/DatepickerRange.tsx
+  - datepickers/src/elements/DatePicker/DatePicker.tsx
+  - datepickers/src/elements/DatePickerRange/DatePickerRange.tsx
 subcomponents:
-  - datepickers/src/elements/DatepickerRange/components/Calendar.tsx
-  - datepickers/src/elements/DatepickerRange/components/End.tsx
-  - datepickers/src/elements/DatepickerRange/components/Start.tsx
+  - datepickers/src/elements/DatePickerRange/components/Calendar.tsx
+  - datepickers/src/elements/DatePickerRange/components/End.tsx
+  - datepickers/src/elements/DatePickerRange/components/Start.tsx
 ---
 
 import { SEO } from '../../components';

--- a/src/pages/components/draggable.mdx
+++ b/src/pages/components/draggable.mdx
@@ -3,18 +3,18 @@ title: Draggable
 description: >
   The draggable is an interactive element that can be "grabbed", dragged, and dropped to
   another location. This lets users rearrange and/or organize items.
-package: '@zendeskgarden/react-drag-drop'
+package: '@zendeskgarden/react-draggable'
 components:
-  - drag-drop/src/elements/draggable/Draggable.tsx
-  - drag-drop/src/elements/draggable-list/DraggableList.tsx
-  - drag-drop/src/elements/dropzone/Dropzone.tsx
+  - draggable/src/elements/draggable/Draggable.tsx
+  - draggable/src/elements/draggable-list/DraggableList.tsx
+  - draggable/src/elements/dropzone/Dropzone.tsx
 subcomponents:
-  - drag-drop/src/elements/draggable/components/Content.tsx
-  - drag-drop/src/elements/draggable/components/Grip.tsx
-  - drag-drop/src/elements/draggable-list/components/DropIndicator.tsx
-  - drag-drop/src/elements/draggable-list/components/Item.tsx
-  - drag-drop/src/elements/dropzone/components/Icon.tsx
-  - drag-drop/src/elements/dropzone/components/Message.tsx
+  - draggable/src/elements/draggable/components/Content.tsx
+  - draggable/src/elements/draggable/components/Grip.tsx
+  - draggable/src/elements/draggable-list/components/DropIndicator.tsx
+  - draggable/src/elements/draggable-list/components/Item.tsx
+  - draggable/src/elements/dropzone/components/Icon.tsx
+  - draggable/src/elements/dropzone/components/Message.tsx
 ---
 
 import { SEO } from '../../components';

--- a/src/pages/components/drawer.mdx
+++ b/src/pages/components/drawer.mdx
@@ -4,13 +4,13 @@ description: >
   A Drawer is a container for supplementary content that is anchored to the edge of a page.
 package: '@zendeskgarden/react-modals'
 components:
-  - modals/src/elements/DrawerModal/DrawerModal.tsx
+  - modals/src/elements/Drawer/Drawer.tsx
 subcomponents:
-  - modals/src/elements/DrawerModal/Body.tsx
-  - modals/src/elements/DrawerModal/Close.tsx
-  - modals/src/elements/DrawerModal/Footer.tsx
-  - modals/src/elements/DrawerModal/FooterItem.tsx
-  - modals/src/elements/DrawerModal/Header.tsx
+  - modals/src/elements/Drawer/Body.tsx
+  - modals/src/elements/Drawer/Close.tsx
+  - modals/src/elements/Drawer/Footer.tsx
+  - modals/src/elements/Drawer/FooterItem.tsx
+  - modals/src/elements/Drawer/Header.tsx
 ---
 
 import { SEO } from '../../components';
@@ -51,39 +51,39 @@ import DefaultCode from '!!raw-loader!../../examples/drawer/DrawerDefault.tsx';
 
 ### DrawerModal
 
-<Component components={props.data.mdx.components} componentName="drawerModal" />
+<Component components={props.data.mdx.components} componentName="drawer" />
 
-<PropSheet components={props.data.mdx.components} componentName="drawerModal" />
+<PropSheet components={props.data.mdx.components} componentName="drawer" />
 
 #### DrawerModal.Body
 
-<Component components={props.data.mdx.subcomponents} componentName="drawerModal.body" />
+<Component components={props.data.mdx.subcomponents} componentName="drawer.body" />
 
-<PropSheet components={props.data.mdx.subcomponents} componentName="drawerModal.body" />
+<PropSheet components={props.data.mdx.subcomponents} componentName="drawer.body" />
 
 #### DrawerModal.Close
 
-<Component components={props.data.mdx.subcomponents} componentName="drawerModal.close" />
+<Component components={props.data.mdx.subcomponents} componentName="drawer.close" />
 
-<PropSheet components={props.data.mdx.subcomponents} componentName="drawerModal.close" />
+<PropSheet components={props.data.mdx.subcomponents} componentName="drawer.close" />
 
 #### DrawerModal.Footer
 
-<Component components={props.data.mdx.subcomponents} componentName="drawerModal.footer" />
+<Component components={props.data.mdx.subcomponents} componentName="drawer.footer" />
 
-<PropSheet components={props.data.mdx.subcomponents} componentName="drawerModal.footer" />
+<PropSheet components={props.data.mdx.subcomponents} componentName="drawer.footer" />
 
 #### DrawerModal.FooterItem
 
-<Component components={props.data.mdx.subcomponents} componentName="drawerModal.footerItem" />
+<Component components={props.data.mdx.subcomponents} componentName="drawer.footerItem" />
 
-<PropSheet components={props.data.mdx.subcomponents} componentName="drawerModal.footerItem" />
+<PropSheet components={props.data.mdx.subcomponents} componentName="drawer.footerItem" />
 
 #### DrawerModal.Header
 
-<Component components={props.data.mdx.subcomponents} componentName="drawerModal.header" />
+<Component components={props.data.mdx.subcomponents} componentName="drawer.header" />
 
-<PropSheet components={props.data.mdx.subcomponents} componentName="drawerModal.header" />
+<PropSheet components={props.data.mdx.subcomponents} componentName="drawer.header" />
 
 import { graphql } from 'gatsby';
 

--- a/src/pages/components/legacy-combobox.mdx
+++ b/src/pages/components/legacy-combobox.mdx
@@ -1,15 +1,15 @@
 ---
 title: Combobox
 description: Combobox is an input plus a list box that appears beneath it. It searches and filters down options for the user.
-package: '@zendeskgarden/react-dropdowns'
+package: '@zendeskgarden/react-dropdowns.legacy'
 components:
-  - dropdowns/src/elements/Combobox/Combobox.tsx
-  - dropdowns/src/elements/Dropdown/Dropdown.tsx
-  - dropdowns/src/elements/Fields/Field.tsx
-  - dropdowns/src/elements/Fields/Hint.tsx
-  - dropdowns/src/elements/Menu/Items/Item.tsx
-  - dropdowns/src/elements/Fields/Label.tsx
-  - dropdowns/src/elements/Menu/Menu.tsx
+  - dropdowns.legacy/src/elements/Combobox/Combobox.tsx
+  - dropdowns.legacy/src/elements/Dropdown/Dropdown.tsx
+  - dropdowns.legacy/src/elements/Fields/Field.tsx
+  - dropdowns.legacy/src/elements/Fields/Hint.tsx
+  - dropdowns.legacy/src/elements/Menu/Items/Item.tsx
+  - dropdowns.legacy/src/elements/Fields/Label.tsx
+  - dropdowns.legacy/src/elements/Menu/Menu.tsx
 ---
 
 import { SEO } from '../../components';

--- a/src/pages/components/legacy-menu.mdx
+++ b/src/pages/components/legacy-menu.mdx
@@ -2,22 +2,22 @@
 title: Menu
 description: >
   Menus help users select a single item from a list of available options.
-package: '@zendeskgarden/react-dropdowns'
+package: '@zendeskgarden/react-dropdowns.legacy'
 components:
-  - dropdowns/src/elements/Menu/Items/AddItem.tsx
-  - dropdowns/src/elements/Dropdown/Dropdown.tsx
-  - dropdowns/src/elements/Menu/Items/HeaderIcon.tsx
-  - dropdowns/src/elements/Menu/Items/HeaderItem.tsx
-  - dropdowns/src/elements/Menu/Items/Item.tsx
-  - dropdowns/src/elements/Menu/Items/ItemMeta.tsx
-  - dropdowns/src/elements/Menu/Items/MediaBody.tsx
-  - dropdowns/src/elements/Menu/Items/MediaFigure.tsx
-  - dropdowns/src/elements/Menu/Items/MediaItem.tsx
-  - dropdowns/src/elements/Menu/Menu.tsx
-  - dropdowns/src/elements/Menu/Items/NextItem.tsx
-  - dropdowns/src/elements/Menu/Items/PreviousItem.tsx
-  - dropdowns/src/elements/Menu/Separator.tsx
-  - dropdowns/src/elements/Trigger/Trigger.tsx
+  - dropdowns.legacy/src/elements/Menu/Items/AddItem.tsx
+  - dropdowns.legacy/src/elements/Dropdown/Dropdown.tsx
+  - dropdowns.legacy/src/elements/Menu/Items/HeaderIcon.tsx
+  - dropdowns.legacy/src/elements/Menu/Items/HeaderItem.tsx
+  - dropdowns.legacy/src/elements/Menu/Items/Item.tsx
+  - dropdowns.legacy/src/elements/Menu/Items/ItemMeta.tsx
+  - dropdowns.legacy/src/elements/Menu/Items/MediaBody.tsx
+  - dropdowns.legacy/src/elements/Menu/Items/MediaFigure.tsx
+  - dropdowns.legacy/src/elements/Menu/Items/MediaItem.tsx
+  - dropdowns.legacy/src/elements/Menu/Menu.tsx
+  - dropdowns.legacy/src/elements/Menu/Items/NextItem.tsx
+  - dropdowns.legacy/src/elements/Menu/Items/PreviousItem.tsx
+  - dropdowns.legacy/src/elements/Menu/Separator.tsx
+  - dropdowns.legacy/src/elements/Trigger/Trigger.tsx
 ---
 
 import { SEO } from '../../components';

--- a/src/pages/components/legacy-select.mdx
+++ b/src/pages/components/legacy-select.mdx
@@ -3,14 +3,14 @@ title: Select
 description: >
   Select allows a user to pick one option from a list.
   This helps simplify the UI when space is limited.
-package: '@zendeskgarden/react-dropdowns'
+package: '@zendeskgarden/react-dropdowns.legacy'
 components:
-  - dropdowns/src/elements/Dropdown/Dropdown.tsx
-  - dropdowns/src/elements/Fields/Field.tsx
-  - dropdowns/src/elements/Fields/Hint.tsx
-  - dropdowns/src/elements/Fields/Label.tsx
-  - dropdowns/src/elements/Fields/Message.tsx
-  - dropdowns/src/elements/Select/Select.tsx
+  - dropdowns.legacy/src/elements/Dropdown/Dropdown.tsx
+  - dropdowns.legacy/src/elements/Fields/Field.tsx
+  - dropdowns.legacy/src/elements/Fields/Hint.tsx
+  - dropdowns.legacy/src/elements/Fields/Label.tsx
+  - dropdowns.legacy/src/elements/Fields/Message.tsx
+  - dropdowns.legacy/src/elements/Select/Select.tsx
 ---
 
 import { SEO } from '../../components';

--- a/src/pages/components/menu.mdx
+++ b/src/pages/components/menu.mdx
@@ -2,14 +2,14 @@
 title: Menu
 description: >
   Menus help users choose items from a list.
-package: '@zendeskgarden/react-dropdowns.next'
+package: '@zendeskgarden/react-dropdowns'
 components:
-  - 'dropdowns.next/src/elements/menu/Menu.tsx'
-  - 'dropdowns.next/src/elements/menu/ItemGroup.tsx'
-  - 'dropdowns.next/src/elements/menu/Item.tsx'
-  - 'dropdowns.next/src/elements/menu/Separator.tsx'
+  - 'dropdowns/src/elements/menu/Menu.tsx'
+  - 'dropdowns/src/elements/menu/ItemGroup.tsx'
+  - 'dropdowns/src/elements/menu/Item.tsx'
+  - 'dropdowns/src/elements/menu/Separator.tsx'
 subcomponents:
-  - 'dropdowns.next/src/elements/menu/ItemMeta.tsx'
+  - 'dropdowns/src/elements/menu/ItemMeta.tsx'
 ---
 
 import { SEO } from '../../components';

--- a/src/pages/components/multiselect.mdx
+++ b/src/pages/components/multiselect.mdx
@@ -3,14 +3,14 @@ title: Multiselect
 description: >
   Multiselect lets users select multiple items from a list. Options are dynamically filtered as a
   user types in the input field and their selections appear as tags in the input field.
-package: '@zendeskgarden/react-dropdowns'
+package: '@zendeskgarden/react-dropdowns.legacy'
 components:
-  - dropdowns/src/elements/Dropdown/Dropdown.tsx
-  - dropdowns/src/elements/Fields/Field.tsx
-  - dropdowns/src/elements/Fields/Hint.tsx
-  - dropdowns/src/elements/Menu/Items/Item.tsx
-  - dropdowns/src/elements/Fields/Label.tsx
-  - dropdowns/src/elements/Multiselect/Multiselect.tsx
+  - dropdowns.legacy/src/elements/Dropdown/Dropdown.tsx
+  - dropdowns.legacy/src/elements/Fields/Field.tsx
+  - dropdowns.legacy/src/elements/Fields/Hint.tsx
+  - dropdowns.legacy/src/elements/Menu/Items/Item.tsx
+  - dropdowns.legacy/src/elements/Fields/Label.tsx
+  - dropdowns.legacy/src/elements/Multiselect/Multiselect.tsx
 ---
 
 import { SEO } from '../../components';

--- a/src/pages/components/pagination.mdx
+++ b/src/pages/components/pagination.mdx
@@ -4,7 +4,7 @@ description: >
   Pagination separates content into pages and allows users to navigate between those pages.
 package: '@zendeskgarden/react-pagination'
 components:
-  - pagination/src/elements/Pagination/Pagination.tsx
+  - pagination/src/elements/OffsetPagination/OffsetPagination.tsx
   - pagination/src/elements/CursorPagination/CursorPagination.tsx
 subcomponents:
   - pagination/src/elements/CursorPagination/components/First.tsx
@@ -85,9 +85,9 @@ import OffsetDefaultCode from '!!raw-loader!../../examples/pagination/OffsetDefa
 
 ### Pagination
 
-<Component components={props.data.mdx.components} componentName="pagination" />
+<Component components={props.data.mdx.components} componentName="offsetPagination" />
 
-<PropSheet components={props.data.mdx.components} componentName="pagination" />
+<PropSheet components={props.data.mdx.components} componentName="offsetPagination" />
 
 ### CursorPagination
 


### PR DESCRIPTION
# Description

This is a prep PR to ensure component pages hold together. Once this merges, those pages can be updated in parallel. **These changes are minimal** to keep the diff small.

As usual, some colors/details will be off, which is intended while the migration process continues.

## Detail

The [migration guide](https://github.com/zendeskgarden/react-components/blob/next/docs/migration.md) was used for details on specific naming/path updates.

### Checklist

Each component page was loaded to validate, including sub-pages (`forms > multiselect`, for instance).

- [x] Theming
- [x] Accordions
- [x] Avatars
- [x] Breadcrumbs
- [x] Buttons
- [x] Chrome
- [x] Color picker
- [x] Color swatch
- [x] Date picker 
- [x] Draggable
- [x] Dropdowns
- [x] Forms
- [x] Grid
- [x] Loaders
- [x] Menu
- [x] Modals
- [x] Notification
- [x] Pagination
- [x] Pane
- [x] Sheet
- [x] Status indicator
- [x] Stepper
- [x] Table
- [x] Tabs
- [x] Tags
- [x] Tiles
- [x] Timeline
- [x] Tooltip
- [x] Tooltip modal
- [x] Typography
- [x] Well