### PR TITLE
fix(draggable): removes extraneous foreground colors in examples

### DIFF
--- a/src/examples/draggable/DraggableListDefault.tsx
+++ b/src/examples/draggable/DraggableListDefault.tsx
@@ -6,7 +6,6 @@
  */
 
 import React from 'react';
-import { getColor } from '@zendeskgarden/react-theming';
 import { Grid } from '@zendeskgarden/react-grid';
 import { MD } from '@zendeskgarden/react-typography';
 import { Draggable, DraggableList } from '@zendeskgarden/react-draggable';
@@ -21,7 +20,6 @@ const items = [
 
 const StyledHeading = styled(MD)`
   margin-bottom: ${p => p.theme.space.xs};
-  color: ${p => getColor({ variable: 'foreground.default', theme: p.theme })};
 `;
 
 const Example = () => (

--- a/src/examples/draggable/DraggableListHorizontal.tsx
+++ b/src/examples/draggable/DraggableListHorizontal.tsx
@@ -6,7 +6,6 @@
  */
 
 import React from 'react';
-import { getColor } from '@zendeskgarden/react-theming';
 import { Grid } from '@zendeskgarden/react-grid';
 import { MD } from '@zendeskgarden/react-typography';
 import { Draggable, DraggableList } from '@zendeskgarden/react-draggable';
@@ -20,7 +19,6 @@ const items = [
 
 const StyledHeading = styled(MD)`
   margin-bottom: ${p => p.theme.space.xs};
-  color: ${p => getColor({ variable: 'foreground.default', theme: p.theme })};
 `;
 
 const Example = () => (

--- a/src/examples/draggable/DraggableListIndicator.tsx
+++ b/src/examples/draggable/DraggableListIndicator.tsx
@@ -6,7 +6,6 @@
  */
 
 import React from 'react';
-import { getColor } from '@zendeskgarden/react-theming';
 import { Grid } from '@zendeskgarden/react-grid';
 import { MD } from '@zendeskgarden/react-typography';
 import { Draggable, DraggableList } from '@zendeskgarden/react-draggable';
@@ -22,7 +21,6 @@ const items = [
 
 const StyledHeading = styled(MD)`
   margin-bottom: ${p => p.theme.space.xs};
-  color: ${p => getColor({ variable: 'foreground.default', theme: p.theme })};
 `;
 
 const Example = () => (

--- a/src/examples/draggable/DraggablePlaceholder.tsx
+++ b/src/examples/draggable/DraggablePlaceholder.tsx
@@ -6,7 +6,6 @@
  */
 
 import React from 'react';
-import { getColor } from '@zendeskgarden/react-theming';
 import { Grid } from '@zendeskgarden/react-grid';
 import { MD } from '@zendeskgarden/react-typography';
 import { Draggable, DraggableList } from '@zendeskgarden/react-draggable';
@@ -21,7 +20,6 @@ const items = [
 
 const StyledHeading = styled(MD)`
   margin-bottom: ${p => p.theme.space.xs};
-  color: ${p => getColor({ variable: 'foreground.default', theme: p.theme })};
 `;
 
 const Example = () => (

--- a/src/examples/draggable/DropzoneDanger.tsx
+++ b/src/examples/draggable/DropzoneDanger.tsx
@@ -32,7 +32,7 @@ import {
 } from '@zendeskgarden/react-draggable';
 import { Grid } from '@zendeskgarden/react-grid';
 import { MD } from '@zendeskgarden/react-typography';
-import { getColor, mediaQuery } from '@zendeskgarden/react-theming';
+import { mediaQuery } from '@zendeskgarden/react-theming';
 
 interface IColumnItem {
   id: string;
@@ -106,7 +106,6 @@ const announcements: Announcements = {
 
 const StyledHeading = styled(MD)`
   margin-bottom: ${p => p.theme.space.xs};
-  color: ${p => getColor({ variable: 'foreground.default', theme: p.theme })};
 `;
 
 const StyledDropzone = styled(Dropzone)`

--- a/src/examples/draggable/DropzoneDefault.tsx
+++ b/src/examples/draggable/DropzoneDefault.tsx
@@ -123,7 +123,6 @@ const getAnnouncements = (count: number): Announcements => ({
 
 const StyledHeading = styled(MD)`
   margin-bottom: ${p => p.theme.space.xs};
-  color: ${p => getColor({ variable: 'foreground.default', theme: p.theme })};
 `;
 
 const StyledDropzone = styled(Dropzone)`


### PR DESCRIPTION
Removing the extra foreground definitions given the central foreground update in #626  