### PR TITLE
feat(components): updates grid to v9

### DIFF
--- a/src/examples/grid/GridAllBreak.tsx
+++ b/src/examples/grid/GridAllBreak.tsx
@@ -6,11 +6,17 @@
  */
 
 import React from 'react';
+import styled from 'styled-components';
+import { getColor } from '@zendeskgarden/react-theming';
 import { MD } from '@zendeskgarden/react-typography';
 import { Grid } from '@zendeskgarden/react-grid';
 
+const StyledGrid = styled(Grid)`
+  color: ${p => getColor({ variable: 'foreground.default', theme: p.theme })};
+`;
+
 const Example = () => (
-  <Grid debug>
+  <StyledGrid debug>
     <Grid.Row>
       <Grid.Col>
         <MD>Col</MD>
@@ -33,7 +39,7 @@ const Example = () => (
         <MD>Col[size=4]</MD>
       </Grid.Col>
     </Grid.Row>
-  </Grid>
+  </StyledGrid>
 );
 
 export default Example;

--- a/src/examples/grid/GridAllBreak.tsx
+++ b/src/examples/grid/GridAllBreak.tsx
@@ -6,17 +6,11 @@
  */
 
 import React from 'react';
-import styled from 'styled-components';
-import { getColor } from '@zendeskgarden/react-theming';
 import { MD } from '@zendeskgarden/react-typography';
 import { Grid } from '@zendeskgarden/react-grid';
 
-const StyledGrid = styled(Grid)`
-  color: ${p => getColor({ variable: 'foreground.default', theme: p.theme })};
-`;
-
 const Example = () => (
-  <StyledGrid debug>
+  <Grid debug>
     <Grid.Row>
       <Grid.Col>
         <MD>Col</MD>
@@ -39,7 +33,7 @@ const Example = () => (
         <MD>Col[size=4]</MD>
       </Grid.Col>
     </Grid.Row>
-  </StyledGrid>
+  </Grid>
 );
 
 export default Example;

--- a/src/examples/grid/GridAllBreak.tsx
+++ b/src/examples/grid/GridAllBreak.tsx
@@ -7,32 +7,32 @@
 
 import React from 'react';
 import { MD } from '@zendeskgarden/react-typography';
-import { Grid, Row, Col } from '@zendeskgarden/react-grid';
+import { Grid } from '@zendeskgarden/react-grid';
 
 const Example = () => (
   <Grid debug>
-    <Row>
-      <Col>
+    <Grid.Row>
+      <Grid.Col>
         <MD>Col</MD>
-      </Col>
-      <Col>
+      </Grid.Col>
+      <Grid.Col>
         <MD>Col</MD>
-      </Col>
-      <Col>
+      </Grid.Col>
+      <Grid.Col>
         <MD>Col</MD>
-      </Col>
-      <Col>
+      </Grid.Col>
+      <Grid.Col>
         <MD>Col</MD>
-      </Col>
-    </Row>
-    <Row>
-      <Col size={8}>
+      </Grid.Col>
+    </Grid.Row>
+    <Grid.Row>
+      <Grid.Col size={8}>
         <MD>Col[size=8]</MD>
-      </Col>
-      <Col size={4}>
+      </Grid.Col>
+      <Grid.Col size={4}>
         <MD>Col[size=4]</MD>
-      </Col>
-    </Row>
+      </Grid.Col>
+    </Grid.Row>
   </Grid>
 );
 

--- a/src/examples/grid/GridColumnBreaks.tsx
+++ b/src/examples/grid/GridColumnBreaks.tsx
@@ -7,25 +7,25 @@
 
 import React from 'react';
 import { MD } from '@zendeskgarden/react-typography';
-import { Grid, Row, Col } from '@zendeskgarden/react-grid';
+import { Grid } from '@zendeskgarden/react-grid';
 
 const Example = () => (
   <Grid debug>
-    <Row>
-      <Col size={6} sm={3}>
+    <Grid.Row>
+      <Grid.Col size={6} sm={3}>
         <MD>Col[size=6][sm=3]</MD>
-      </Col>
-      <Col size={6} sm={3}>
+      </Grid.Col>
+      <Grid.Col size={6} sm={3}>
         <MD>Col[size=6][sm=3]</MD>
-      </Col>
+      </Grid.Col>
       <div style={{ width: '100%' }} />
-      <Col size={6} sm={3}>
+      <Grid.Col size={6} sm={3}>
         <MD>Col[size=6][sm=3]</MD>
-      </Col>
-      <Col size={6} sm={3}>
+      </Grid.Col>
+      <Grid.Col size={6} sm={3}>
         <MD>Col[size=6][sm=3]</MD>
-      </Col>
-    </Row>
+      </Grid.Col>
+    </Grid.Row>
   </Grid>
 );
 

--- a/src/examples/grid/GridColumnBreaks.tsx
+++ b/src/examples/grid/GridColumnBreaks.tsx
@@ -6,17 +6,11 @@
  */
 
 import React from 'react';
-import styled from 'styled-components';
-import { getColor } from '@zendeskgarden/react-theming';
 import { MD } from '@zendeskgarden/react-typography';
 import { Grid } from '@zendeskgarden/react-grid';
 
-const StyledGrid = styled(Grid)`
-  color: ${p => getColor({ variable: 'foreground.default', theme: p.theme })};
-`;
-
 const Example = () => (
-  <StyledGrid debug>
+  <Grid debug>
     <Grid.Row>
       <Grid.Col size={6} sm={3}>
         <MD>Col[size=6][sm=3]</MD>
@@ -32,7 +26,7 @@ const Example = () => (
         <MD>Col[size=6][sm=3]</MD>
       </Grid.Col>
     </Grid.Row>
-  </StyledGrid>
+  </Grid>
 );
 
 export default Example;

--- a/src/examples/grid/GridColumnBreaks.tsx
+++ b/src/examples/grid/GridColumnBreaks.tsx
@@ -6,11 +6,17 @@
  */
 
 import React from 'react';
+import styled from 'styled-components';
+import { getColor } from '@zendeskgarden/react-theming';
 import { MD } from '@zendeskgarden/react-typography';
 import { Grid } from '@zendeskgarden/react-grid';
 
+const StyledGrid = styled(Grid)`
+  color: ${p => getColor({ variable: 'foreground.default', theme: p.theme })};
+`;
+
 const Example = () => (
-  <Grid debug>
+  <StyledGrid debug>
     <Grid.Row>
       <Grid.Col size={6} sm={3}>
         <MD>Col[size=6][sm=3]</MD>
@@ -26,7 +32,7 @@ const Example = () => (
         <MD>Col[size=6][sm=3]</MD>
       </Grid.Col>
     </Grid.Row>
-  </Grid>
+  </StyledGrid>
 );
 
 export default Example;

--- a/src/examples/grid/GridColumnWrapping.tsx
+++ b/src/examples/grid/GridColumnWrapping.tsx
@@ -6,17 +6,12 @@
  */
 
 import React from 'react';
-import styled from 'styled-components';
-import { getColor } from '@zendeskgarden/react-theming';
+
 import { MD } from '@zendeskgarden/react-typography';
 import { Grid } from '@zendeskgarden/react-grid';
 
-const StyledGrid = styled(Grid)`
-  color: ${p => getColor({ variable: 'foreground.default', theme: p.theme })};
-`;
-
 const Example = () => (
-  <StyledGrid debug>
+  <Grid debug>
     <Grid.Row>
       <Grid.Col size={9}>
         <MD>Col[size=9]</MD>
@@ -31,7 +26,7 @@ const Example = () => (
         <MD>Col[size=6]: subsequent columns continue along the new line.</MD>
       </Grid.Col>
     </Grid.Row>
-  </StyledGrid>
+  </Grid>
 );
 
 export default Example;

--- a/src/examples/grid/GridColumnWrapping.tsx
+++ b/src/examples/grid/GridColumnWrapping.tsx
@@ -7,24 +7,24 @@
 
 import React from 'react';
 import { MD } from '@zendeskgarden/react-typography';
-import { Grid, Row, Col } from '@zendeskgarden/react-grid';
+import { Grid } from '@zendeskgarden/react-grid';
 
 const Example = () => (
   <Grid debug>
-    <Row>
-      <Col size={9}>
+    <Grid.Row>
+      <Grid.Col size={9}>
         <MD>Col[size=9]</MD>
-      </Col>
-      <Col size={4}>
+      </Grid.Col>
+      <Grid.Col size={4}>
         <MD>
           Col[size=4]: since 9 + 4 = 13 &gt; 12, this column gets wrapped onto a new line as one
           contiguous unit.
         </MD>
-      </Col>
-      <Col size={6}>
+      </Grid.Col>
+      <Grid.Col size={6}>
         <MD>Col[size=6]: subsequent columns continue along the new line.</MD>
-      </Col>
-    </Row>
+      </Grid.Col>
+    </Grid.Row>
   </Grid>
 );
 

--- a/src/examples/grid/GridColumnWrapping.tsx
+++ b/src/examples/grid/GridColumnWrapping.tsx
@@ -6,11 +6,17 @@
  */
 
 import React from 'react';
+import styled from 'styled-components';
+import { getColor } from '@zendeskgarden/react-theming';
 import { MD } from '@zendeskgarden/react-typography';
 import { Grid } from '@zendeskgarden/react-grid';
 
+const StyledGrid = styled(Grid)`
+  color: ${p => getColor({ variable: 'foreground.default', theme: p.theme })};
+`;
+
 const Example = () => (
-  <Grid debug>
+  <StyledGrid debug>
     <Grid.Row>
       <Grid.Col size={9}>
         <MD>Col[size=9]</MD>
@@ -25,7 +31,7 @@ const Example = () => (
         <MD>Col[size=6]: subsequent columns continue along the new line.</MD>
       </Grid.Col>
     </Grid.Row>
-  </Grid>
+  </StyledGrid>
 );
 
 export default Example;

--- a/src/examples/grid/GridEqual.tsx
+++ b/src/examples/grid/GridEqual.tsx
@@ -7,29 +7,29 @@
 
 import React from 'react';
 import { MD } from '@zendeskgarden/react-typography';
-import { Grid, Row, Col } from '@zendeskgarden/react-grid';
+import { Grid } from '@zendeskgarden/react-grid';
 
 const Example = () => (
   <Grid debug>
-    <Row>
-      <Col>
+    <Grid.Row>
+      <Grid.Col>
         <MD>1 of 2</MD>
-      </Col>
-      <Col>
+      </Grid.Col>
+      <Grid.Col>
         <MD>2 of 2</MD>
-      </Col>
-    </Row>
-    <Row>
-      <Col>
+      </Grid.Col>
+    </Grid.Row>
+    <Grid.Row>
+      <Grid.Col>
         <MD>1 of 3</MD>
-      </Col>
-      <Col>
+      </Grid.Col>
+      <Grid.Col>
         <MD>2 of 3</MD>
-      </Col>
-      <Col>
+      </Grid.Col>
+      <Grid.Col>
         <MD>3 of 3</MD>
-      </Col>
-    </Row>
+      </Grid.Col>
+    </Grid.Row>
   </Grid>
 );
 

--- a/src/examples/grid/GridEqual.tsx
+++ b/src/examples/grid/GridEqual.tsx
@@ -6,17 +6,11 @@
  */
 
 import React from 'react';
-import styled from 'styled-components';
-import { getColor } from '@zendeskgarden/react-theming';
 import { MD } from '@zendeskgarden/react-typography';
 import { Grid } from '@zendeskgarden/react-grid';
 
-const StyledGrid = styled(Grid)`
-  color: ${p => getColor({ variable: 'foreground.default', theme: p.theme })};
-`;
-
 const Example = () => (
-  <StyledGrid debug>
+  <Grid debug>
     <Grid.Row>
       <Grid.Col>
         <MD>1 of 2</MD>
@@ -36,7 +30,7 @@ const Example = () => (
         <MD>3 of 3</MD>
       </Grid.Col>
     </Grid.Row>
-  </StyledGrid>
+  </Grid>
 );
 
 export default Example;

--- a/src/examples/grid/GridEqual.tsx
+++ b/src/examples/grid/GridEqual.tsx
@@ -6,11 +6,17 @@
  */
 
 import React from 'react';
+import styled from 'styled-components';
+import { getColor } from '@zendeskgarden/react-theming';
 import { MD } from '@zendeskgarden/react-typography';
 import { Grid } from '@zendeskgarden/react-grid';
 
+const StyledGrid = styled(Grid)`
+  color: ${p => getColor({ variable: 'foreground.default', theme: p.theme })};
+`;
+
 const Example = () => (
-  <Grid debug>
+  <StyledGrid debug>
     <Grid.Row>
       <Grid.Col>
         <MD>1 of 2</MD>
@@ -30,7 +36,7 @@ const Example = () => (
         <MD>3 of 3</MD>
       </Grid.Col>
     </Grid.Row>
-  </Grid>
+  </StyledGrid>
 );
 
 export default Example;

--- a/src/examples/grid/GridEqualMulti.tsx
+++ b/src/examples/grid/GridEqualMulti.tsx
@@ -6,11 +6,17 @@
  */
 
 import React from 'react';
+import styled from 'styled-components';
+import { getColor } from '@zendeskgarden/react-theming';
 import { MD } from '@zendeskgarden/react-typography';
 import { Grid } from '@zendeskgarden/react-grid';
 
+const StyledGrid = styled(Grid)`
+  color: ${p => getColor({ variable: 'foreground.default', theme: p.theme })};
+`;
+
 const Example = () => (
-  <Grid debug>
+  <StyledGrid debug>
     <Grid.Row>
       <Grid.Col>
         <MD>Col</MD>
@@ -26,7 +32,7 @@ const Example = () => (
         <MD>Col</MD>
       </Grid.Col>
     </Grid.Row>
-  </Grid>
+  </StyledGrid>
 );
 
 export default Example;

--- a/src/examples/grid/GridEqualMulti.tsx
+++ b/src/examples/grid/GridEqualMulti.tsx
@@ -7,25 +7,25 @@
 
 import React from 'react';
 import { MD } from '@zendeskgarden/react-typography';
-import { Grid, Row, Col } from '@zendeskgarden/react-grid';
+import { Grid } from '@zendeskgarden/react-grid';
 
 const Example = () => (
   <Grid debug>
-    <Row>
-      <Col>
+    <Grid.Row>
+      <Grid.Col>
         <MD>Col</MD>
-      </Col>
-      <Col>
+      </Grid.Col>
+      <Grid.Col>
         <MD>Col</MD>
-      </Col>
+      </Grid.Col>
       <div style={{ width: '100%' }} />
-      <Col>
+      <Grid.Col>
         <MD>Col</MD>
-      </Col>
-      <Col>
+      </Grid.Col>
+      <Grid.Col>
         <MD>Col</MD>
-      </Col>
-    </Row>
+      </Grid.Col>
+    </Grid.Row>
   </Grid>
 );
 

--- a/src/examples/grid/GridEqualMulti.tsx
+++ b/src/examples/grid/GridEqualMulti.tsx
@@ -6,17 +6,11 @@
  */
 
 import React from 'react';
-import styled from 'styled-components';
-import { getColor } from '@zendeskgarden/react-theming';
 import { MD } from '@zendeskgarden/react-typography';
 import { Grid } from '@zendeskgarden/react-grid';
 
-const StyledGrid = styled(Grid)`
-  color: ${p => getColor({ variable: 'foreground.default', theme: p.theme })};
-`;
-
 const Example = () => (
-  <StyledGrid debug>
+  <Grid debug>
     <Grid.Row>
       <Grid.Col>
         <MD>Col</MD>
@@ -32,7 +26,7 @@ const Example = () => (
         <MD>Col</MD>
       </Grid.Col>
     </Grid.Row>
-  </StyledGrid>
+  </Grid>
 );
 
 export default Example;

--- a/src/examples/grid/GridHorizontal.tsx
+++ b/src/examples/grid/GridHorizontal.tsx
@@ -6,11 +6,17 @@
  */
 
 import React from 'react';
+import styled from 'styled-components';
+import { getColor } from '@zendeskgarden/react-theming';
 import { MD } from '@zendeskgarden/react-typography';
 import { Grid } from '@zendeskgarden/react-grid';
 
+const StyledGrid = styled(Grid)`
+  color: ${p => getColor({ variable: 'foreground.default', theme: p.theme })};
+`;
+
 const Example = () => (
-  <Grid debug>
+  <StyledGrid debug>
     <Grid.Row justifyContent="start">
       <Grid.Col size={4}>
         <MD>One of two columns</MD>
@@ -51,7 +57,7 @@ const Example = () => (
         <MD>One of two columns</MD>
       </Grid.Col>
     </Grid.Row>
-  </Grid>
+  </StyledGrid>
 );
 
 export default Example;

--- a/src/examples/grid/GridHorizontal.tsx
+++ b/src/examples/grid/GridHorizontal.tsx
@@ -6,17 +6,11 @@
  */
 
 import React from 'react';
-import styled from 'styled-components';
-import { getColor } from '@zendeskgarden/react-theming';
 import { MD } from '@zendeskgarden/react-typography';
 import { Grid } from '@zendeskgarden/react-grid';
 
-const StyledGrid = styled(Grid)`
-  color: ${p => getColor({ variable: 'foreground.default', theme: p.theme })};
-`;
-
 const Example = () => (
-  <StyledGrid debug>
+  <Grid debug>
     <Grid.Row justifyContent="start">
       <Grid.Col size={4}>
         <MD>One of two columns</MD>
@@ -57,7 +51,7 @@ const Example = () => (
         <MD>One of two columns</MD>
       </Grid.Col>
     </Grid.Row>
-  </StyledGrid>
+  </Grid>
 );
 
 export default Example;

--- a/src/examples/grid/GridHorizontal.tsx
+++ b/src/examples/grid/GridHorizontal.tsx
@@ -7,50 +7,50 @@
 
 import React from 'react';
 import { MD } from '@zendeskgarden/react-typography';
-import { Grid, Row, Col } from '@zendeskgarden/react-grid';
+import { Grid } from '@zendeskgarden/react-grid';
 
 const Example = () => (
   <Grid debug>
-    <Row justifyContent="start">
-      <Col size={4}>
+    <Grid.Row justifyContent="start">
+      <Grid.Col size={4}>
         <MD>One of two columns</MD>
-      </Col>
-      <Col size={4}>
+      </Grid.Col>
+      <Grid.Col size={4}>
         <MD>One of two columns</MD>
-      </Col>
-    </Row>
-    <Row justifyContent="center">
-      <Col size={4}>
+      </Grid.Col>
+    </Grid.Row>
+    <Grid.Row justifyContent="center">
+      <Grid.Col size={4}>
         <MD>One of two columns</MD>
-      </Col>
-      <Col size={4}>
+      </Grid.Col>
+      <Grid.Col size={4}>
         <MD>One of two columns</MD>
-      </Col>
-    </Row>
-    <Row justifyContent="end">
-      <Col size={4}>
+      </Grid.Col>
+    </Grid.Row>
+    <Grid.Row justifyContent="end">
+      <Grid.Col size={4}>
         <MD>One of two columns</MD>
-      </Col>
-      <Col size={4}>
+      </Grid.Col>
+      <Grid.Col size={4}>
         <MD>One of two columns</MD>
-      </Col>
-    </Row>
-    <Row justifyContent="around">
-      <Col size={4}>
+      </Grid.Col>
+    </Grid.Row>
+    <Grid.Row justifyContent="around">
+      <Grid.Col size={4}>
         <MD>One of two columns</MD>
-      </Col>
-      <Col size={4}>
+      </Grid.Col>
+      <Grid.Col size={4}>
         <MD>One of two columns</MD>
-      </Col>
-    </Row>
-    <Row justifyContent="between">
-      <Col size={4}>
+      </Grid.Col>
+    </Grid.Row>
+    <Grid.Row justifyContent="between">
+      <Grid.Col size={4}>
         <MD>One of two columns</MD>
-      </Col>
-      <Col size={4}>
+      </Grid.Col>
+      <Grid.Col size={4}>
         <MD>One of two columns</MD>
-      </Col>
-    </Row>
+      </Grid.Col>
+    </Grid.Row>
   </Grid>
 );
 

--- a/src/examples/grid/GridNesting.tsx
+++ b/src/examples/grid/GridNesting.tsx
@@ -6,11 +6,17 @@
  */
 
 import React from 'react';
+import styled from 'styled-components';
+import { getColor } from '@zendeskgarden/react-theming';
 import { MD } from '@zendeskgarden/react-typography';
 import { Grid } from '@zendeskgarden/react-grid';
 
+const StyledGrid = styled(Grid)`
+  color: ${p => getColor({ variable: 'foreground.default', theme: p.theme })};
+`;
+
 const Example = () => (
-  <Grid debug>
+  <StyledGrid debug>
     <Grid.Row>
       <Grid.Col sm={9}>
         <MD>
@@ -26,7 +32,7 @@ const Example = () => (
         </MD>
       </Grid.Col>
     </Grid.Row>
-  </Grid>
+  </StyledGrid>
 );
 
 export default Example;

--- a/src/examples/grid/GridNesting.tsx
+++ b/src/examples/grid/GridNesting.tsx
@@ -7,25 +7,25 @@
 
 import React from 'react';
 import { MD } from '@zendeskgarden/react-typography';
-import { Grid, Row, Col } from '@zendeskgarden/react-grid';
+import { Grid } from '@zendeskgarden/react-grid';
 
 const Example = () => (
   <Grid debug>
-    <Row>
-      <Col sm={9}>
+    <Grid.Row>
+      <Grid.Col sm={9}>
         <MD>
           Level 1: Col[sm=9]
-          <Row>
-            <Col size={8} sm={6}>
+          <Grid.Row>
+            <Grid.Col size={8} sm={6}>
               <MD>Level 2: Col[size=8][sm=6]</MD>
-            </Col>
-            <Col size={4} sm={6}>
+            </Grid.Col>
+            <Grid.Col size={4} sm={6}>
               <MD>Level 2: Col[size=4][sm=6]</MD>
-            </Col>
-          </Row>
+            </Grid.Col>
+          </Grid.Row>
         </MD>
-      </Col>
-    </Row>
+      </Grid.Col>
+    </Grid.Row>
   </Grid>
 );
 

--- a/src/examples/grid/GridNesting.tsx
+++ b/src/examples/grid/GridNesting.tsx
@@ -6,17 +6,11 @@
  */
 
 import React from 'react';
-import styled from 'styled-components';
-import { getColor } from '@zendeskgarden/react-theming';
 import { MD } from '@zendeskgarden/react-typography';
 import { Grid } from '@zendeskgarden/react-grid';
 
-const StyledGrid = styled(Grid)`
-  color: ${p => getColor({ variable: 'foreground.default', theme: p.theme })};
-`;
-
 const Example = () => (
-  <StyledGrid debug>
+  <Grid debug>
     <Grid.Row>
       <Grid.Col sm={9}>
         <MD>
@@ -32,7 +26,7 @@ const Example = () => (
         </MD>
       </Grid.Col>
     </Grid.Row>
-  </StyledGrid>
+  </Grid>
 );
 
 export default Example;

--- a/src/examples/grid/GridNoGutters.tsx
+++ b/src/examples/grid/GridNoGutters.tsx
@@ -6,11 +6,17 @@
  */
 
 import React from 'react';
+import styled from 'styled-components';
+import { getColor } from '@zendeskgarden/react-theming';
 import { MD } from '@zendeskgarden/react-typography';
 import { Grid } from '@zendeskgarden/react-grid';
 
+const StyledGrid = styled(Grid)`
+  color: ${p => getColor({ variable: 'foreground.default', theme: p.theme })};
+`;
+
 const Example = () => (
-  <Grid gutters={false} debug>
+  <StyledGrid gutters={false} debug>
     <Grid.Row>
       <Grid.Col size={12} sm={6} md={8}>
         <MD>Col[size=12][sm=6][md=8]</MD>
@@ -19,7 +25,7 @@ const Example = () => (
         <MD>Col[size=6][md=4]</MD>
       </Grid.Col>
     </Grid.Row>
-  </Grid>
+  </StyledGrid>
 );
 
 export default Example;

--- a/src/examples/grid/GridNoGutters.tsx
+++ b/src/examples/grid/GridNoGutters.tsx
@@ -7,18 +7,18 @@
 
 import React from 'react';
 import { MD } from '@zendeskgarden/react-typography';
-import { Grid, Row, Col } from '@zendeskgarden/react-grid';
+import { Grid } from '@zendeskgarden/react-grid';
 
 const Example = () => (
   <Grid gutters={false} debug>
-    <Row>
-      <Col size={12} sm={6} md={8}>
+    <Grid.Row>
+      <Grid.Col size={12} sm={6} md={8}>
         <MD>Col[size=12][sm=6][md=8]</MD>
-      </Col>
-      <Col size={6} md={4}>
+      </Grid.Col>
+      <Grid.Col size={6} md={4}>
         <MD>Col[size=6][md=4]</MD>
-      </Col>
-    </Row>
+      </Grid.Col>
+    </Grid.Row>
   </Grid>
 );
 

--- a/src/examples/grid/GridNoGutters.tsx
+++ b/src/examples/grid/GridNoGutters.tsx
@@ -6,17 +6,11 @@
  */
 
 import React from 'react';
-import styled from 'styled-components';
-import { getColor } from '@zendeskgarden/react-theming';
 import { MD } from '@zendeskgarden/react-typography';
 import { Grid } from '@zendeskgarden/react-grid';
 
-const StyledGrid = styled(Grid)`
-  color: ${p => getColor({ variable: 'foreground.default', theme: p.theme })};
-`;
-
 const Example = () => (
-  <StyledGrid gutters={false} debug>
+  <Grid gutters={false} debug>
     <Grid.Row>
       <Grid.Col size={12} sm={6} md={8}>
         <MD>Col[size=12][sm=6][md=8]</MD>
@@ -25,7 +19,7 @@ const Example = () => (
         <MD>Col[size=6][md=4]</MD>
       </Grid.Col>
     </Grid.Row>
-  </StyledGrid>
+  </Grid>
 );
 
 export default Example;

--- a/src/examples/grid/GridOffset.tsx
+++ b/src/examples/grid/GridOffset.tsx
@@ -6,17 +6,11 @@
  */
 
 import React from 'react';
-import styled from 'styled-components';
-import { getColor } from '@zendeskgarden/react-theming';
 import { MD } from '@zendeskgarden/react-typography';
 import { Grid } from '@zendeskgarden/react-grid';
 
-const StyledGrid = styled(Grid)`
-  color: ${p => getColor({ variable: 'foreground.default', theme: p.theme })};
-`;
-
 const Example = () => (
-  <StyledGrid debug>
+  <Grid debug>
     <Grid.Row>
       <Grid.Col md={4}>
         <MD>Col[md=4]</MD>
@@ -38,7 +32,7 @@ const Example = () => (
         <MD>Col[md=6][offsetMd=3]</MD>
       </Grid.Col>
     </Grid.Row>
-  </StyledGrid>
+  </Grid>
 );
 
 export default Example;

--- a/src/examples/grid/GridOffset.tsx
+++ b/src/examples/grid/GridOffset.tsx
@@ -6,11 +6,17 @@
  */
 
 import React from 'react';
+import styled from 'styled-components';
+import { getColor } from '@zendeskgarden/react-theming';
 import { MD } from '@zendeskgarden/react-typography';
 import { Grid } from '@zendeskgarden/react-grid';
 
+const StyledGrid = styled(Grid)`
+  color: ${p => getColor({ variable: 'foreground.default', theme: p.theme })};
+`;
+
 const Example = () => (
-  <Grid debug>
+  <StyledGrid debug>
     <Grid.Row>
       <Grid.Col md={4}>
         <MD>Col[md=4]</MD>
@@ -32,7 +38,7 @@ const Example = () => (
         <MD>Col[md=6][offsetMd=3]</MD>
       </Grid.Col>
     </Grid.Row>
-  </Grid>
+  </StyledGrid>
 );
 
 export default Example;

--- a/src/examples/grid/GridOffset.tsx
+++ b/src/examples/grid/GridOffset.tsx
@@ -7,31 +7,31 @@
 
 import React from 'react';
 import { MD } from '@zendeskgarden/react-typography';
-import { Grid, Row, Col } from '@zendeskgarden/react-grid';
+import { Grid } from '@zendeskgarden/react-grid';
 
 const Example = () => (
   <Grid debug>
-    <Row>
-      <Col md={4}>
+    <Grid.Row>
+      <Grid.Col md={4}>
         <MD>Col[md=4]</MD>
-      </Col>
-      <Col md={4} offsetMd={4}>
+      </Grid.Col>
+      <Grid.Col md={4} offsetMd={4}>
         <MD>Col[md=4][offsetMd=4]</MD>
-      </Col>
-    </Row>
-    <Row>
-      <Col md={3} offsetMd={3}>
+      </Grid.Col>
+    </Grid.Row>
+    <Grid.Row>
+      <Grid.Col md={3} offsetMd={3}>
         <MD>Col[md=3][offsetMd=3]</MD>
-      </Col>
-      <Col md={3} offsetMd={3}>
+      </Grid.Col>
+      <Grid.Col md={3} offsetMd={3}>
         <MD>Col[md=3][offsetMd=3]</MD>
-      </Col>
-    </Row>
-    <Row>
-      <Col md={6} offsetMd={3}>
+      </Grid.Col>
+    </Grid.Row>
+    <Grid.Row>
+      <Grid.Col md={6} offsetMd={3}>
         <MD>Col[md=6][offsetMd=3]</MD>
-      </Col>
-    </Row>
+      </Grid.Col>
+    </Grid.Row>
   </Grid>
 );
 

--- a/src/examples/grid/GridOneCol.tsx
+++ b/src/examples/grid/GridOneCol.tsx
@@ -7,32 +7,32 @@
 
 import React from 'react';
 import { MD } from '@zendeskgarden/react-typography';
-import { Grid, Row, Col } from '@zendeskgarden/react-grid';
+import { Grid } from '@zendeskgarden/react-grid';
 
 const Example = () => (
   <Grid debug>
-    <Row>
-      <Col>
+    <Grid.Row>
+      <Grid.Col>
         <MD>1 of 3</MD>
-      </Col>
-      <Col size={6}>
+      </Grid.Col>
+      <Grid.Col size={6}>
         <MD>2 of 3 (wider)</MD>
-      </Col>
-      <Col>
+      </Grid.Col>
+      <Grid.Col>
         <MD>3 of 3</MD>
-      </Col>
-    </Row>
-    <Row>
-      <Col>
+      </Grid.Col>
+    </Grid.Row>
+    <Grid.Row>
+      <Grid.Col>
         <MD>1 of 3</MD>
-      </Col>
-      <Col size={5}>
+      </Grid.Col>
+      <Grid.Col size={5}>
         <MD>2 of 3 (wider)</MD>
-      </Col>
-      <Col>
+      </Grid.Col>
+      <Grid.Col>
         <MD>3 of 3</MD>
-      </Col>
-    </Row>
+      </Grid.Col>
+    </Grid.Row>
   </Grid>
 );
 

--- a/src/examples/grid/GridOneCol.tsx
+++ b/src/examples/grid/GridOneCol.tsx
@@ -6,17 +6,11 @@
  */
 
 import React from 'react';
-import styled from 'styled-components';
-import { getColor } from '@zendeskgarden/react-theming';
 import { MD } from '@zendeskgarden/react-typography';
 import { Grid } from '@zendeskgarden/react-grid';
 
-const StyledGrid = styled(Grid)`
-  color: ${p => getColor({ variable: 'foreground.default', theme: p.theme })};
-`;
-
 const Example = () => (
-  <StyledGrid debug>
+  <Grid debug>
     <Grid.Row>
       <Grid.Col>
         <MD>1 of 3</MD>
@@ -39,7 +33,7 @@ const Example = () => (
         <MD>3 of 3</MD>
       </Grid.Col>
     </Grid.Row>
-  </StyledGrid>
+  </Grid>
 );
 
 export default Example;

--- a/src/examples/grid/GridOneCol.tsx
+++ b/src/examples/grid/GridOneCol.tsx
@@ -6,11 +6,17 @@
  */
 
 import React from 'react';
+import styled from 'styled-components';
+import { getColor } from '@zendeskgarden/react-theming';
 import { MD } from '@zendeskgarden/react-typography';
 import { Grid } from '@zendeskgarden/react-grid';
 
+const StyledGrid = styled(Grid)`
+  color: ${p => getColor({ variable: 'foreground.default', theme: p.theme })};
+`;
+
 const Example = () => (
-  <Grid debug>
+  <StyledGrid debug>
     <Grid.Row>
       <Grid.Col>
         <MD>1 of 3</MD>
@@ -33,7 +39,7 @@ const Example = () => (
         <MD>3 of 3</MD>
       </Grid.Col>
     </Grid.Row>
-  </Grid>
+  </StyledGrid>
 );
 
 export default Example;

--- a/src/examples/grid/GridReordering.tsx
+++ b/src/examples/grid/GridReordering.tsx
@@ -6,17 +6,11 @@
  */
 
 import React from 'react';
-import styled from 'styled-components';
-import { getColor } from '@zendeskgarden/react-theming';
 import { MD } from '@zendeskgarden/react-typography';
 import { Grid } from '@zendeskgarden/react-grid';
 
-const StyledGrid = styled(Grid)`
-  color: ${p => getColor({ variable: 'foreground.default', theme: p.theme })};
-`;
-
 const Example = () => (
-  <StyledGrid debug>
+  <Grid debug>
     <Grid.Row>
       <Grid.Col>
         <MD>First, but unordered</MD>
@@ -39,7 +33,7 @@ const Example = () => (
         <MD>Third, but first</MD>
       </Grid.Col>
     </Grid.Row>
-  </StyledGrid>
+  </Grid>
 );
 
 export default Example;

--- a/src/examples/grid/GridReordering.tsx
+++ b/src/examples/grid/GridReordering.tsx
@@ -7,32 +7,32 @@
 
 import React from 'react';
 import { MD } from '@zendeskgarden/react-typography';
-import { Grid, Row, Col } from '@zendeskgarden/react-grid';
+import { Grid } from '@zendeskgarden/react-grid';
 
 const Example = () => (
   <Grid debug>
-    <Row>
-      <Col>
+    <Grid.Row>
+      <Grid.Col>
         <MD>First, but unordered</MD>
-      </Col>
-      <Col order="12">
+      </Grid.Col>
+      <Grid.Col order="12">
         <MD>Second, but last</MD>
-      </Col>
-      <Col order="1">
+      </Grid.Col>
+      <Grid.Col order="1">
         <MD>Third, but first</MD>
-      </Col>
-    </Row>
-    <Row>
-      <Col order="last">
+      </Grid.Col>
+    </Grid.Row>
+    <Grid.Row>
+      <Grid.Col order="last">
         <MD>First, but last</MD>
-      </Col>
-      <Col>
+      </Grid.Col>
+      <Grid.Col>
         <MD>Second, but unordered</MD>
-      </Col>
-      <Col order="first">
+      </Grid.Col>
+      <Grid.Col order="first">
         <MD>Third, but first</MD>
-      </Col>
-    </Row>
+      </Grid.Col>
+    </Grid.Row>
   </Grid>
 );
 

--- a/src/examples/grid/GridReordering.tsx
+++ b/src/examples/grid/GridReordering.tsx
@@ -6,11 +6,17 @@
  */
 
 import React from 'react';
+import styled from 'styled-components';
+import { getColor } from '@zendeskgarden/react-theming';
 import { MD } from '@zendeskgarden/react-typography';
 import { Grid } from '@zendeskgarden/react-grid';
 
+const StyledGrid = styled(Grid)`
+  color: ${p => getColor({ variable: 'foreground.default', theme: p.theme })};
+`;
+
 const Example = () => (
-  <Grid debug>
+  <StyledGrid debug>
     <Grid.Row>
       <Grid.Col>
         <MD>First, but unordered</MD>
@@ -33,7 +39,7 @@ const Example = () => (
         <MD>Third, but first</MD>
       </Grid.Col>
     </Grid.Row>
-  </Grid>
+  </StyledGrid>
 );
 
 export default Example;

--- a/src/examples/grid/GridStacked.tsx
+++ b/src/examples/grid/GridStacked.tsx
@@ -6,17 +6,11 @@
  */
 
 import React from 'react';
-import styled from 'styled-components';
-import { getColor } from '@zendeskgarden/react-theming';
 import { MD } from '@zendeskgarden/react-typography';
 import { Grid } from '@zendeskgarden/react-grid';
 
-const StyledGrid = styled(Grid)`
-  color: ${p => getColor({ variable: 'foreground.default', theme: p.theme })};
-`;
-
 const Example = () => (
-  <StyledGrid debug>
+  <Grid debug>
     <Grid.Row>
       <Grid.Col sm={8}>
         <MD>Col[sm=8]</MD>
@@ -36,7 +30,7 @@ const Example = () => (
         <MD>Col[sm]</MD>
       </Grid.Col>
     </Grid.Row>
-  </StyledGrid>
+  </Grid>
 );
 
 export default Example;

--- a/src/examples/grid/GridStacked.tsx
+++ b/src/examples/grid/GridStacked.tsx
@@ -6,11 +6,17 @@
  */
 
 import React from 'react';
+import styled from 'styled-components';
+import { getColor } from '@zendeskgarden/react-theming';
 import { MD } from '@zendeskgarden/react-typography';
 import { Grid } from '@zendeskgarden/react-grid';
 
+const StyledGrid = styled(Grid)`
+  color: ${p => getColor({ variable: 'foreground.default', theme: p.theme })};
+`;
+
 const Example = () => (
-  <Grid debug>
+  <StyledGrid debug>
     <Grid.Row>
       <Grid.Col sm={8}>
         <MD>Col[sm=8]</MD>
@@ -30,7 +36,7 @@ const Example = () => (
         <MD>Col[sm]</MD>
       </Grid.Col>
     </Grid.Row>
-  </Grid>
+  </StyledGrid>
 );
 
 export default Example;

--- a/src/examples/grid/GridStacked.tsx
+++ b/src/examples/grid/GridStacked.tsx
@@ -7,29 +7,29 @@
 
 import React from 'react';
 import { MD } from '@zendeskgarden/react-typography';
-import { Grid, Row, Col } from '@zendeskgarden/react-grid';
+import { Grid } from '@zendeskgarden/react-grid';
 
 const Example = () => (
   <Grid debug>
-    <Row>
-      <Col sm={8}>
+    <Grid.Row>
+      <Grid.Col sm={8}>
         <MD>Col[sm=8]</MD>
-      </Col>
-      <Col sm={4}>
+      </Grid.Col>
+      <Grid.Col sm={4}>
         <MD>Col[sm=4]</MD>
-      </Col>
-    </Row>
-    <Row>
-      <Col sm>
+      </Grid.Col>
+    </Grid.Row>
+    <Grid.Row>
+      <Grid.Col sm>
         <MD>Col[sm]</MD>
-      </Col>
-      <Col sm>
+      </Grid.Col>
+      <Grid.Col sm>
         <MD>Col[sm]</MD>
-      </Col>
-      <Col sm>
+      </Grid.Col>
+      <Grid.Col sm>
         <MD>Col[sm]</MD>
-      </Col>
-    </Row>
+      </Grid.Col>
+    </Grid.Row>
   </Grid>
 );
 

--- a/src/examples/grid/GridVariable.tsx
+++ b/src/examples/grid/GridVariable.tsx
@@ -7,32 +7,32 @@
 
 import React from 'react';
 import { MD } from '@zendeskgarden/react-typography';
-import { Grid, Row, Col } from '@zendeskgarden/react-grid';
+import { Grid } from '@zendeskgarden/react-grid';
 
 const Example = () => (
   <Grid debug>
-    <Row justifyContentMd="center">
-      <Col xs lg={2}>
+    <Grid.Row justifyContentMd="center">
+      <Grid.Col xs lg={2}>
         <MD>1 of 3</MD>
-      </Col>
-      <Col md="auto">
+      </Grid.Col>
+      <Grid.Col md="auto">
         <MD>Variable width content</MD>
-      </Col>
-      <Col xs lg={2}>
+      </Grid.Col>
+      <Grid.Col xs lg={2}>
         <MD>3 of 3</MD>
-      </Col>
-    </Row>
-    <Row justifyContent="center">
-      <Col>
+      </Grid.Col>
+    </Grid.Row>
+    <Grid.Row justifyContent="center">
+      <Grid.Col>
         <MD>1 of 3</MD>
-      </Col>
-      <Col md="auto">
+      </Grid.Col>
+      <Grid.Col md="auto">
         <MD>Variable width content</MD>
-      </Col>
-      <Col xs lg={2}>
+      </Grid.Col>
+      <Grid.Col xs lg={2}>
         <MD>3 of 3</MD>
-      </Col>
-    </Row>
+      </Grid.Col>
+    </Grid.Row>
   </Grid>
 );
 

--- a/src/examples/grid/GridVariable.tsx
+++ b/src/examples/grid/GridVariable.tsx
@@ -6,11 +6,17 @@
  */
 
 import React from 'react';
+import styled from 'styled-components';
+import { getColor } from '@zendeskgarden/react-theming';
 import { MD } from '@zendeskgarden/react-typography';
 import { Grid } from '@zendeskgarden/react-grid';
 
+const StyledGrid = styled(Grid)`
+  color: ${p => getColor({ variable: 'foreground.default', theme: p.theme })};
+`;
+
 const Example = () => (
-  <Grid debug>
+  <StyledGrid debug>
     <Grid.Row justifyContentMd="center">
       <Grid.Col xs lg={2}>
         <MD>1 of 3</MD>
@@ -33,7 +39,7 @@ const Example = () => (
         <MD>3 of 3</MD>
       </Grid.Col>
     </Grid.Row>
-  </Grid>
+  </StyledGrid>
 );
 
 export default Example;

--- a/src/examples/grid/GridVariable.tsx
+++ b/src/examples/grid/GridVariable.tsx
@@ -6,17 +6,11 @@
  */
 
 import React from 'react';
-import styled from 'styled-components';
-import { getColor } from '@zendeskgarden/react-theming';
 import { MD } from '@zendeskgarden/react-typography';
 import { Grid } from '@zendeskgarden/react-grid';
 
-const StyledGrid = styled(Grid)`
-  color: ${p => getColor({ variable: 'foreground.default', theme: p.theme })};
-`;
-
 const Example = () => (
-  <StyledGrid debug>
+  <Grid debug>
     <Grid.Row justifyContentMd="center">
       <Grid.Col xs lg={2}>
         <MD>1 of 3</MD>
@@ -39,7 +33,7 @@ const Example = () => (
         <MD>3 of 3</MD>
       </Grid.Col>
     </Grid.Row>
-  </StyledGrid>
+  </Grid>
 );
 
 export default Example;

--- a/src/examples/grid/GridVertical.tsx
+++ b/src/examples/grid/GridVertical.tsx
@@ -7,43 +7,43 @@
 
 import React from 'react';
 import { MD } from '@zendeskgarden/react-typography';
-import { Grid, Row, Col } from '@zendeskgarden/react-grid';
+import { Grid } from '@zendeskgarden/react-grid';
 
 const Example = () => (
   <Grid debug>
-    <Row alignItems="start" style={{ minHeight: '5em' }}>
-      <Col>
+    <Grid.Row alignItems="start" style={{ minHeight: '5em' }}>
+      <Grid.Col>
         <MD>One of three columns</MD>
-      </Col>
-      <Col>
+      </Grid.Col>
+      <Grid.Col>
         <MD>One of three columns</MD>
-      </Col>
-      <Col>
+      </Grid.Col>
+      <Grid.Col>
         <MD>One of three columns</MD>
-      </Col>
-    </Row>
-    <Row alignItems="center" style={{ minHeight: '5em' }}>
-      <Col>
+      </Grid.Col>
+    </Grid.Row>
+    <Grid.Row alignItems="center" style={{ minHeight: '5em' }}>
+      <Grid.Col>
         <MD>One of three columns</MD>
-      </Col>
-      <Col>
+      </Grid.Col>
+      <Grid.Col>
         <MD>One of three columns</MD>
-      </Col>
-      <Col>
+      </Grid.Col>
+      <Grid.Col>
         <MD>One of three columns</MD>
-      </Col>
-    </Row>
-    <Row alignItems="end" style={{ minHeight: '5em' }}>
-      <Col>
+      </Grid.Col>
+    </Grid.Row>
+    <Grid.Row alignItems="end" style={{ minHeight: '5em' }}>
+      <Grid.Col>
         <MD>One of three columns</MD>
-      </Col>
-      <Col>
+      </Grid.Col>
+      <Grid.Col>
         <MD>One of three columns</MD>
-      </Col>
-      <Col>
+      </Grid.Col>
+      <Grid.Col>
         <MD>One of three columns</MD>
-      </Col>
-    </Row>
+      </Grid.Col>
+    </Grid.Row>
   </Grid>
 );
 

--- a/src/examples/grid/GridVertical.tsx
+++ b/src/examples/grid/GridVertical.tsx
@@ -6,17 +6,11 @@
  */
 
 import React from 'react';
-import styled from 'styled-components';
-import { getColor } from '@zendeskgarden/react-theming';
 import { MD } from '@zendeskgarden/react-typography';
 import { Grid } from '@zendeskgarden/react-grid';
 
-const StyledGrid = styled(Grid)`
-  color: ${p => getColor({ variable: 'foreground.default', theme: p.theme })};
-`;
-
 const Example = () => (
-  <StyledGrid debug>
+  <Grid debug>
     <Grid.Row alignItems="start" style={{ minHeight: '5em' }}>
       <Grid.Col>
         <MD>One of three columns</MD>
@@ -50,7 +44,7 @@ const Example = () => (
         <MD>One of three columns</MD>
       </Grid.Col>
     </Grid.Row>
-  </StyledGrid>
+  </Grid>
 );
 
 export default Example;

--- a/src/examples/grid/GridVertical.tsx
+++ b/src/examples/grid/GridVertical.tsx
@@ -6,11 +6,17 @@
  */
 
 import React from 'react';
+import styled from 'styled-components';
+import { getColor } from '@zendeskgarden/react-theming';
 import { MD } from '@zendeskgarden/react-typography';
 import { Grid } from '@zendeskgarden/react-grid';
 
+const StyledGrid = styled(Grid)`
+  color: ${p => getColor({ variable: 'foreground.default', theme: p.theme })};
+`;
+
 const Example = () => (
-  <Grid debug>
+  <StyledGrid debug>
     <Grid.Row alignItems="start" style={{ minHeight: '5em' }}>
       <Grid.Col>
         <MD>One of three columns</MD>
@@ -44,7 +50,7 @@ const Example = () => (
         <MD>One of three columns</MD>
       </Grid.Col>
     </Grid.Row>
-  </Grid>
+  </StyledGrid>
 );
 
 export default Example;

--- a/src/examples/pane/PaneGrid.tsx
+++ b/src/examples/pane/PaneGrid.tsx
@@ -10,7 +10,6 @@ import { PaneProvider, Pane } from '@zendeskgarden/react-grid';
 import useResizeObserver from 'use-resize-observer';
 import { XL, Paragraph } from '@zendeskgarden/react-typography';
 import styled from 'styled-components';
-import { getColor } from '@zendeskgarden/react-theming';
 
 const StyledParagraph = styled(Paragraph)`
   margin-top: ${p => p.theme.space.xs};
@@ -19,7 +18,6 @@ const StyledParagraph = styled(Paragraph)`
 const StyledPaneContent = styled(Pane.Content)`
   padding: ${p => p.theme.space.base * 6}px ${p => p.theme.space.base * 6}px
     ${p => p.theme.space.base * 4}px;
-  color: ${p => getColor({ variable: 'foreground.default', theme: p.theme })};
 `;
 
 const Example = () => {

--- a/src/examples/pane/PaneGrid.tsx
+++ b/src/examples/pane/PaneGrid.tsx
@@ -10,6 +10,7 @@ import { PaneProvider, Pane } from '@zendeskgarden/react-grid';
 import useResizeObserver from 'use-resize-observer';
 import { XL, Paragraph } from '@zendeskgarden/react-typography';
 import styled from 'styled-components';
+import { getColor } from '@zendeskgarden/react-theming';
 
 const StyledParagraph = styled(Paragraph)`
   margin-top: ${p => p.theme.space.xs};
@@ -18,6 +19,7 @@ const StyledParagraph = styled(Paragraph)`
 const StyledPaneContent = styled(Pane.Content)`
   padding: ${p => p.theme.space.base * 6}px ${p => p.theme.space.base * 6}px
     ${p => p.theme.space.base * 4}px;
+  color: ${p => getColor({ variable: 'foreground.default', theme: p.theme })};
 `;
 
 const Example = () => {

--- a/src/examples/pane/PaneHorizontal.tsx
+++ b/src/examples/pane/PaneHorizontal.tsx
@@ -17,7 +17,6 @@ const StyledPaneContent = styled(Pane.Content)<{ isSecondary?: boolean }>`
     p.isSecondary && getColor({ variable: 'background.subtle', theme: p.theme })};
   padding: ${p => p.theme.space.base * 6}px ${p => p.theme.space.base * 6}px
     ${p => p.theme.space.base * 4}px;
-  color: ${p => getColor({ variable: 'foreground.default', theme: p.theme })};
 `;
 
 const StyledParagraph = styled(Paragraph)`

--- a/src/examples/pane/PaneHorizontal.tsx
+++ b/src/examples/pane/PaneHorizontal.tsx
@@ -9,13 +9,15 @@ import React from 'react';
 import { PaneProvider, Pane } from '@zendeskgarden/react-grid';
 import useResizeObserver from 'use-resize-observer';
 import { XL, Paragraph } from '@zendeskgarden/react-typography';
-import { getColorV8 } from '@zendeskgarden/react-theming';
+import { getColor } from '@zendeskgarden/react-theming';
 import styled from 'styled-components';
 
 const StyledPaneContent = styled(Pane.Content)<{ isSecondary?: boolean }>`
+  background-color: ${p =>
+    p.isSecondary && getColor({ variable: 'background.subtle', theme: p.theme })};
   padding: ${p => p.theme.space.base * 6}px ${p => p.theme.space.base * 6}px
     ${p => p.theme.space.base * 4}px;
-  ${p => p.isSecondary && `background-color: ${getColorV8('neutralHue', 100, p.theme)}`};
+  color: ${p => getColor({ variable: 'foreground.default', theme: p.theme })};
 `;
 
 const StyledParagraph = styled(Paragraph)`

--- a/src/examples/pane/PaneHorizontalCollapse.tsx
+++ b/src/examples/pane/PaneHorizontalCollapse.tsx
@@ -9,7 +9,7 @@ import React from 'react';
 import { PaneProvider, Pane } from '@zendeskgarden/react-grid';
 import useResizeObserver from 'use-resize-observer';
 import { XL, Paragraph } from '@zendeskgarden/react-typography';
-import { getColorV8 } from '@zendeskgarden/react-theming';
+import { getColor } from '@zendeskgarden/react-theming';
 import styled from 'styled-components';
 
 const StyledDiv = styled.div`
@@ -23,7 +23,9 @@ const StyledParagraph = styled(Paragraph)`
 `;
 
 const StyledPane = styled(Pane)<{ isSecondary?: boolean }>`
-  ${p => p.isSecondary && `background-color: ${getColorV8('neutralHue', 100, p.theme)}`};
+  background-color: ${p =>
+    p.isSecondary && getColor({ variable: 'background.subtle', theme: p.theme })};
+  color: ${p => getColor({ variable: 'foreground.default', theme: p.theme })};
 `;
 
 const Example = () => {

--- a/src/examples/pane/PaneHorizontalCollapse.tsx
+++ b/src/examples/pane/PaneHorizontalCollapse.tsx
@@ -25,7 +25,6 @@ const StyledParagraph = styled(Paragraph)`
 const StyledPane = styled(Pane)<{ isSecondary?: boolean }>`
   background-color: ${p =>
     p.isSecondary && getColor({ variable: 'background.subtle', theme: p.theme })};
-  color: ${p => getColor({ variable: 'foreground.default', theme: p.theme })};
 `;
 
 const Example = () => {

--- a/src/examples/pane/PaneVertical.tsx
+++ b/src/examples/pane/PaneVertical.tsx
@@ -9,13 +9,15 @@ import React from 'react';
 import { PaneProvider, Pane } from '@zendeskgarden/react-grid';
 import useResizeObserver from 'use-resize-observer';
 import { XL, Paragraph } from '@zendeskgarden/react-typography';
-import { getColorV8 } from '@zendeskgarden/react-theming';
+import { getColor } from '@zendeskgarden/react-theming';
 import styled from 'styled-components';
 
 const StyledPaneContent = styled(Pane.Content)<{ isSecondary?: boolean }>`
+  background-color: ${p =>
+    p.isSecondary && getColor({ variable: 'background.subtle', theme: p.theme })};
   padding: ${p => p.theme.space.base * 6}px;
   height: 240px;
-  ${p => p.isSecondary && `background-color: ${getColorV8('neutralHue', 100, p.theme)}`};
+  color: ${p => getColor({ variable: 'foreground.default', theme: p.theme })};
 `;
 
 const StyledParagraph = styled(Paragraph)`

--- a/src/examples/pane/PaneVertical.tsx
+++ b/src/examples/pane/PaneVertical.tsx
@@ -17,7 +17,6 @@ const StyledPaneContent = styled(Pane.Content)<{ isSecondary?: boolean }>`
     p.isSecondary && getColor({ variable: 'background.subtle', theme: p.theme })};
   padding: ${p => p.theme.space.base * 6}px;
   height: 240px;
-  color: ${p => getColor({ variable: 'foreground.default', theme: p.theme })};
 `;
 
 const StyledParagraph = styled(Paragraph)`

--- a/src/examples/pane/PaneVerticalCollapse.tsx
+++ b/src/examples/pane/PaneVerticalCollapse.tsx
@@ -9,7 +9,7 @@ import React from 'react';
 import { PaneProvider, Pane } from '@zendeskgarden/react-grid';
 import useResizeObserver from 'use-resize-observer';
 import { XL, Paragraph } from '@zendeskgarden/react-typography';
-import { getColorV8 } from '@zendeskgarden/react-theming';
+import { getColor } from '@zendeskgarden/react-theming';
 import styled from 'styled-components';
 
 const StyledParagraph = styled(Paragraph)`
@@ -21,8 +21,10 @@ const StyledPaneContent = styled(Pane.Content)`
 `;
 
 const StyledPane = styled(Pane)<{ isSecondary?: boolean }>`
+  background-color: ${p =>
+    p.isSecondary && getColor({ variable: 'background.subtle', theme: p.theme })};
   padding: ${p => p.theme.space.base * 6}px;
-  ${p => p.isSecondary && `background-color: ${getColorV8('neutralHue', 100, p.theme)}`};
+  color: ${p => getColor({ variable: 'foreground.default', theme: p.theme })};
 `;
 
 const Example = () => {

--- a/src/examples/pane/PaneVerticalCollapse.tsx
+++ b/src/examples/pane/PaneVerticalCollapse.tsx
@@ -24,7 +24,6 @@ const StyledPane = styled(Pane)<{ isSecondary?: boolean }>`
   background-color: ${p =>
     p.isSecondary && getColor({ variable: 'background.subtle', theme: p.theme })};
   padding: ${p => p.theme.space.base * 6}px;
-  color: ${p => getColor({ variable: 'foreground.default', theme: p.theme })};
 `;
 
 const Example = () => {

--- a/src/examples/pane/SplitterButtonPosition.tsx
+++ b/src/examples/pane/SplitterButtonPosition.tsx
@@ -10,7 +10,7 @@ import { PaneProvider, Pane } from '@zendeskgarden/react-grid';
 import useResizeObserver from 'use-resize-observer';
 import { XL, XXL, Paragraph } from '@zendeskgarden/react-typography';
 import styled from 'styled-components';
-import { getColorV8 } from '@zendeskgarden/react-theming';
+import { getColor } from '@zendeskgarden/react-theming';
 
 const StyledDiv = styled.div`
   padding: ${p => p.theme.space.base * 6}px;
@@ -19,6 +19,7 @@ const StyledDiv = styled.div`
 const StyledXXL = styled(XXL)`
   margin-bottom: ${p => p.theme.space.base * 6}px;
   text-transform: capitalize;
+  color: ${p => getColor({ variable: 'foreground.default', theme: p.theme })};
 `;
 
 const StyledParagraph = styled(Paragraph)`
@@ -27,11 +28,12 @@ const StyledParagraph = styled(Paragraph)`
 
 const StyledPaneContent = styled(Pane.Content)`
   height: 180px;
+  color: ${p => getColor({ variable: 'foreground.default', theme: p.theme })};
 `;
 
 const StyledPanesContainer = styled.div`
   & > :first-child {
-    background-color: ${p => getColorV8('neutralHue', 100, p.theme)};
+    background-color: ${p => getColor({ variable: 'background.subtle', theme: p.theme })};
   }
 
   &:not(:last-child) {

--- a/src/examples/pane/SplitterButtonPosition.tsx
+++ b/src/examples/pane/SplitterButtonPosition.tsx
@@ -19,7 +19,6 @@ const StyledDiv = styled.div`
 const StyledXXL = styled(XXL)`
   margin-bottom: ${p => p.theme.space.base * 6}px;
   text-transform: capitalize;
-  color: ${p => getColor({ variable: 'foreground.default', theme: p.theme })};
 `;
 
 const StyledParagraph = styled(Paragraph)`
@@ -28,7 +27,6 @@ const StyledParagraph = styled(Paragraph)`
 
 const StyledPaneContent = styled(Pane.Content)`
   height: 180px;
-  color: ${p => getColor({ variable: 'foreground.default', theme: p.theme })};
 `;
 
 const StyledPanesContainer = styled.div`


### PR DESCRIPTION
<!-- structure the Title above as the first line of a
  https://conventionalcommits.org/ message. example: "chore:
  add a new 'thing' component page". -->

## Description

Updates Pane and Grid pages to support v9 changes.

## Detail

**Migration guide changes:**
- [x] Updates `Grid` subcomponent properties

**Demo-specific changes:**
- [x] Support light/dark foreground/background in examples

**Completed in previous PRs:**
- Updates to MDX files

## Demo

**Grid**

https://github.com/user-attachments/assets/cab8805f-3a2e-4728-8e06-a070b32e0eb9

**Pane**

https://github.com/user-attachments/assets/f0251620-2d8f-463a-8bf4-576396f4d963

## Checklist

- ~~:ok_hand: website updates are Garden Designer approved (add the designer as a reviewer)~~
- ~~:black_nib: copy updates are approved (add the content strategist as a reviewer)~~
- ~~:link: considered opportunities for adding cross-reference URLs (grep for keywords)~~
- ~~:wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver~~
- ~~:memo: tested in Chrome, Firefox, Safari, Edge~~
