### PR TITLE
feat(components): update accordions to v9

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "@zendeskgarden/container-utilities": "2.0.0",
         "@zendeskgarden/css-bedrock": "9.1.1",
         "@zendeskgarden/eslint-config": "42.0.0",
-        "@zendeskgarden/react-accordions": "8.76.3",
+        "@zendeskgarden/react-accordions": "9.0.0-next.19",
         "@zendeskgarden/react-avatars": "8.76.3",
         "@zendeskgarden/react-breadcrumbs": "8.76.3",
         "@zendeskgarden/react-buttons": "9.0.0-next.19",
@@ -6932,11 +6932,10 @@
       }
     },
     "node_modules/@zendeskgarden/react-accordions": {
-      "version": "8.76.3",
-      "resolved": "https://registry.npmjs.org/@zendeskgarden/react-accordions/-/react-accordions-8.76.3.tgz",
-      "integrity": "sha512-JDN5ewpZKPDcI41/AOT5wRUdFqenbRGAQkwm/rk+Y599FnAVPe3U1GwmAeXey9AMNso+inCWPaWPk8ZLnHPJxg==",
+      "version": "9.0.0-next.19",
+      "resolved": "https://registry.npmjs.org/@zendeskgarden/react-accordions/-/react-accordions-9.0.0-next.19.tgz",
+      "integrity": "sha512-IE8ifAQ4WdF7vK08OkGJhLLGFUqt9Txi6jAnqCgCPqMcN5u03TR6HhtDJ2u4lf7TxZLBxw+z2NwkBPkQBl2C2A==",
       "dev": true,
-      "license": "Apache-2.0",
       "dependencies": {
         "@zendeskgarden/container-accordion": "^3.0.0",
         "@zendeskgarden/container-utilities": "^2.0.0",
@@ -6944,10 +6943,10 @@
         "prop-types": "^15.5.7"
       },
       "peerDependencies": {
-        "@zendeskgarden/react-theming": "^8.75.0",
+        "@zendeskgarden/react-theming": ">=9.0.0-next",
         "react": ">=16.8.0",
         "react-dom": ">=16.8.0",
-        "styled-components": "^4.2.0 || ^5.0.0"
+        "styled-components": "^5.3.1"
       }
     },
     "node_modules/@zendeskgarden/react-avatars": {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "@zendeskgarden/container-utilities": "2.0.0",
     "@zendeskgarden/css-bedrock": "9.1.1",
     "@zendeskgarden/eslint-config": "42.0.0",
-    "@zendeskgarden/react-accordions": "8.76.3",
+    "@zendeskgarden/react-accordions": "9.0.0-next.19",
     "@zendeskgarden/react-avatars": "8.76.3",
     "@zendeskgarden/react-breadcrumbs": "8.76.3",
     "@zendeskgarden/react-buttons": "9.0.0-next.19",

--- a/src/examples/accordions/accordion/AccordionBare.tsx
+++ b/src/examples/accordions/accordion/AccordionBare.tsx
@@ -7,11 +7,11 @@
 
 import React from 'react';
 import { Accordion } from '@zendeskgarden/react-accordions';
-import { Row, Col } from '@zendeskgarden/react-grid';
+import { Grid } from '@zendeskgarden/react-grid';
 
 const Example = () => (
-  <Row justifyContent="center">
-    <Col sm={10}>
+  <Grid.Row justifyContent="center">
+    <Grid.Col sm={10}>
       <Accordion level={4} isBare>
         <Accordion.Section>
           <Accordion.Header>
@@ -41,8 +41,8 @@ const Example = () => (
           </Accordion.Panel>
         </Accordion.Section>
       </Accordion>
-    </Col>
-  </Row>
+    </Grid.Col>
+  </Grid.Row>
 );
 
 export default Example;

--- a/src/examples/accordions/accordion/AccordionDefault.tsx
+++ b/src/examples/accordions/accordion/AccordionDefault.tsx
@@ -7,11 +7,11 @@
 
 import React from 'react';
 import { Accordion } from '@zendeskgarden/react-accordions';
-import { Row, Col } from '@zendeskgarden/react-grid';
+import { Grid } from '@zendeskgarden/react-grid';
 
 const Example = () => (
-  <Row justifyContent="center">
-    <Col sm={10}>
+  <Grid.Row justifyContent="center">
+    <Grid.Col sm={10}>
       <Accordion level={4}>
         <Accordion.Section>
           <Accordion.Header>
@@ -41,8 +41,8 @@ const Example = () => (
           </Accordion.Panel>
         </Accordion.Section>
       </Accordion>
-    </Col>
-  </Row>
+    </Grid.Col>
+  </Grid.Row>
 );
 
 export default Example;

--- a/src/examples/accordions/accordion/AccordionExpandable.tsx
+++ b/src/examples/accordions/accordion/AccordionExpandable.tsx
@@ -7,12 +7,12 @@
 
 import React from 'react';
 import { Accordion } from '@zendeskgarden/react-accordions';
-import { Row, Col } from '@zendeskgarden/react-grid';
+import { Grid } from '@zendeskgarden/react-grid';
 
 const Example = () => {
   return (
-    <Row justifyContent="center">
-      <Col sm={10}>
+    <Grid.Row justifyContent="center">
+      <Grid.Col sm={10}>
         <Accordion level={4} isExpandable>
           <Accordion.Section>
             <Accordion.Header>
@@ -43,8 +43,8 @@ const Example = () => {
             </Accordion.Panel>
           </Accordion.Section>
         </Accordion>
-      </Col>
-    </Row>
+      </Grid.Col>
+    </Grid.Row>
   );
 };
 

--- a/src/examples/accordions/accordion/AccordionSize.tsx
+++ b/src/examples/accordions/accordion/AccordionSize.tsx
@@ -7,14 +7,14 @@
 
 import React, { useState } from 'react';
 import { Accordion } from '@zendeskgarden/react-accordions';
-import { Row, Col } from '@zendeskgarden/react-grid';
+import { Grid } from '@zendeskgarden/react-grid';
 
 const Example = () => {
   const [expandedSections, setExpandedSections] = useState<number[]>([]);
 
   return (
-    <Row justifyContent="center">
-      <Col sm={10}>
+    <Grid.Row justifyContent="center">
+      <Grid.Col sm={10}>
         <Accordion
           isCompact
           level={4}
@@ -56,8 +56,8 @@ const Example = () => {
             </Accordion.Panel>
           </Accordion.Section>
         </Accordion>
-      </Col>
-    </Row>
+      </Grid.Col>
+    </Grid.Row>
   );
 };
 

--- a/src/examples/accordions/stepper/StepperIcons.tsx
+++ b/src/examples/accordions/stepper/StepperIcons.tsx
@@ -8,11 +8,11 @@
 import React from 'react';
 import { Stepper } from '@zendeskgarden/react-accordions';
 import { ReactComponent as LeafIcon } from '@zendeskgarden/svg-icons/src/12/leaf-stroke.svg';
-import { Row, Col } from '@zendeskgarden/react-grid';
+import { Grid } from '@zendeskgarden/react-grid';
 
 const Example = () => (
-  <Row justifyContent="center">
-    <Col sm={10}>
+  <Grid.Row justifyContent="center">
+    <Grid.Col sm={10}>
       <Stepper isHorizontal>
         <Stepper.Step key="step-1">
           <Stepper.Label icon={<LeafIcon />}>Make good use of your location</Stepper.Label>
@@ -24,8 +24,8 @@ const Example = () => (
           <Stepper.Label icon={<LeafIcon />}>Buy great seeds</Stepper.Label>
         </Stepper.Step>
       </Stepper>
-    </Col>
-  </Row>
+    </Grid.Col>
+  </Grid.Row>
 );
 
 export default Example;

--- a/src/examples/accordions/stepper/StepperLayout.tsx
+++ b/src/examples/accordions/stepper/StepperLayout.tsx
@@ -9,7 +9,7 @@ import React, { useState } from 'react';
 import styled from 'styled-components';
 import { Stepper } from '@zendeskgarden/react-accordions';
 import { Button } from '@zendeskgarden/react-buttons';
-import { Row, Col } from '@zendeskgarden/react-grid';
+import { Grid } from '@zendeskgarden/react-grid';
 
 const StyledButtons = styled.div`
   margin-top: ${p => p.theme.space.sm};
@@ -59,8 +59,8 @@ const Example = () => {
   ];
 
   return (
-    <Row justifyContent="center">
-      <Col sm={10} textAlign="center">
+    <Grid.Row justifyContent="center">
+      <Grid.Col sm={10} textAlign="center">
         <Stepper activeIndex={currentStep} isHorizontal>
           <Stepper.Step key="step-1">
             <Stepper.Label>Choose a good location</Stepper.Label>
@@ -81,8 +81,8 @@ const Example = () => {
               </StyledContainer>
             )
         )}
-      </Col>
-    </Row>
+      </Grid.Col>
+    </Grid.Row>
   );
 };
 

--- a/src/examples/accordions/timeline/TimelineCustomMedia.tsx
+++ b/src/examples/accordions/timeline/TimelineCustomMedia.tsx
@@ -8,7 +8,7 @@
 import React from 'react';
 import styled from 'styled-components';
 import { Timeline } from '@zendeskgarden/react-accordions';
-import { Row, Col } from '@zendeskgarden/react-grid';
+import { Grid } from '@zendeskgarden/react-grid';
 import { Span } from '@zendeskgarden/react-typography';
 import { ReactComponent as LocationIcon } from '@zendeskgarden/svg-icons/src/12/location-stroke.svg';
 import { ReactComponent as RearrangeIcon } from '@zendeskgarden/svg-icons/src/12/rearrange-stroke.svg';
@@ -20,8 +20,8 @@ export const StyledSpan = styled(Span).attrs({ isBold: true })`
 `;
 
 const Example = () => (
-  <Row justifyContent="center">
-    <Col sm="auto">
+  <Grid.Row justifyContent="center">
+    <Grid.Col sm="auto">
       <Timeline>
         <Timeline.Item icon={<LeafIcon />}>
           <Timeline.Content>
@@ -48,8 +48,8 @@ const Example = () => (
           </Timeline.Content>
         </Timeline.Item>
       </Timeline>
-    </Col>
-  </Row>
+    </Grid.Col>
+  </Grid.Row>
 );
 
 export default Example;

--- a/src/examples/accordions/timeline/TimelineDefault.tsx
+++ b/src/examples/accordions/timeline/TimelineDefault.tsx
@@ -8,7 +8,7 @@
 import React from 'react';
 import styled from 'styled-components';
 import { Timeline } from '@zendeskgarden/react-accordions';
-import { Row, Col } from '@zendeskgarden/react-grid';
+import { Grid } from '@zendeskgarden/react-grid';
 import { Span } from '@zendeskgarden/react-typography';
 
 export const StyledSpan = styled(Span).attrs({ isBold: true })`
@@ -16,8 +16,8 @@ export const StyledSpan = styled(Span).attrs({ isBold: true })`
 `;
 
 const Example = () => (
-  <Row justifyContent="center">
-    <Col sm="auto">
+  <Grid.Row justifyContent="center">
+    <Grid.Col sm="auto">
       <Timeline>
         <Timeline.Item>
           <Timeline.Content>
@@ -44,8 +44,8 @@ const Example = () => (
           </Timeline.Content>
         </Timeline.Item>
       </Timeline>
-    </Col>
-  </Row>
+    </Grid.Col>
+  </Grid.Row>
 );
 
 export default Example;


### PR DESCRIPTION
## Description

Updates accordions (including timeline and stepper) to v9 & applies relevant v9 changes to package examples.

Follows [migration guide](https://github.com/zendeskgarden/react-components/blob/next/docs/migration.md) where applicable.

## Checklist

- ~~:ok_hand: website updates are Garden Designer approved (add the designer as a reviewer)~~
- ~~:black_nib: copy updates are approved (add the content strategist as a reviewer)~~
- ~~:link: considered opportunities for adding cross-reference URLs (grep for keywords)~~
- ~~:wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver~~
- ~~:memo: tested in Chrome, Firefox, Safari, Edge~~
