### PR TITLE
feat(components): update `loaders` to v9 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,7 @@
         "@zendeskgarden/react-dropdowns.next": "8.76.3",
         "@zendeskgarden/react-forms": "9.0.0-next.19",
         "@zendeskgarden/react-grid": "9.0.0-next.19",
-        "@zendeskgarden/react-loaders": "8.76.3",
+        "@zendeskgarden/react-loaders": "9.0.0-next.20",
         "@zendeskgarden/react-modals": "8.76.3",
         "@zendeskgarden/react-notifications": "9.0.0-next.19",
         "@zendeskgarden/react-pagination": "8.76.3",
@@ -7365,21 +7365,20 @@
       }
     },
     "node_modules/@zendeskgarden/react-loaders": {
-      "version": "8.76.3",
-      "resolved": "https://registry.npmjs.org/@zendeskgarden/react-loaders/-/react-loaders-8.76.3.tgz",
-      "integrity": "sha512-klDeNl088KQeJnMkcGo7KbZfEONDeWa0K8tVU7o5toaRm6JxnMAW0f2TEb51fc6lTXZJkGDHXY8DbbstZ01JIw==",
+      "version": "9.0.0-next.20",
+      "resolved": "https://registry.npmjs.org/@zendeskgarden/react-loaders/-/react-loaders-9.0.0-next.20.tgz",
+      "integrity": "sha512-MWGEje5DCRy2bdVZi18/EDHosnZnPa1IJ99sVLwGPdfsmiZZtWDGQtwEM9LAR70WzSKE+UrTTptOS6gxXa+fnQ==",
       "dev": true,
-      "license": "Apache-2.0",
       "dependencies": {
         "@zendeskgarden/container-schedule": "^2.0.9",
         "polished": "^4.3.1",
         "prop-types": "^15.5.7"
       },
       "peerDependencies": {
-        "@zendeskgarden/react-theming": "^8.75.0",
+        "@zendeskgarden/react-theming": ">=9.0.0-next",
         "react": ">=16.8.0",
         "react-dom": ">=16.8.0",
-        "styled-components": "^4.2.0 || ^5.0.0"
+        "styled-components": "^5.3.1"
       }
     },
     "node_modules/@zendeskgarden/react-modals": {

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "@zendeskgarden/react-dropdowns.next": "8.76.3",
     "@zendeskgarden/react-forms": "9.0.0-next.19",
     "@zendeskgarden/react-grid": "9.0.0-next.19",
-    "@zendeskgarden/react-loaders": "8.76.3",
+    "@zendeskgarden/react-loaders": "9.0.0-next.20",
     "@zendeskgarden/react-modals": "8.76.3",
     "@zendeskgarden/react-notifications": "9.0.0-next.19",
     "@zendeskgarden/react-pagination": "8.76.3",

--- a/src/examples/loaders/dots/DotsColor.tsx
+++ b/src/examples/loaders/dots/DotsColor.tsx
@@ -6,22 +6,22 @@
  */
 
 import React from 'react';
-import { Row, Col } from '@zendeskgarden/react-grid';
+import { Grid } from '@zendeskgarden/react-grid';
 import { PALETTE } from '@zendeskgarden/react-theming';
 import { Dots } from '@zendeskgarden/react-loaders';
 
 const Example = () => (
-  <Row>
-    <Col textAlign="center">
+  <Grid.Row>
+    <Grid.Col textAlign="center">
       <Dots size={32} color={PALETTE.grey[600]} />
-    </Col>
-    <Col textAlign="center">
+    </Grid.Col>
+    <Grid.Col textAlign="center">
       <Dots size={32} color={PALETTE.blue[600]} />
-    </Col>
-    <Col textAlign="center">
+    </Grid.Col>
+    <Grid.Col textAlign="center">
       <Dots size={32} color={PALETTE.green[600]} />
-    </Col>
-  </Row>
+    </Grid.Col>
+  </Grid.Row>
 );
 
 export default Example;

--- a/src/examples/loaders/dots/DotsDefault.tsx
+++ b/src/examples/loaders/dots/DotsDefault.tsx
@@ -6,15 +6,15 @@
  */
 
 import React from 'react';
-import { Row, Col } from '@zendeskgarden/react-grid';
+import { Grid } from '@zendeskgarden/react-grid';
 import { Dots } from '@zendeskgarden/react-loaders';
 
 const Example = () => (
-  <Row>
-    <Col textAlign="center">
+  <Grid.Row>
+    <Grid.Col textAlign="center">
       <Dots />
-    </Col>
-  </Row>
+    </Grid.Col>
+  </Grid.Row>
 );
 
 export default Example;

--- a/src/examples/loaders/dots/DotsSize.tsx
+++ b/src/examples/loaders/dots/DotsSize.tsx
@@ -6,21 +6,21 @@
  */
 
 import React from 'react';
-import { Row, Col } from '@zendeskgarden/react-grid';
+import { Grid } from '@zendeskgarden/react-grid';
 import { Dots } from '@zendeskgarden/react-loaders';
 
 const Example = () => (
-  <Row alignItems="center">
-    <Col textAlign="center">
+  <Grid.Row alignItems="center">
+    <Grid.Col textAlign="center">
       <Dots size={32} />
-    </Col>
-    <Col textAlign="center">
+    </Grid.Col>
+    <Grid.Col textAlign="center">
       <Dots size={48} />
-    </Col>
-    <Col textAlign="center">
+    </Grid.Col>
+    <Grid.Col textAlign="center">
       <Dots size={64} />
-    </Col>
-  </Row>
+    </Grid.Col>
+  </Grid.Row>
 );
 
 export default Example;

--- a/src/examples/loaders/inline/InlineColor.tsx
+++ b/src/examples/loaders/inline/InlineColor.tsx
@@ -6,22 +6,22 @@
  */
 
 import React from 'react';
-import { Row, Col } from '@zendeskgarden/react-grid';
+import { Grid } from '@zendeskgarden/react-grid';
 import { PALETTE } from '@zendeskgarden/react-theming';
 import { Inline } from '@zendeskgarden/react-loaders';
 
 const Example = () => (
-  <Row>
-    <Col textAlign="center">
+  <Grid.Row>
+    <Grid.Col textAlign="center">
       <Inline size={32} color={PALETTE.grey[600]} />
-    </Col>
-    <Col textAlign="center">
+    </Grid.Col>
+    <Grid.Col textAlign="center">
       <Inline size={32} color={PALETTE.blue[600]} />
-    </Col>
-    <Col textAlign="center">
+    </Grid.Col>
+    <Grid.Col textAlign="center">
       <Inline size={32} color={PALETTE.green[600]} />
-    </Col>
-  </Row>
+    </Grid.Col>
+  </Grid.Row>
 );
 
 export default Example;

--- a/src/examples/loaders/inline/InlineDefault.tsx
+++ b/src/examples/loaders/inline/InlineDefault.tsx
@@ -6,15 +6,15 @@
  */
 
 import React from 'react';
-import { Row, Col } from '@zendeskgarden/react-grid';
+import { Grid } from '@zendeskgarden/react-grid';
 import { Inline } from '@zendeskgarden/react-loaders';
 
 const Example = () => (
-  <Row>
-    <Col textAlign="center">
+  <Grid.Row>
+    <Grid.Col textAlign="center">
       <Inline />
-    </Col>
-  </Row>
+    </Grid.Col>
+  </Grid.Row>
 );
 
 export default Example;

--- a/src/examples/loaders/inline/InlineSize.tsx
+++ b/src/examples/loaders/inline/InlineSize.tsx
@@ -6,21 +6,21 @@
  */
 
 import React from 'react';
-import { Row, Col } from '@zendeskgarden/react-grid';
+import { Grid } from '@zendeskgarden/react-grid';
 import { Inline } from '@zendeskgarden/react-loaders';
 
 const Example = () => (
-  <Row alignItems="center">
-    <Col textAlign="center">
+  <Grid.Row alignItems="center">
+    <Grid.Col textAlign="center">
       <Inline size={32} />
-    </Col>
-    <Col textAlign="center">
+    </Grid.Col>
+    <Grid.Col textAlign="center">
       <Inline size={48} />
-    </Col>
-    <Col textAlign="center">
+    </Grid.Col>
+    <Grid.Col textAlign="center">
       <Inline size={64} />
-    </Col>
-  </Row>
+    </Grid.Col>
+  </Grid.Row>
 );
 
 export default Example;

--- a/src/examples/loaders/progress/ProgressColor.tsx
+++ b/src/examples/loaders/progress/ProgressColor.tsx
@@ -6,22 +6,22 @@
  */
 
 import React from 'react';
-import { Row, Col } from '@zendeskgarden/react-grid';
+import { Grid } from '@zendeskgarden/react-grid';
 import { PALETTE } from '@zendeskgarden/react-theming';
 import { Progress } from '@zendeskgarden/react-loaders';
 
 const Example = () => (
-  <Row>
-    <Col textAlign="center">
+  <Grid.Row>
+    <Grid.Col textAlign="center">
       <Progress color={PALETTE.grey[600]} value={80} aria-label="Fertilizing seeds" />
-    </Col>
-    <Col textAlign="center">
+    </Grid.Col>
+    <Grid.Col textAlign="center">
       <Progress color={PALETTE.blue[600]} value={80} aria-label="Watering all plants" />
-    </Col>
-    <Col textAlign="center">
+    </Grid.Col>
+    <Grid.Col textAlign="center">
       <Progress color={PALETTE.kale[600]} value={80} aria-label="Removing weeds" />
-    </Col>
-  </Row>
+    </Grid.Col>
+  </Grid.Row>
 );
 
 export default Example;

--- a/src/examples/loaders/progress/ProgressDefault.tsx
+++ b/src/examples/loaders/progress/ProgressDefault.tsx
@@ -6,15 +6,15 @@
  */
 
 import React from 'react';
-import { Row, Col } from '@zendeskgarden/react-grid';
+import { Grid } from '@zendeskgarden/react-grid';
 import { Progress } from '@zendeskgarden/react-loaders';
 
 const Example = () => (
-  <Row justifyContent="center">
-    <Col sm={5}>
+  <Grid.Row justifyContent="center">
+    <Grid.Col sm={5}>
       <Progress value={50} aria-label="Preparing garden" />
-    </Col>
-  </Row>
+    </Grid.Col>
+  </Grid.Row>
 );
 
 export default Example;

--- a/src/examples/loaders/progress/ProgressSize.tsx
+++ b/src/examples/loaders/progress/ProgressSize.tsx
@@ -6,21 +6,21 @@
  */
 
 import React from 'react';
-import { Row, Col } from '@zendeskgarden/react-grid';
+import { Grid } from '@zendeskgarden/react-grid';
 import { Progress } from '@zendeskgarden/react-loaders';
 
 const Example = () => (
-  <Row alignItems="center">
-    <Col textAlign="center">
+  <Grid.Row alignItems="center">
+    <Grid.Col textAlign="center">
       <Progress size="small" value={80} aria-label="Tilling the land" />
-    </Col>
-    <Col textAlign="center">
+    </Grid.Col>
+    <Grid.Col textAlign="center">
       <Progress size="medium" value={80} aria-label="Harvesting crops" />
-    </Col>
-    <Col textAlign="center">
+    </Grid.Col>
+    <Grid.Col textAlign="center">
       <Progress size="large" value={80} aria-label="Tending to plants" />
-    </Col>
-  </Row>
+    </Grid.Col>
+  </Grid.Row>
 );
 
 export default Example;

--- a/src/examples/loaders/skeleton/SkeletonDefault.tsx
+++ b/src/examples/loaders/skeleton/SkeletonDefault.tsx
@@ -6,13 +6,13 @@
  */
 
 import React from 'react';
-import { Row, Col } from '@zendeskgarden/react-grid';
+import { Grid } from '@zendeskgarden/react-grid';
 import { MD, XXL } from '@zendeskgarden/react-typography';
 import { Skeleton } from '@zendeskgarden/react-loaders';
 
 const Example = () => (
-  <Row justifyContent="center">
-    <Col sm={5}>
+  <Grid.Row justifyContent="center">
+    <Grid.Col sm={5}>
       <XXL>
         <Skeleton />
       </XXL>
@@ -21,8 +21,8 @@ const Example = () => (
         <Skeleton />
         <Skeleton />
       </MD>
-    </Col>
-  </Row>
+    </Grid.Col>
+  </Grid.Row>
 );
 
 export default Example;

--- a/src/examples/loaders/skeleton/SkeletonLight.tsx
+++ b/src/examples/loaders/skeleton/SkeletonLight.tsx
@@ -7,17 +7,17 @@
 
 import React from 'react';
 import styled from 'styled-components';
-import { Row, Col } from '@zendeskgarden/react-grid';
+import { Grid } from '@zendeskgarden/react-grid';
 import { MD, XXL } from '@zendeskgarden/react-typography';
 import { Skeleton } from '@zendeskgarden/react-loaders';
 
-const StyledCol = styled(Col)`
+const StyledCol = styled(Grid.Col)`
   background-color: ${p => p.theme.palette.kale[600]};
   padding: ${p => p.theme.space.md};
 `;
 
 const Example = () => (
-  <Row justifyContent="center">
+  <Grid.Row justifyContent="center">
     <StyledCol sm={5}>
       <XXL>
         <Skeleton isLight />
@@ -28,7 +28,7 @@ const Example = () => (
         <Skeleton isLight />
       </MD>
     </StyledCol>
-  </Row>
+  </Grid.Row>
 );
 
 export default Example;

--- a/src/examples/loaders/skeleton/SkeletonSize.tsx
+++ b/src/examples/loaders/skeleton/SkeletonSize.tsx
@@ -6,19 +6,19 @@
  */
 
 import React from 'react';
-import { Row, Col } from '@zendeskgarden/react-grid';
+import { Grid } from '@zendeskgarden/react-grid';
 import { Skeleton } from '@zendeskgarden/react-loaders';
 
 const Example = () => (
-  <Row justifyContent="center">
-    <Col sm={5}>
+  <Grid.Row justifyContent="center">
+    <Grid.Col sm={5}>
       <Skeleton height="48px" />
       <Skeleton height="24px" width="80%" />
       <Skeleton height="16px" width="90%" />
       <Skeleton height="16px" width="85%" />
       <Skeleton height="16px" width="75%" />
-    </Col>
-  </Row>
+    </Grid.Col>
+  </Grid.Row>
 );
 
 export default Example;

--- a/src/examples/loaders/spinner/SpinnerColor.tsx
+++ b/src/examples/loaders/spinner/SpinnerColor.tsx
@@ -6,22 +6,22 @@
  */
 
 import React from 'react';
-import { Row, Col } from '@zendeskgarden/react-grid';
+import { Grid } from '@zendeskgarden/react-grid';
 import { PALETTE } from '@zendeskgarden/react-theming';
 import { Spinner } from '@zendeskgarden/react-loaders';
 
 const Example = () => (
-  <Row>
-    <Col textAlign="center">
+  <Grid.Row>
+    <Grid.Col textAlign="center">
       <Spinner size="32" color={PALETTE.grey[600]} />
-    </Col>
-    <Col textAlign="center">
+    </Grid.Col>
+    <Grid.Col textAlign="center">
       <Spinner size="32" color={PALETTE.blue[600]} />
-    </Col>
-    <Col textAlign="center">
+    </Grid.Col>
+    <Grid.Col textAlign="center">
       <Spinner size="32" color={PALETTE.green[600]} />
-    </Col>
-  </Row>
+    </Grid.Col>
+  </Grid.Row>
 );
 
 export default Example;

--- a/src/examples/loaders/spinner/SpinnerDefault.tsx
+++ b/src/examples/loaders/spinner/SpinnerDefault.tsx
@@ -6,15 +6,15 @@
  */
 
 import React from 'react';
-import { Row, Col } from '@zendeskgarden/react-grid';
+import { Grid } from '@zendeskgarden/react-grid';
 import { Spinner } from '@zendeskgarden/react-loaders';
 
 const Example = () => (
-  <Row>
-    <Col textAlign="center">
+  <Grid.Row>
+    <Grid.Col textAlign="center">
       <Spinner />
-    </Col>
-  </Row>
+    </Grid.Col>
+  </Grid.Row>
 );
 
 export default Example;

--- a/src/examples/loaders/spinner/SpinnerSize.tsx
+++ b/src/examples/loaders/spinner/SpinnerSize.tsx
@@ -6,21 +6,21 @@
  */
 
 import React from 'react';
-import { Row, Col } from '@zendeskgarden/react-grid';
+import { Grid } from '@zendeskgarden/react-grid';
 import { Spinner } from '@zendeskgarden/react-loaders';
 
 const Example = () => (
-  <Row alignItems="center">
-    <Col textAlign="center">
+  <Grid.Row alignItems="center">
+    <Grid.Col textAlign="center">
       <Spinner size="32" />
-    </Col>
-    <Col textAlign="center">
+    </Grid.Col>
+    <Grid.Col textAlign="center">
       <Spinner size="48" />
-    </Col>
-    <Col textAlign="center">
+    </Grid.Col>
+    <Grid.Col textAlign="center">
       <Spinner size="64" />
-    </Col>
-  </Row>
+    </Grid.Col>
+  </Grid.Row>
 );
 
 export default Example;


### PR DESCRIPTION
## Description
Upgrade `loaders` component pages to v9 following the [migration guide](https://github.com/zendeskgarden/react-components/blob/next/docs/migration.md) changes.

## Checklist

- [ ] ~~:ok_hand: website updates are Garden Designer approved (add the designer as a reviewer)~~
- [ ] ~~:black_nib: copy updates are approved (add the content strategist as a reviewer)~~
- [ ] ~~:link: considered opportunities for adding cross-reference URLs (grep for keywords)~~
- [ ] ~~:wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver~~
- [ ] ~~:memo: tested in Chrome, Firefox, Safari, Edge~~
