### PR TITLE
fix(components): add subcomponent property syntax to Tooltip configuration

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -45,7 +45,7 @@
         "@zendeskgarden/react-tabs": "8.76.3",
         "@zendeskgarden/react-tags": "8.76.3",
         "@zendeskgarden/react-theming": "9.0.0-next.19",
-        "@zendeskgarden/react-tooltips": "^9.0.0-next.20",
+        "@zendeskgarden/react-tooltips": "9.0.0-next.20",
         "@zendeskgarden/react-typography": "9.0.0-next.19",
         "@zendeskgarden/scripts": "2.4.0",
         "@zendeskgarden/stylelint-config": "21.0.0",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "@zendeskgarden/react-tabs": "8.76.3",
     "@zendeskgarden/react-tags": "8.76.3",
     "@zendeskgarden/react-theming": "9.0.0-next.19",
-    "@zendeskgarden/react-tooltips": "^9.0.0-next.20",
+    "@zendeskgarden/react-tooltips": "9.0.0-next.20",
     "@zendeskgarden/react-typography": "9.0.0-next.19",
     "@zendeskgarden/scripts": "2.4.0",
     "@zendeskgarden/stylelint-config": "21.0.0",

--- a/src/pages/components/tooltip.mdx
+++ b/src/pages/components/tooltip.mdx
@@ -86,23 +86,23 @@ import TypeCode from '!!raw-loader!../../examples/tooltip/TooltipType.tsx';
 
 ## API
 
-### Paragraph
-
-<Component components={props.data.mdx.components} componentName="paragraph" />
-
-<PropSheet components={props.data.mdx.components} componentName="paragraph" />
-
-### Title
-
-<Component components={props.data.mdx.components} componentName="title" />
-
-<PropSheet components={props.data.mdx.components} componentName="title" />
-
 ### Tooltip
 
 <Component components={props.data.mdx.components} componentName="tooltip" />
 
 <PropSheet components={props.data.mdx.components} componentName="tooltip" />
+
+### Tooltip.Paragraph
+
+<Component components={props.data.mdx.components} componentName="paragraph" />
+
+<PropSheet components={props.data.mdx.components} componentName="paragraph" />
+
+### Tooltip.Title
+
+<Component components={props.data.mdx.components} componentName="title" />
+
+<PropSheet components={props.data.mdx.components} componentName="title" />
 
 import { graphql } from 'gatsby';
 

--- a/src/pages/components/tooltip.mdx
+++ b/src/pages/components/tooltip.mdx
@@ -92,13 +92,13 @@ import TypeCode from '!!raw-loader!../../examples/tooltip/TooltipType.tsx';
 
 <PropSheet components={props.data.mdx.components} componentName="tooltip" />
 
-### Tooltip.Paragraph
+#### Tooltip.Paragraph
 
 <Component components={props.data.mdx.components} componentName="paragraph" />
 
 <PropSheet components={props.data.mdx.components} componentName="paragraph" />
 
-### Tooltip.Title
+#### Tooltip.Title
 
 <Component components={props.data.mdx.components} componentName="title" />
 


### PR DESCRIPTION
Forgot this in #612 😶 

<img width="867" alt="Screenshot 2024-08-06 at 3 56 23 PM" src="https://github.com/user-attachments/assets/b9a7952b-7d22-40f9-a23c-385b1e5902de">

<img width="328" alt="Screenshot 2024-08-06 at 4 07 59 PM" src="https://github.com/user-attachments/assets/a26fc40d-8bb1-43ba-94b1-df3ba9640cd0">

