### PR TITLE
feat(components): update draggable to v9

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,7 @@
         "@zendeskgarden/react-chrome": "8.76.3",
         "@zendeskgarden/react-colorpickers": "9.0.0-next.19",
         "@zendeskgarden/react-datepickers": "9.0.0-next.21",
-        "@zendeskgarden/react-drag-drop": "8.76.3",
+        "@zendeskgarden/react-draggable": "9.0.0-next.21",
         "@zendeskgarden/react-dropdowns": "9.0.0-next.20",
         "@zendeskgarden/react-forms": "9.0.0-next.19",
         "@zendeskgarden/react-grid": "9.0.0-next.19",
@@ -7059,21 +7059,20 @@
         "url": "https://github.com/sponsors/gregberge"
       }
     },
-    "node_modules/@zendeskgarden/react-drag-drop": {
-      "version": "8.76.3",
-      "resolved": "https://registry.npmjs.org/@zendeskgarden/react-drag-drop/-/react-drag-drop-8.76.3.tgz",
-      "integrity": "sha512-DzFNRwOnYcBgYQrybXJKlakgCaKExpoU7sRHfJBF8fFICA2dtOQCnARDXR2MiqAkBQB4QdKi39fFgAgRM9nqhg==",
+    "node_modules/@zendeskgarden/react-draggable": {
+      "version": "9.0.0-next.21",
+      "resolved": "https://registry.npmjs.org/@zendeskgarden/react-draggable/-/react-draggable-9.0.0-next.21.tgz",
+      "integrity": "sha512-PbnPMXmQjen3g8kE6tHsyaeWd+JUMUGaVarthebGCPvGsKkpgef6Z2SZLLlTH9e5duEEEJdAOvdS6uuhY592aQ==",
       "dev": true,
-      "license": "Apache-2.0",
       "dependencies": {
         "polished": "^4.3.1",
         "prop-types": "^15.7.2"
       },
       "peerDependencies": {
-        "@zendeskgarden/react-theming": "^8.75.0",
+        "@zendeskgarden/react-theming": ">=9.0.0-next",
         "react": ">=16.8.0",
         "react-dom": ">=16.8.0",
-        "styled-components": "^4.2.0 || ^5.0.0"
+        "styled-components": "^5.3.1"
       }
     },
     "node_modules/@zendeskgarden/react-dropdowns": {

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "@zendeskgarden/react-chrome": "8.76.3",
     "@zendeskgarden/react-colorpickers": "9.0.0-next.19",
     "@zendeskgarden/react-datepickers": "9.0.0-next.21",
-    "@zendeskgarden/react-drag-drop": "8.76.3",
+    "@zendeskgarden/react-draggable": "9.0.0-next.21",
     "@zendeskgarden/react-dropdowns": "9.0.0-next.20",
     "@zendeskgarden/react-forms": "9.0.0-next.19",
     "@zendeskgarden/react-grid": "9.0.0-next.19",

--- a/src/examples/draggable/DraggableBare.tsx
+++ b/src/examples/draggable/DraggableBare.tsx
@@ -7,31 +7,31 @@
 
 import React from 'react';
 import styled from 'styled-components';
-import { Row, Col } from '@zendeskgarden/react-grid';
-import { Draggable } from '@zendeskgarden/react-drag-drop';
+import { Grid } from '@zendeskgarden/react-grid';
+import { Draggable } from '@zendeskgarden/react-draggable';
 import { mediaQuery } from '@zendeskgarden/react-theming';
 
-const StyledCol = styled(Col)`
+const StyledCol = styled(Grid.Col)`
   ${p => mediaQuery('down', 'xs', p.theme)} {
     margin-top: ${p => p.theme.space.sm};
   }
 `;
 
 const Example = () => (
-  <Row justifyContent="center">
-    <Col sm={4}>
+  <Grid.Row justifyContent="center">
+    <Grid.Col sm={4}>
       <Draggable>
         <Draggable.Grip />
         <Draggable.Content>Orange</Draggable.Content>
       </Draggable>
-    </Col>
+    </Grid.Col>
     <StyledCol sm={4}>
       <Draggable isBare>
         <Draggable.Grip />
         <Draggable.Content>Orange</Draggable.Content>
       </Draggable>
     </StyledCol>
-  </Row>
+  </Grid.Row>
 );
 
 export default Example;

--- a/src/examples/draggable/DraggableContent.tsx
+++ b/src/examples/draggable/DraggableContent.tsx
@@ -7,8 +7,8 @@
 
 import React from 'react';
 import { PALETTE, getColor } from '@zendeskgarden/react-theming';
-import { Row, Col } from '@zendeskgarden/react-grid';
-import { Draggable } from '@zendeskgarden/react-drag-drop';
+import { Grid } from '@zendeskgarden/react-grid';
+import { Draggable } from '@zendeskgarden/react-draggable';
 import { IconButton } from '@zendeskgarden/react-buttons';
 import { Tooltip } from '@zendeskgarden/react-tooltips';
 import { Span } from '@zendeskgarden/react-typography';
@@ -23,8 +23,8 @@ const StyledDecorator = styled.div`
 `;
 
 const Example = () => (
-  <Row justifyContent="center">
-    <Col sm={7}>
+  <Grid.Row justifyContent="center">
+    <Grid.Col sm={7}>
       <Draggable isCompact>
         <Draggable.Grip />
         <StyledDecorator>
@@ -42,8 +42,8 @@ const Example = () => (
           </IconButton>
         </Tooltip>
       </Draggable>
-    </Col>
-  </Row>
+    </Grid.Col>
+  </Grid.Row>
 );
 
 export default Example;

--- a/src/examples/draggable/DraggableDefault.tsx
+++ b/src/examples/draggable/DraggableDefault.tsx
@@ -6,18 +6,18 @@
  */
 
 import React from 'react';
-import { Row, Col } from '@zendeskgarden/react-grid';
-import { Draggable } from '@zendeskgarden/react-drag-drop';
+import { Grid } from '@zendeskgarden/react-grid';
+import { Draggable } from '@zendeskgarden/react-draggable';
 
 const Example = () => (
-  <Row justifyContent="center">
-    <Col sm={4}>
+  <Grid.Row justifyContent="center">
+    <Grid.Col sm={4}>
       <Draggable>
         <Draggable.Grip />
         <Draggable.Content>Apple</Draggable.Content>
       </Draggable>
-    </Col>
-  </Row>
+    </Grid.Col>
+  </Grid.Row>
 );
 
 export default Example;

--- a/src/examples/draggable/DraggableDisabled.tsx
+++ b/src/examples/draggable/DraggableDisabled.tsx
@@ -6,18 +6,18 @@
  */
 
 import React from 'react';
-import { Row, Col } from '@zendeskgarden/react-grid';
-import { Draggable } from '@zendeskgarden/react-drag-drop';
+import { Grid } from '@zendeskgarden/react-grid';
+import { Draggable } from '@zendeskgarden/react-draggable';
 
 const Example = () => (
-  <Row justifyContent="center">
-    <Col sm={4}>
+  <Grid.Row justifyContent="center">
+    <Grid.Col sm={4}>
       <Draggable isDisabled>
         <Draggable.Grip />
         <Draggable.Content>Pear</Draggable.Content>
       </Draggable>
-    </Col>
-  </Row>
+    </Grid.Col>
+  </Grid.Row>
 );
 
 export default Example;

--- a/src/examples/draggable/DraggableListDefault.tsx
+++ b/src/examples/draggable/DraggableListDefault.tsx
@@ -20,7 +20,6 @@ const items = [
 ];
 
 const StyledHeading = styled(MD)`
-  transition: color 0.2s ease-in-out;
   margin-bottom: ${p => p.theme.space.xs};
   color: ${p => getColor({ variable: 'foreground.default', theme: p.theme })};
 `;

--- a/src/examples/draggable/DraggableListDefault.tsx
+++ b/src/examples/draggable/DraggableListDefault.tsx
@@ -6,9 +6,10 @@
  */
 
 import React from 'react';
-import { Row, Col } from '@zendeskgarden/react-grid';
+import { getColor } from '@zendeskgarden/react-theming';
+import { Grid } from '@zendeskgarden/react-grid';
 import { MD } from '@zendeskgarden/react-typography';
-import { Draggable, DraggableList } from '@zendeskgarden/react-drag-drop';
+import { Draggable, DraggableList } from '@zendeskgarden/react-draggable';
 import styled from 'styled-components';
 
 const items = [
@@ -19,12 +20,14 @@ const items = [
 ];
 
 const StyledHeading = styled(MD)`
+  transition: color 0.2s ease-in-out;
   margin-bottom: ${p => p.theme.space.xs};
+  color: ${p => getColor({ variable: 'foreground.default', theme: p.theme })};
 `;
 
 const Example = () => (
-  <Row justifyContent="center">
-    <Col sm={4}>
+  <Grid.Row justifyContent="center">
+    <Grid.Col sm={4}>
       <StyledHeading isBold tag="h4">
         Favorites
       </StyledHeading>
@@ -38,8 +41,8 @@ const Example = () => (
           </DraggableList.Item>
         ))}
       </DraggableList>
-    </Col>
-  </Row>
+    </Grid.Col>
+  </Grid.Row>
 );
 
 export default Example;

--- a/src/examples/draggable/DraggableListHorizontal.tsx
+++ b/src/examples/draggable/DraggableListHorizontal.tsx
@@ -6,9 +6,10 @@
  */
 
 import React from 'react';
-import { Row, Col } from '@zendeskgarden/react-grid';
+import { getColor } from '@zendeskgarden/react-theming';
+import { Grid } from '@zendeskgarden/react-grid';
 import { MD } from '@zendeskgarden/react-typography';
-import { Draggable, DraggableList } from '@zendeskgarden/react-drag-drop';
+import { Draggable, DraggableList } from '@zendeskgarden/react-draggable';
 import styled from 'styled-components';
 
 const items = [
@@ -18,12 +19,14 @@ const items = [
 ];
 
 const StyledHeading = styled(MD)`
+  transition: color 0.2s ease-in-out;
   margin-bottom: ${p => p.theme.space.xs};
+  color: ${p => getColor({ variable: 'foreground.default', theme: p.theme })};
 `;
 
 const Example = () => (
-  <Row justifyContent="center">
-    <Col sm={10}>
+  <Grid.Row justifyContent="center">
+    <Grid.Col sm={10}>
       <StyledHeading isBold tag="h4">
         Favorites
       </StyledHeading>
@@ -37,8 +40,8 @@ const Example = () => (
           </DraggableList.Item>
         ))}
       </DraggableList>
-    </Col>
-  </Row>
+    </Grid.Col>
+  </Grid.Row>
 );
 
 export default Example;

--- a/src/examples/draggable/DraggableListHorizontal.tsx
+++ b/src/examples/draggable/DraggableListHorizontal.tsx
@@ -19,7 +19,6 @@ const items = [
 ];
 
 const StyledHeading = styled(MD)`
-  transition: color 0.2s ease-in-out;
   margin-bottom: ${p => p.theme.space.xs};
   color: ${p => getColor({ variable: 'foreground.default', theme: p.theme })};
 `;

--- a/src/examples/draggable/DraggableListIndicator.tsx
+++ b/src/examples/draggable/DraggableListIndicator.tsx
@@ -21,7 +21,6 @@ const items = [
 ];
 
 const StyledHeading = styled(MD)`
-  transition: color 0.2s ease-in-out;
   margin-bottom: ${p => p.theme.space.xs};
   color: ${p => getColor({ variable: 'foreground.default', theme: p.theme })};
 `;

--- a/src/examples/draggable/DraggableListIndicator.tsx
+++ b/src/examples/draggable/DraggableListIndicator.tsx
@@ -6,9 +6,10 @@
  */
 
 import React from 'react';
-import { Row, Col } from '@zendeskgarden/react-grid';
+import { getColor } from '@zendeskgarden/react-theming';
+import { Grid } from '@zendeskgarden/react-grid';
 import { MD } from '@zendeskgarden/react-typography';
-import { Draggable, DraggableList } from '@zendeskgarden/react-drag-drop';
+import { Draggable, DraggableList } from '@zendeskgarden/react-draggable';
 import styled from 'styled-components';
 
 const items = [
@@ -20,12 +21,14 @@ const items = [
 ];
 
 const StyledHeading = styled(MD)`
+  transition: color 0.2s ease-in-out;
   margin-bottom: ${p => p.theme.space.xs};
+  color: ${p => getColor({ variable: 'foreground.default', theme: p.theme })};
 `;
 
 const Example = () => (
-  <Row justifyContent="center">
-    <Col sm={4}>
+  <Grid.Row justifyContent="center">
+    <Grid.Col sm={4}>
       <StyledHeading isBold tag="h4">
         Favorites
       </StyledHeading>
@@ -46,8 +49,8 @@ const Example = () => (
           )
         )}
       </DraggableList>
-    </Col>
-  </Row>
+    </Grid.Col>
+  </Grid.Row>
 );
 
 export default Example;

--- a/src/examples/draggable/DraggablePlaceholder.tsx
+++ b/src/examples/draggable/DraggablePlaceholder.tsx
@@ -20,7 +20,6 @@ const items = [
 ];
 
 const StyledHeading = styled(MD)`
-  transition: color 0.2s ease-in-out;
   margin-bottom: ${p => p.theme.space.xs};
   color: ${p => getColor({ variable: 'foreground.default', theme: p.theme })};
 `;

--- a/src/examples/draggable/DraggablePlaceholder.tsx
+++ b/src/examples/draggable/DraggablePlaceholder.tsx
@@ -6,9 +6,10 @@
  */
 
 import React from 'react';
-import { Row, Col } from '@zendeskgarden/react-grid';
+import { getColor } from '@zendeskgarden/react-theming';
+import { Grid } from '@zendeskgarden/react-grid';
 import { MD } from '@zendeskgarden/react-typography';
-import { Draggable, DraggableList } from '@zendeskgarden/react-drag-drop';
+import { Draggable, DraggableList } from '@zendeskgarden/react-draggable';
 import styled from 'styled-components';
 
 const items = [
@@ -19,12 +20,14 @@ const items = [
 ];
 
 const StyledHeading = styled(MD)`
+  transition: color 0.2s ease-in-out;
   margin-bottom: ${p => p.theme.space.xs};
+  color: ${p => getColor({ variable: 'foreground.default', theme: p.theme })};
 `;
 
 const Example = () => (
-  <Row justifyContent="center">
-    <Col sm={4}>
+  <Grid.Row justifyContent="center">
+    <Grid.Col sm={4}>
       <StyledHeading isBold tag="h4">
         Favorites
       </StyledHeading>
@@ -38,8 +41,8 @@ const Example = () => (
           </DraggableList.Item>
         ))}
       </DraggableList>
-    </Col>
-  </Row>
+    </Grid.Col>
+  </Grid.Row>
 );
 
 export default Example;

--- a/src/examples/draggable/DraggableSize.tsx
+++ b/src/examples/draggable/DraggableSize.tsx
@@ -7,31 +7,31 @@
 
 import React from 'react';
 import styled from 'styled-components';
-import { Row, Col } from '@zendeskgarden/react-grid';
-import { Draggable } from '@zendeskgarden/react-drag-drop';
+import { Grid } from '@zendeskgarden/react-grid';
+import { Draggable } from '@zendeskgarden/react-draggable';
 import { mediaQuery } from '@zendeskgarden/react-theming';
 
-const StyledCol = styled(Col)`
+const StyledCol = styled(Grid.Col)`
   ${p => mediaQuery('down', 'xs', p.theme)} {
     margin-top: ${p => p.theme.space.sm};
   }
 `;
 
 const Example = () => (
-  <Row justifyContent="center">
-    <Col sm={4}>
+  <Grid.Row justifyContent="center">
+    <Grid.Col sm={4}>
       <Draggable>
         <Draggable.Grip />
         <Draggable.Content>Raspberry</Draggable.Content>
       </Draggable>
-    </Col>
+    </Grid.Col>
     <StyledCol sm={4}>
       <Draggable isCompact>
         <Draggable.Grip />
         <Draggable.Content>Raspberry</Draggable.Content>
       </Draggable>
     </StyledCol>
-  </Row>
+  </Grid.Row>
 );
 
 export default Example;

--- a/src/examples/draggable/DropzoneDanger.tsx
+++ b/src/examples/draggable/DropzoneDanger.tsx
@@ -105,7 +105,6 @@ const announcements: Announcements = {
 };
 
 const StyledHeading = styled(MD)`
-  transition: color 0.2s ease-in-out;
   margin-bottom: ${p => p.theme.space.xs};
   color: ${p => getColor({ variable: 'foreground.default', theme: p.theme })};
 `;

--- a/src/examples/draggable/DropzoneDanger.tsx
+++ b/src/examples/draggable/DropzoneDanger.tsx
@@ -29,10 +29,10 @@ import {
   DraggableList,
   Dropzone,
   IDraggableProps
-} from '@zendeskgarden/react-drag-drop';
-import { Row, Col } from '@zendeskgarden/react-grid';
+} from '@zendeskgarden/react-draggable';
+import { Grid } from '@zendeskgarden/react-grid';
 import { MD } from '@zendeskgarden/react-typography';
-import { mediaQuery } from '@zendeskgarden/react-theming';
+import { getColor, mediaQuery } from '@zendeskgarden/react-theming';
 
 interface IColumnItem {
   id: string;
@@ -105,7 +105,9 @@ const announcements: Announcements = {
 };
 
 const StyledHeading = styled(MD)`
+  transition: color 0.2s ease-in-out;
   margin-bottom: ${p => p.theme.space.xs};
+  color: ${p => getColor({ variable: 'foreground.default', theme: p.theme })};
 `;
 
 const StyledDropzone = styled(Dropzone)`
@@ -116,7 +118,7 @@ const StyledDraggableOverlay = styled.div`
   padding: ${p => p.theme.space.xxs} 0;
 `;
 
-const StyledCol = styled(Col)`
+const StyledCol = styled(Grid.Col)`
   ${p => mediaQuery('down', 'xs', p.theme)} {
     margin-top: ${p => p.theme.space.sm};
   }
@@ -228,15 +230,15 @@ const Example = () => {
       onDragCancel={onDragCancel}
       measuring={{ droppable: { strategy: MeasuringStrategy.Always } }}
     >
-      <Row justifyContent="center">
-        <Col sm={4}>
+      <Grid.Row justifyContent="center">
+        <Grid.Col sm={4}>
           <StyledHeading isBold>List of produce</StyledHeading>
           <DraggableList>
             {items.map(item => (
               <DraggableListItem key={item.id} {...item} />
             ))}
           </DraggableList>
-        </Col>
+        </Grid.Col>
         <StyledCol sm={5}>
           <StyledHeading isBold>Yucky fruits</StyledHeading>
           <DroppableColumn isActive={!!activeId} isHighlighted={dropzoneIsHighlighted} />
@@ -254,7 +256,7 @@ const Example = () => {
             </StyledDraggableOverlay>
           )}
         </DragOverlay>
-      </Row>
+      </Grid.Row>
     </DndContext>
   );
 };

--- a/src/examples/draggable/DropzoneDefault.tsx
+++ b/src/examples/draggable/DropzoneDefault.tsx
@@ -29,8 +29,8 @@ import {
   DraggableList,
   Dropzone,
   IDraggableProps
-} from '@zendeskgarden/react-drag-drop';
-import { Row, Col } from '@zendeskgarden/react-grid';
+} from '@zendeskgarden/react-draggable';
+import { Grid } from '@zendeskgarden/react-grid';
 import { MD } from '@zendeskgarden/react-typography';
 import { getColor, mediaQuery } from '@zendeskgarden/react-theming';
 
@@ -122,7 +122,9 @@ const getAnnouncements = (count: number): Announcements => ({
 });
 
 const StyledHeading = styled(MD)`
+  transition: color 0.2s ease-in-out;
   margin-bottom: ${p => p.theme.space.xs};
+  color: ${p => getColor({ variable: 'foreground.default', theme: p.theme })};
 `;
 
 const StyledDropzone = styled(Dropzone)`
@@ -133,7 +135,7 @@ const StyledDraggableOverlay = styled.div`
   padding: ${p => p.theme.space.xxs} 0;
 `;
 
-const StyledCol = styled(Col)`
+const StyledCol = styled(Grid.Col)`
   ${p => mediaQuery('down', 'xs', p.theme)} {
     margin-top: ${p => p.theme.space.sm};
   }
@@ -286,15 +288,15 @@ const Example = () => {
       onDragCancel={onDragCancel}
       measuring={{ droppable: { strategy: MeasuringStrategy.Always } }}
     >
-      <Row justifyContent="center">
-        <Col sm={4}>
+      <Grid.Row justifyContent="center">
+        <Grid.Col sm={4}>
           <StyledHeading isBold>List of produce</StyledHeading>
           <DraggableList>
             {draggableItems.map(item => (
               <DraggableListItem key={item.id} {...item} />
             ))}
           </DraggableList>
-        </Col>
+        </Grid.Col>
         <StyledCol sm={5}>
           <StyledHeading isBold>Favorite fruits</StyledHeading>
           <DroppableColumn
@@ -316,7 +318,7 @@ const Example = () => {
             </StyledDraggableOverlay>
           )}
         </DragOverlay>
-      </Row>
+      </Grid.Row>
     </DndContext>
   );
 };

