### PR TITLE
feat(components): update `tabs` to v9

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -42,7 +42,7 @@
         "@zendeskgarden/react-notifications": "9.0.0-next.21",
         "@zendeskgarden/react-pagination": "8.76.3",
         "@zendeskgarden/react-tables": "9.0.0-next.21",
-        "@zendeskgarden/react-tabs": "8.76.3",
+        "@zendeskgarden/react-tabs": "9.0.0-next.21",
         "@zendeskgarden/react-tags": "8.76.3",
         "@zendeskgarden/react-theming": "9.0.0-next.21",
         "@zendeskgarden/react-tooltips": "9.0.0-next.21",
@@ -7303,23 +7303,32 @@
       }
     },
     "node_modules/@zendeskgarden/react-tabs": {
-      "version": "8.76.3",
-      "resolved": "https://registry.npmjs.org/@zendeskgarden/react-tabs/-/react-tabs-8.76.3.tgz",
-      "integrity": "sha512-Wk9PPOKJdgH4JD0V5VeHNhRzMSPdYUGoA8g/UwUy9wuw/R29SnHSCxhsngguQ+uTciVrDybKZauHY25AE6jZqQ==",
+      "version": "9.0.0-next.21",
+      "resolved": "https://registry.npmjs.org/@zendeskgarden/react-tabs/-/react-tabs-9.0.0-next.21.tgz",
+      "integrity": "sha512-POdqqpib/h5QyzIpjTGHIeyI/xdRj9Q6hjS60LqCPG/l04BQEZ1ryJy53boj4sLyLkB+vp5VzfS1UzX3PmRNyQ==",
       "dev": true,
-      "license": "Apache-2.0",
       "dependencies": {
         "@zendeskgarden/container-tabs": "^2.0.10",
         "@zendeskgarden/container-utilities": "^2.0.0",
         "polished": "^4.3.1",
         "prop-types": "^15.5.7",
-        "react-merge-refs": "^1.1.0"
+        "react-merge-refs": "^2.0.0"
       },
       "peerDependencies": {
-        "@zendeskgarden/react-theming": "^8.75.0",
+        "@zendeskgarden/react-theming": ">=9.0.0-next",
         "react": ">=16.8.0",
         "react-dom": ">=16.8.0",
-        "styled-components": "^4.2.0 || ^5.0.0"
+        "styled-components": "^5.3.1"
+      }
+    },
+    "node_modules/@zendeskgarden/react-tabs/node_modules/react-merge-refs": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/react-merge-refs/-/react-merge-refs-2.1.1.tgz",
+      "integrity": "sha512-jLQXJ/URln51zskhgppGJ2ub7b2WFKGq3cl3NYKtlHoTG+dN2q7EzWrn3hN3EgPsTMvpR9tpq5ijdp7YwFZkag==",
+      "dev": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/gregberge"
       }
     },
     "node_modules/@zendeskgarden/react-tags": {

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "@zendeskgarden/react-notifications": "9.0.0-next.21",
     "@zendeskgarden/react-pagination": "8.76.3",
     "@zendeskgarden/react-tables": "9.0.0-next.21",
-    "@zendeskgarden/react-tabs": "8.76.3",
+    "@zendeskgarden/react-tabs": "9.0.0-next.21",
     "@zendeskgarden/react-tags": "8.76.3",
     "@zendeskgarden/react-theming": "9.0.0-next.21",
     "@zendeskgarden/react-tooltips": "9.0.0-next.21",

--- a/src/components/MarkdownProvider/components/CodeExample/index.tsx
+++ b/src/components/MarkdownProvider/components/CodeExample/index.tsx
@@ -128,6 +128,7 @@ export const CodeExample: React.FC<ICodeExampleProps> = ({ children, code }) => 
             border-top-right-radius: ${props => math(`${props.theme.borderRadii.md} - 1px`)};
             background-color: ${p => getColor({ theme: p.theme, variable: 'background.default' })};
             padding: ${p => p.theme.space.md};
+            color: ${p => getColor({ theme: p.theme, variable: 'foreground.default' })};
             direction: ${p => p.theme.rtl && 'rtl'};
           `}
         >

--- a/src/examples/tabs/TabsDefault.tsx
+++ b/src/examples/tabs/TabsDefault.tsx
@@ -6,32 +6,32 @@
  */
 
 import React, { useState } from 'react';
-import { Tabs, TabList, Tab, TabPanel } from '@zendeskgarden/react-tabs';
+import { Tabs } from '@zendeskgarden/react-tabs';
 
 const Example = () => {
   const [selectedTab, setSelectedTab] = useState('tab-1');
 
   return (
     <Tabs selectedItem={selectedTab} onChange={setSelectedTab}>
-      <TabList>
-        <Tab item="tab-1">Elm</Tab>
-        <Tab item="tab-2">Sugar Maple</Tab>
-        <Tab item="tab-3">Dogwood</Tab>
-      </TabList>
-      <TabPanel item="tab-1">
+      <Tabs.TabList>
+        <Tabs.Tab item="tab-1">Elm</Tabs.Tab>
+        <Tabs.Tab item="tab-2">Sugar Maple</Tabs.Tab>
+        <Tabs.Tab item="tab-3">Dogwood</Tabs.Tab>
+      </Tabs.TabList>
+      <Tabs.TabPanel item="tab-1">
         Elms are deciduous and semi-deciduous trees comprising the flowering plant genus Ulmus in
         the plant family Ulmaceae.
-      </TabPanel>
-      <TabPanel item="tab-2">
+      </Tabs.TabPanel>
+      <Tabs.TabPanel item="tab-2">
         The sugar maple is one of America’s most-loved trees. In fact, more states have claimed it
         as their state tree than any other single species—for New York, West Virginia, Wisconsin,
         and Vermont, the maple tree stands alone.
-      </TabPanel>
-      <TabPanel item="tab-3">
+      </Tabs.TabPanel>
+      <Tabs.TabPanel item="tab-3">
         Cornus is a genus of about 30–60 species of woody plants in the family Cornaceae, commonly
         known as dogwoods, which can generally be distinguished by their blossoms, berries, and
         distinctive bark.
-      </TabPanel>
+      </Tabs.TabPanel>
     </Tabs>
   );
 };

--- a/src/examples/tabs/TabsDisabled.tsx
+++ b/src/examples/tabs/TabsDisabled.tsx
@@ -6,36 +6,36 @@
  */
 
 import React, { useState } from 'react';
-import { Tabs, TabList, Tab, TabPanel } from '@zendeskgarden/react-tabs';
+import { Tabs } from '@zendeskgarden/react-tabs';
 
 const Example = () => {
   const [selectedTab, setSelectedTab] = useState('tab-1');
 
   return (
     <Tabs selectedItem={selectedTab} onChange={setSelectedTab}>
-      <TabList>
-        <Tab item="tab-1">Elm</Tab>
-        <Tab item="tab-2" disabled>
+      <Tabs.TabList>
+        <Tabs.Tab item="tab-1">Elm</Tabs.Tab>
+        <Tabs.Tab item="tab-2" disabled>
           Sugar Maple
-        </Tab>
-        <Tab item="tab-3" disabled>
+        </Tabs.Tab>
+        <Tabs.Tab item="tab-3" disabled>
           Dogwood
-        </Tab>
-      </TabList>
-      <TabPanel item="tab-1">
+        </Tabs.Tab>
+      </Tabs.TabList>
+      <Tabs.TabPanel item="tab-1">
         Elms are deciduous and semi-deciduous trees comprising the flowering plant genus Ulmus in
         the plant family Ulmaceae.
-      </TabPanel>
-      <TabPanel item="tab-2">
+      </Tabs.TabPanel>
+      <Tabs.TabPanel item="tab-2">
         The sugar maple is one of America’s most-loved trees. In fact, more states have claimed it
         as their state tree than any other single species—for New York, West Virginia, Wisconsin,
         and Vermont, the maple tree stands alone.
-      </TabPanel>
-      <TabPanel item="tab-3">
+      </Tabs.TabPanel>
+      <Tabs.TabPanel item="tab-3">
         Cornus is a genus of about 30–60 species of woody plants in the family Cornaceae, commonly
         known as dogwoods, which can generally be distinguished by their blossoms, berries, and
         distinctive bark.
-      </TabPanel>
+      </Tabs.TabPanel>
     </Tabs>
   );
 };

--- a/src/examples/tabs/TabsVertical.tsx
+++ b/src/examples/tabs/TabsVertical.tsx
@@ -6,32 +6,32 @@
  */
 
 import React, { useState } from 'react';
-import { Tabs, TabList, Tab, TabPanel } from '@zendeskgarden/react-tabs';
+import { Tabs } from '@zendeskgarden/react-tabs';
 
 const Example = () => {
   const [selectedTab, setSelectedTab] = useState('tab-1');
 
   return (
     <Tabs selectedItem={selectedTab} onChange={setSelectedTab} isVertical>
-      <TabList>
-        <Tab item="tab-1">Elm</Tab>
-        <Tab item="tab-2">Sugar Maple</Tab>
-        <Tab item="tab-3">Dogwood</Tab>
-      </TabList>
-      <TabPanel item="tab-1">
+      <Tabs.TabList>
+        <Tabs.Tab item="tab-1">Elm</Tabs.Tab>
+        <Tabs.Tab item="tab-2">Sugar Maple</Tabs.Tab>
+        <Tabs.Tab item="tab-3">Dogwood</Tabs.Tab>
+      </Tabs.TabList>
+      <Tabs.TabPanel item="tab-1">
         Elms are deciduous and semi-deciduous trees comprising the flowering plant genus Ulmus in
         the plant family Ulmaceae.
-      </TabPanel>
-      <TabPanel item="tab-2">
+      </Tabs.TabPanel>
+      <Tabs.TabPanel item="tab-2">
         The sugar maple is one of America’s most-loved trees. In fact, more states have claimed it
         as their state tree than any other single species—for New York, West Virginia, Wisconsin,
         and Vermont, the maple tree stands alone.
-      </TabPanel>
-      <TabPanel item="tab-3">
+      </Tabs.TabPanel>
+      <Tabs.TabPanel item="tab-3">
         Cornus is a genus of about 30–60 species of woody plants in the family Cornaceae, commonly
         known as dogwoods, which can generally be distinguished by their blossoms, berries, and
         distinctive bark.
-      </TabPanel>
+      </Tabs.TabPanel>
     </Tabs>
   );
 };

--- a/src/examples/theme-provider/ThemeProviderTargeting.tsx
+++ b/src/examples/theme-provider/ThemeProviderTargeting.tsx
@@ -7,7 +7,7 @@
 
 import React, { useState } from 'react';
 import { css, DefaultTheme } from 'styled-components';
-import { Tabs, TabList, Tab, TabPanel } from '@zendeskgarden/react-tabs';
+import { Tabs } from '@zendeskgarden/react-tabs';
 import { getColorV8, ThemeProvider } from '@zendeskgarden/react-theming';
 
 /* Each Garden example is wrapped by a <ThemeProvider> */
@@ -34,25 +34,25 @@ const Example = () => {
   return (
     <ThemeProvider theme={theme}>
       <Tabs selectedItem={selectedTab} onChange={setSelectedTab}>
-        <TabPanel item="tab-1">
+        <Tabs.TabPanel item="tab-1">
           Elms are deciduous and semi-deciduous trees comprising the flowering plant genus Ulmus in
           the plant family Ulmaceae.
-        </TabPanel>
-        <TabPanel item="tab-2">
+        </Tabs.TabPanel>
+        <Tabs.TabPanel item="tab-2">
           The sugar maple is one of America’s most-loved trees. In fact, more states have claimed it
           as their state tree than any other single species—for New York, West Virginia, Wisconsin,
           and Vermont, the maple tree stands alone.
-        </TabPanel>
-        <TabPanel item="tab-3">
+        </Tabs.TabPanel>
+        <Tabs.TabPanel item="tab-3">
           Cornus is a genus of about 30–60 species of woody plants in the family Cornaceae, commonly
           known as dogwoods, which can generally be distinguished by their blossoms, berries, and
           distinctive bark.
-        </TabPanel>
-        <TabList>
-          <Tab item="tab-1">Elm</Tab>
-          <Tab item="tab-2">Sugar Maple</Tab>
-          <Tab item="tab-3">Dogwood</Tab>
-        </TabList>
+        </Tabs.TabPanel>
+        <Tabs.TabList>
+          <Tabs.Tab item="tab-1">Elm</Tabs.Tab>
+          <Tabs.Tab item="tab-2">Sugar Maple</Tabs.Tab>
+          <Tabs.Tab item="tab-3">Dogwood</Tabs.Tab>
+        </Tabs.TabList>
       </Tabs>
     </ThemeProvider>
   );


### PR DESCRIPTION
## Description

Updates `react-tabs` to v9.

## Details
- Refactors examples to use `Tabs`' subComponent properties
- Set `CodeExample`’s text color to `foreground.default` var

## V9 Migration checklist
- [x] Bump @zendeskgarden dependency
- [ ] ~~Update imports source~~
- [x] `Tabs` - Update examples to subcomponent properties 
- [ ] ~~`Field` - Update examples to subcomponent properties~~
- [ ] ~~`Grid` - Update examples to subcomponent properties~~
- [ ] ~~Update API breaking changes~~
- [ ] ~~MDX - Update docs to reflect migration changes~~
- [x] MDX - Update to subcomponent properties (handled [here](https://github.com/zendeskgarden/website/pull/621/files#diff-719cdc2fa3f81eeff582ab2efde23b365b3b521b3619c1cbfc1e2aff0db79e3dR77-R99))


![Screenshot 2024-08-13 at 11 34 35 AM](https://github.com/user-attachments/assets/e53fc53c-046d-4173-bc37-cb2bc9d4ba4f)
![Screenshot 2024-08-13 at 11 34 51 AM](https://github.com/user-attachments/assets/d8744b6a-6a7f-4c82-b552-bf0187e42305)

## Checklist

- [ ] ~~:ok_hand: website updates are Garden Designer approved (add the designer as a reviewer)~~
- [ ] ~~:black_nib: copy updates are approved (add the content strategist as a reviewer)~~
- [ ] ~~:link: considered opportunities for adding cross-reference URLs (grep for keywords)~~
- [ ] ~~:wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver~~
- [ ] ~~:memo: tested in Chrome, Firefox, Safari, Edge~~
