### PR TITLE
chore: removes ESLint `--max-warning` flag from lint-staged config

### DIFF
--- a/.lintstagedrc
+++ b/.lintstagedrc
@@ -1,14 +1,5 @@
 {
-  "*.{js,ts,tsx}": [
-    "stylelint",
-    "eslint --max-warnings 0",
-    "prettier --write"
-  ],
-  "*.{md,mdx}": [
-    "markdownlint",
-    "prettier --write"
-  ],
-  "**/package.json": [
-    "prettier-package-json --write"
-  ]
+  "*.{js,ts,tsx}": ["stylelint", "eslint", "prettier --write"],
+  "*.{md,mdx}": ["markdownlint", "prettier --write"],
+  "**/package.json": ["prettier-package-json --write"]
 }


### PR DESCRIPTION
## Description

Temporarily removes ESLint --max-warning flag from lint-staged config (omission from refactor(component pages): reference updated subComponents' displayName #621).
## Detail