--- a/src/examples/draggable/DropzoneDefault.tsx
+++ b/src/examples/draggable/DropzoneDefault.tsx
@@ -122,7 +122,6 @@ const getAnnouncements = (count: number): Announcements => ({
 });
 
 const StyledHeading = styled(MD)`
-  transition: color 0.2s ease-in-out;
   margin-bottom: ${p => p.theme.space.xs};
   color: ${p => getColor({ variable: 'foreground.default', theme: p.theme })};
 `;


### PR DESCRIPTION
## Description

**Package migration changes:**
- Updates `react-drag-drop` to `react-draggable` (v9)

**Other updates:**
- Updates examples 
  - Use `Grid` subcomponent properties
  - Apply custom colors to support dark mode (headings in `DraggableList` and `Dropzone` examples)

https://github.com/user-attachments/assets/83d92bf8-cc34-4559-a7f2-09450f9df511

Notes:
- No changes to MDX file(s)

## Checklist

- ~~:ok_hand: website updates are Garden Designer approved (add the designer as a reviewer)~~
- ~~:black_nib: copy updates are approved (add the content strategist as a reviewer)~~
- ~~:link: considered opportunities for adding cross-reference URLs (grep for keywords)~~
- ~~:wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver~~
- ~~:memo: tested in Chrome, Firefox, Safari, Edge~~
