### PR TITLE
feat(components): update typography to v9

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -46,7 +46,7 @@
         "@zendeskgarden/react-tags": "8.76.3",
         "@zendeskgarden/react-theming": "9.0.0-next.21",
         "@zendeskgarden/react-tooltips": "9.0.0-next.21",
-        "@zendeskgarden/react-typography": "9.0.0-next.21",
+        "@zendeskgarden/react-typography": "9.0.0-next.22",
         "@zendeskgarden/scripts": "2.4.0",
         "@zendeskgarden/stylelint-config": "21.0.0",
         "@zendeskgarden/svg-icons": "7.2.0",
@@ -7298,9 +7298,9 @@
       }
     },
     "node_modules/@zendeskgarden/react-typography": {
-      "version": "9.0.0-next.21",
-      "resolved": "https://registry.npmjs.org/@zendeskgarden/react-typography/-/react-typography-9.0.0-next.21.tgz",
-      "integrity": "sha512-OOKDpYBEjRxp4SanqtxF+KR9wMuenTEcUMiTjPQ3nzZIvr20xHJe75dfs3QIVdg4a15p3+CCKfv3TKYk7Fo54A==",
+      "version": "9.0.0-next.22",
+      "resolved": "https://registry.npmjs.org/@zendeskgarden/react-typography/-/react-typography-9.0.0-next.22.tgz",
+      "integrity": "sha512-U8eT90UKTlDpw1QFOr+Do1PyNpjaTyXPaFb5eM2giR88GQrIVl775NQ0jmMXfH8kQM41AII2dXAy4Tqo7GSINQ==",
       "dev": true,
       "dependencies": {
         "@zendeskgarden/container-scrollregion": "^1.0.9",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "@zendeskgarden/react-tags": "8.76.3",
     "@zendeskgarden/react-theming": "9.0.0-next.21",
     "@zendeskgarden/react-tooltips": "9.0.0-next.21",
-    "@zendeskgarden/react-typography": "9.0.0-next.21",
+    "@zendeskgarden/react-typography": "9.0.0-next.22",
     "@zendeskgarden/scripts": "2.4.0",
     "@zendeskgarden/stylelint-config": "21.0.0",
     "@zendeskgarden/svg-icons": "7.2.0",

--- a/src/examples/accordions/timeline/TimelineAlternating.tsx
+++ b/src/examples/accordions/timeline/TimelineAlternating.tsx
@@ -19,25 +19,25 @@ const Example = () => (
     <Timeline.Item>
       <Timeline.Content>
         <StyledSpan>Planted seed</StyledSpan>
-        <Span hue="grey">Today 9:00 AM</Span>
+        <Span hue="foreground.subtle">Today 9:00 AM</Span>
       </Timeline.Content>
     </Timeline.Item>
     <Timeline.Item>
       <Timeline.Content>
         <StyledSpan>Purchased seed</StyledSpan>
-        <Span hue="grey">Feb 08, 9:05 AM</Span>
+        <Span hue="foreground.subtle">Feb 08, 9:05 AM</Span>
       </Timeline.Content>
     </Timeline.Item>
     <Timeline.Item>
       <Timeline.Content>
         <StyledSpan>Arranged layout of garden</StyledSpan>
-        <Span hue="grey">Jan 21, 9:13 AM</Span>
+        <Span hue="foreground.subtle">Jan 21, 9:13 AM</Span>
       </Timeline.Content>
     </Timeline.Item>
     <Timeline.Item>
       <Timeline.Content>
         <StyledSpan>Chose a gardening location</StyledSpan>
-        <Span hue="grey">Jan 21, 9:21 AM </Span>
+        <Span hue="foreground.subtle">Jan 21, 9:21 AM </Span>
       </Timeline.Content>
     </Timeline.Item>
   </Timeline>

--- a/src/examples/accordions/timeline/TimelineCustomMedia.tsx
+++ b/src/examples/accordions/timeline/TimelineCustomMedia.tsx
@@ -26,25 +26,25 @@ const Example = () => (
         <Timeline.Item icon={<LeafIcon />}>
           <Timeline.Content>
             <StyledSpan>Planted seed</StyledSpan>
-            <Span hue="grey">Today 9:00 AM</Span>
+            <Span hue="foreground.subtle">Today 9:00 AM</Span>
           </Timeline.Content>
         </Timeline.Item>
         <Timeline.Item icon={<CartIcon />}>
           <Timeline.Content>
             <StyledSpan>Purchased seed</StyledSpan>
-            <Span hue="grey">Feb 08, 9:05 AM</Span>
+            <Span hue="foreground.subtle">Feb 08, 9:05 AM</Span>
           </Timeline.Content>
         </Timeline.Item>
         <Timeline.Item icon={<RearrangeIcon />}>
           <Timeline.Content>
             <StyledSpan>Arranged layout of garden</StyledSpan>
-            <Span hue="grey">Jan 21, 9:13 AM</Span>
+            <Span hue="foreground.subtle">Jan 21, 9:13 AM</Span>
           </Timeline.Content>
         </Timeline.Item>
         <Timeline.Item icon={<LocationIcon />}>
           <Timeline.Content>
             <StyledSpan>Chose a gardening location</StyledSpan>
-            <Span hue="grey">Jan 21, 9:21 AM </Span>
+            <Span hue="foreground.subtle">Jan 21, 9:21 AM </Span>
           </Timeline.Content>
         </Timeline.Item>
       </Timeline>

--- a/src/examples/accordions/timeline/TimelineDefault.tsx
+++ b/src/examples/accordions/timeline/TimelineDefault.tsx
@@ -22,25 +22,25 @@ const Example = () => (
         <Timeline.Item>
           <Timeline.Content>
             <StyledSpan>Planted seed</StyledSpan>
-            <Span hue="grey">Today 9:00 AM</Span>
+            <Span hue="foreground.subtle">Today 9:00 AM</Span>
           </Timeline.Content>
         </Timeline.Item>
         <Timeline.Item>
           <Timeline.Content>
             <StyledSpan>Purchased seed</StyledSpan>
-            <Span hue="grey">Feb 08, 9:05 AM</Span>
+            <Span hue="foreground.subtle">Feb 08, 9:05 AM</Span>
           </Timeline.Content>
         </Timeline.Item>
         <Timeline.Item>
           <Timeline.Content>
             <StyledSpan>Arranged layout of garden</StyledSpan>
-            <Span hue="grey">Jan 21, 9:13 AM</Span>
+            <Span hue="foreground.subtle">Jan 21, 9:13 AM</Span>
           </Timeline.Content>
         </Timeline.Item>
         <Timeline.Item>
           <Timeline.Content>
             <StyledSpan>Chose a gardening location</StyledSpan>
-            <Span hue="grey">Jan 21, 9:21 AM </Span>
+            <Span hue="foreground.subtle">Jan 21, 9:21 AM </Span>
           </Timeline.Content>
         </Timeline.Item>
       </Timeline>

--- a/src/examples/accordions/timeline/TimelineOppositeContent.tsx
+++ b/src/examples/accordions/timeline/TimelineOppositeContent.tsx
@@ -13,7 +13,7 @@ const Example = () => (
   <Timeline>
     <Timeline.Item>
       <Timeline.OppositeContent>
-        <Span hue="grey">Today 9:00 AM</Span>
+        <Span hue="foreground.subtle">Today 9:00 AM</Span>
       </Timeline.OppositeContent>
       <Timeline.Content>
         <Span isBold>Planted seed</Span>
@@ -21,7 +21,7 @@ const Example = () => (
     </Timeline.Item>
     <Timeline.Item>
       <Timeline.OppositeContent>
-        <Span hue="grey">Feb 08, 9:05 AM</Span>
+        <Span hue="foreground.subtle">Feb 08, 9:05 AM</Span>
       </Timeline.OppositeContent>
       <Timeline.Content>
         <Span isBold>Purchased seed</Span>
@@ -29,7 +29,7 @@ const Example = () => (
     </Timeline.Item>
     <Timeline.Item>
       <Timeline.OppositeContent>
-        <Span hue="grey">Jan 21, 9:13 AM</Span>
+        <Span hue="foreground.subtle">Jan 21, 9:13 AM</Span>
       </Timeline.OppositeContent>
       <Timeline.Content>
         <Span isBold>Arranged layout of garden</Span>
@@ -37,7 +37,7 @@ const Example = () => (
     </Timeline.Item>
     <Timeline.Item>
       <Timeline.OppositeContent>
-        <Span hue="grey">Jan 21, 9:21 AM </Span>
+        <Span hue="foreground.subtle">Jan 21, 9:21 AM </Span>
       </Timeline.OppositeContent>
       <Timeline.Content>
         <Span isBold>Chose a gardening location</Span>

--- a/src/examples/draggable/DraggableContent.tsx
+++ b/src/examples/draggable/DraggableContent.tsx
@@ -6,7 +6,6 @@
  */
 
 import React from 'react';
-import { PALETTE, getColor } from '@zendeskgarden/react-theming';
 import { Grid } from '@zendeskgarden/react-grid';
 import { Draggable } from '@zendeskgarden/react-draggable';
 import { IconButton } from '@zendeskgarden/react-buttons';
@@ -16,9 +15,8 @@ import { ReactComponent as PuzzleIcon } from '@zendeskgarden/svg-icons/src/16/pu
 import { ReactComponent as OverflowIcon } from '@zendeskgarden/svg-icons/src/16/overflow-vertical-stroke.svg';
 import styled from 'styled-components';
 
-const StyledDecorator = styled.div`
+const StyledDecorator = styled(Span)`
   display: flex;
-  color: ${p => getColor({ theme: p.theme, hue: 'neutralHue', shade: 700 })};
   padding-inline-end: ${p => p.theme.space.xs};
 `;
 
@@ -27,14 +25,14 @@ const Example = () => (
     <Grid.Col sm={7}>
       <Draggable isCompact>
         <Draggable.Grip />
-        <StyledDecorator>
+        <StyledDecorator hue="foreground.subtle">
           <PuzzleIcon />
         </StyledDecorator>
         <Draggable.Content>
           <Span isBold tag="div">
             Citrus
           </Span>
-          <Span hue={PALETTE.grey[700]}>Oranges, mandarins, limes, and the like</Span>
+          <Span hue="foreground.subtle">Oranges, mandarins, limes, and the like</Span>
         </Draggable.Content>
         <Tooltip content="More options">
           <IconButton aria-label="More options">

--- a/src/examples/tooltip-modal/TooltipModalPlacement.tsx
+++ b/src/examples/tooltip-modal/TooltipModalPlacement.tsx
@@ -77,7 +77,7 @@ const Example = () => {
         </TooltipModal.Body>
         <TooltipModal.Footer>
           <SM style={{ flexGrow: 1 }}>
-            <Span hue="grey">{currentStep} of 13</Span>
+            <Span hue="foreground.subtle">{currentStep} of 13</Span>
           </SM>
           <TooltipModal.FooterItem>
             {currentStep > 1 && (

--- a/src/examples/typography/code-block/Numbered.tsx
+++ b/src/examples/typography/code-block/Numbered.tsx
@@ -12,25 +12,25 @@ const Example = () => (
   <CodeBlock isNumbered>{`
 import React from 'react';
 import styled from 'styled-components';
-import { Row, Col } from '@zendeskgarden/react-grid';
+import { Grid } from '@zendeskgarden/react-grid';
 import { mediaQuery } from '@zendeskgarden/react-theming';
 import { Field, Label, Input, Message } from '@zendeskgarden/react-forms';
 
-const StyledCol = styled(Col)\`
+const StyledCol = styled(Grid.Col)\`
   \${p => mediaQuery('down', 'xs', p.theme)} {
     margin-top: \${p => p.theme.space.sm};
   }
 \`;
 
 const Example = () => (
-  <Row>
-    <Col sm={4}>
+  <Grid.Row>
+    <Grid.Col sm={4}>
       <Field>
         <Label>Plant</Label>
         <Input validation="success" />
         <Message validation="success">A cactus is a beautiful plant</Message>
       </Field>
-    </Col>
+    </Grid.Col>
     <StyledCol sm={4}>
       <Field>
         <Label>Plant</Label>
@@ -45,7 +45,7 @@ const Example = () => (
         <Message validation="error">A cactus belongs in the desert</Message>
       </Field>
     </StyledCol>
-  </Row>
+  </Grid.Row>
 );
 
 export default Example;

--- a/src/examples/typography/code/Color.tsx
+++ b/src/examples/typography/code/Color.tsx
@@ -8,27 +8,27 @@
 import React from 'react';
 import styled from 'styled-components';
 import { mediaQuery } from '@zendeskgarden/react-theming';
-import { Row, Col } from '@zendeskgarden/react-grid';
+import { Grid } from '@zendeskgarden/react-grid';
 import { Code } from '@zendeskgarden/react-typography';
 
-const StyledCol = styled(Col)`
+const StyledCol = styled(Grid.Col)`
   ${p => mediaQuery('down', 'xs', p.theme)} {
     margin-top: ${p => p.theme.space.sm};
   }
 `;
 
 const Example = () => (
-  <Row>
-    <Col sm={4} textAlign="center">
+  <Grid.Row>
+    <Grid.Col sm={4} textAlign="center">
       <Code hue="green">Veggies es bonus</Code>
-    </Col>
+    </Grid.Col>
     <StyledCol sm={4} textAlign="center">
       <Code hue="yellow">Veggies es bonus</Code>
     </StyledCol>
     <StyledCol sm={4} textAlign="center">
       <Code hue="red">Veggies es bonus</Code>
     </StyledCol>
-  </Row>
+  </Grid.Row>
 );
 
 export default Example;

--- a/src/examples/typography/code/Default.tsx
+++ b/src/examples/typography/code/Default.tsx
@@ -6,15 +6,15 @@
  */
 
 import React from 'react';
-import { Row, Col } from '@zendeskgarden/react-grid';
+import { Grid } from '@zendeskgarden/react-grid';
 import { Code } from '@zendeskgarden/react-typography';
 
 const Example = () => (
-  <Row>
-    <Col textAlign="center">
+  <Grid.Row>
+    <Grid.Col textAlign="center">
       <Code>Veggies es bonus vobis</Code>
-    </Col>
-  </Row>
+    </Grid.Col>
+  </Grid.Row>
 );
 
 export default Example;

--- a/src/examples/typography/code/Size.tsx
+++ b/src/examples/typography/code/Size.tsx
@@ -8,27 +8,27 @@
 import React from 'react';
 import styled from 'styled-components';
 import { mediaQuery } from '@zendeskgarden/react-theming';
-import { Row, Col } from '@zendeskgarden/react-grid';
+import { Grid } from '@zendeskgarden/react-grid';
 import { Code } from '@zendeskgarden/react-typography';
 
-const StyledCol = styled(Col)`
+const StyledCol = styled(Grid.Col)`
   ${p => mediaQuery('down', 'xs', p.theme)} {
     margin-top: ${p => p.theme.space.sm};
   }
 `;
 
 const Example = () => (
-  <Row alignItems="center">
-    <Col sm={4} textAlign="center">
+  <Grid.Row alignItems="center">
+    <Grid.Col sm={4} textAlign="center">
       <Code size="small">Veggies es bonus</Code>
-    </Col>
+    </Grid.Col>
     <StyledCol sm={4} textAlign="center">
       <Code size="medium">Veggies es bonus</Code>
     </StyledCol>
     <StyledCol sm={4} textAlign="center">
       <Code size="large">Veggies es bonus</Code>
     </StyledCol>
-  </Row>
+  </Grid.Row>
 );
 
 export default Example;

--- a/src/examples/typography/lists/Default.tsx
+++ b/src/examples/typography/lists/Default.tsx
@@ -6,26 +6,26 @@
  */
 
 import React from 'react';
-import { Row, Col } from '@zendeskgarden/react-grid';
+import { Grid } from '@zendeskgarden/react-grid';
 import { OrderedList, UnorderedList } from '@zendeskgarden/react-typography';
 
 const Example = () => (
-  <Row>
-    <Col>
+  <Grid.Row>
+    <Grid.Col>
       <OrderedList>
         <OrderedList.Item>Plant</OrderedList.Item>
         <OrderedList.Item>Water</OrderedList.Item>
         <OrderedList.Item>Harvest</OrderedList.Item>
       </OrderedList>
-    </Col>
-    <Col>
+    </Grid.Col>
+    <Grid.Col>
       <UnorderedList>
         <UnorderedList.Item>Garden trowel</UnorderedList.Item>
         <UnorderedList.Item>Pruning shears</UnorderedList.Item>
         <UnorderedList.Item>Hand cultivator</UnorderedList.Item>
       </UnorderedList>
-    </Col>
-  </Row>
+    </Grid.Col>
+  </Grid.Row>
 );
 
 export default Example;

--- a/src/examples/typography/lists/Nesting.tsx
+++ b/src/examples/typography/lists/Nesting.tsx
@@ -8,18 +8,18 @@
 import React from 'react';
 import styled from 'styled-components';
 import { mediaQuery } from '@zendeskgarden/react-theming';
-import { Row, Col } from '@zendeskgarden/react-grid';
+import { Grid } from '@zendeskgarden/react-grid';
 import { OrderedList, UnorderedList } from '@zendeskgarden/react-typography';
 
-const StyledCol = styled(Col)`
+const StyledCol = styled(Grid.Col)`
   ${p => mediaQuery('down', 'xs', p.theme)} {
     margin-top: ${p => p.theme.space.md};
   }
 `;
 
 const Example = () => (
-  <Row>
-    <Col>
+  <Grid.Row>
+    <Grid.Col>
       <OrderedList>
         <OrderedList.Item>
           Gumbo beet greens
@@ -39,7 +39,7 @@ const Example = () => (
         <OrderedList.Item>Grape kakadu plum</OrderedList.Item>
         <OrderedList.Item>Water spinach arugula</OrderedList.Item>
       </OrderedList>
-    </Col>
+    </Grid.Col>
     <StyledCol>
       <UnorderedList>
         <UnorderedList.Item>
@@ -61,7 +61,7 @@ const Example = () => (
         <UnorderedList.Item>Water spinach arugula</UnorderedList.Item>
       </UnorderedList>
     </StyledCol>
-  </Row>
+  </Grid.Row>
 );
 
 export default Example;

--- a/src/examples/typography/paragraph/Size.tsx
+++ b/src/examples/typography/paragraph/Size.tsx
@@ -9,17 +9,17 @@ import React from 'react';
 import styled from 'styled-components';
 import { mediaQuery } from '@zendeskgarden/react-theming';
 import { Paragraph, SM, MD, LG } from '@zendeskgarden/react-typography';
-import { Row, Col } from '@zendeskgarden/react-grid';
+import { Grid } from '@zendeskgarden/react-grid';
 
-const StyledCol = styled(Col)`
+const StyledCol = styled(Grid.Col)`
   ${p => mediaQuery('down', 'xs', p.theme)} {
     margin-top: ${p => p.theme.space.xl};
   }
 `;
 
 const Example = () => (
-  <Row>
-    <Col sm={4}>
+  <Grid.Row>
+    <Grid.Col sm={4}>
       <Paragraph size="small">
         <SM tag="span">
           &lt;SM&gt;Lotus root spinach fennel kombu maize bamboo shoot green bean swiss chard
@@ -37,7 +37,7 @@ const Example = () => (
           Cordn amaranth salsify bunya nuts nori azuki bean chickweed potato bell pepper artichoke.
         </SM>
       </Paragraph>
-    </Col>
+    </Grid.Col>
     <StyledCol sm={4}>
       <Paragraph size="medium">
         <MD tag="span">
@@ -76,7 +76,7 @@ const Example = () => (
         </LG>
       </Paragraph>
     </StyledCol>
-  </Row>
+  </Grid.Row>
 );
 
 export default Example;

--- a/src/examples/typography/span/Hue.tsx
+++ b/src/examples/typography/span/Hue.tsx
@@ -19,9 +19,9 @@ const Example = () => (
       <MD tag="span">
         Water spinach arugula pea tatsoi aubergine spring onion bush tomato kale radicchio turnip
         chicory salsify pea sprouts fava bean.{' '}
-        <Span hue="fuschia">Dandelion zucchini burdock yarrow chickpea dandelion</Span> sorrel
-        courgette turnip greens tigernut soybean radish artichoke wattle seed endive groundnut
-        broccoli arugula.
+        <Span hue="foreground.primary">Dandelion zucchini burdock yarrow chickpea dandelion</Span>{' '}
+        sorrel courgette turnip greens tigernut soybean radish artichoke wattle seed endive
+        groundnut broccoli arugula.
       </MD>
     </Paragraph>
   </>

--- a/src/pages/components/span.mdx
+++ b/src/pages/components/span.mdx
@@ -47,7 +47,8 @@ import BoldCode from '!!raw-loader!../../examples/typography/span/Bold.tsx';
 
 ### Hue
 
-The color of a span is specified with `hue`.
+The color of a span is specified with `hue`. Use a [color variable](/components/theme-object#colors)
+key or [PALETTE](/components/palette#palette) color when possible.
 
 import Hue from '../../examples/typography/span/Hue.tsx';
 import HueCode from '!!raw-loader!../../examples/typography/span/Hue.tsx';


### PR DESCRIPTION
## Description

Updates `react-typography` to `v9`.

## Detail

Update pages using typography components with colors:
- [x] Demonstrate variable keys in `Span` color examples
- [x] Updates examples (`Timeline`, `Draggable`) using `Span` with variable keys
- [x] Updates `Grid` subcomponent properties

## Checklist

- ~~ok_hand: website updates are Garden Designer approved (add the designer as a reviewer)~~
- ~~:black_nib: copy updates are approved (add the content strategist as a reviewer)~~
- [x] :link: considered opportunities for adding cross-reference URLs (grep for keywords)
- ~~:wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver~~
- ~~:memo: tested in Chrome, Firefox, Safari, Edge~~
