### PR TITLE
feat(components): update `colorpickers` to v9

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
         "@zendeskgarden/react-breadcrumbs": "9.0.0-next.21",
         "@zendeskgarden/react-buttons": "9.0.0-next.21",
         "@zendeskgarden/react-chrome": "8.76.3",
-        "@zendeskgarden/react-colorpickers": "9.0.0-next.21",
+        "@zendeskgarden/react-colorpickers": "9.0.0-next.22",
         "@zendeskgarden/react-datepickers": "9.0.0-next.21",
         "@zendeskgarden/react-draggable": "9.0.0-next.21",
         "@zendeskgarden/react-dropdowns": "9.0.0-next.21",
@@ -6904,21 +6904,101 @@
       }
     },
     "node_modules/@zendeskgarden/react-colorpickers": {
-      "version": "9.0.0-next.21",
-      "resolved": "https://registry.npmjs.org/@zendeskgarden/react-colorpickers/-/react-colorpickers-9.0.0-next.21.tgz",
-      "integrity": "sha512-sj3h91dwSXW29nStihVAk74/Yn7/U5PV+Rynb1JvgFG+Xt0FB+l8BIODugIFodmJqnoMMO8UIh2VXo6MWFnMdQ==",
+      "version": "9.0.0-next.22",
+      "resolved": "https://registry.npmjs.org/@zendeskgarden/react-colorpickers/-/react-colorpickers-9.0.0-next.22.tgz",
+      "integrity": "sha512-Dq/iVhT3aACJeQn1y0CJ3AEvjCAZQo/3AXJJVdlP6CDFy9vpeH4yLM9Mp/YEfuBH1PgnQ5qCrxr/QiQpp9nyhw==",
       "dev": true,
       "dependencies": {
         "@zendeskgarden/container-grid": "^3.0.0",
         "@zendeskgarden/container-utilities": "^2.0.0",
-        "@zendeskgarden/react-buttons": "^9.0.0-next.21",
-        "@zendeskgarden/react-forms": "^9.0.0-next.21",
-        "@zendeskgarden/react-modals": "^9.0.0-next.21",
-        "@zendeskgarden/react-tooltips": "^9.0.0-next.21",
+        "@zendeskgarden/react-buttons": "^9.0.0-next.22",
+        "@zendeskgarden/react-forms": "^9.0.0-next.22",
+        "@zendeskgarden/react-modals": "^9.0.0-next.22",
+        "@zendeskgarden/react-tooltips": "^9.0.0-next.22",
         "lodash.isequal": "^4.5.0",
         "lodash.throttle": "^4.1.1",
         "polished": "^4.3.1",
         "prop-types": "^15.7.2",
+        "react-merge-refs": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@zendeskgarden/react-theming": ">=9.0.0-next",
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0",
+        "styled-components": "^5.3.1"
+      }
+    },
+    "node_modules/@zendeskgarden/react-colorpickers/node_modules/@zendeskgarden/react-buttons": {
+      "version": "9.0.0-next.22",
+      "resolved": "https://registry.npmjs.org/@zendeskgarden/react-buttons/-/react-buttons-9.0.0-next.22.tgz",
+      "integrity": "sha512-KQERoOtWM3cETym5JVuTsvnu5cCaREPzm5BO49o1gZ6V3Fu6Tt+++FHb45nMXaJ6FXeps76vVCYgzZlgyvKubw==",
+      "dev": true,
+      "dependencies": {
+        "@zendeskgarden/container-utilities": "^2.0.0",
+        "polished": "^4.3.1",
+        "prop-types": "^15.5.7",
+        "react-merge-refs": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@zendeskgarden/react-theming": ">=9.0.0-next",
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0",
+        "styled-components": "^5.3.1"
+      }
+    },
+    "node_modules/@zendeskgarden/react-colorpickers/node_modules/@zendeskgarden/react-forms": {
+      "version": "9.0.0-next.22",
+      "resolved": "https://registry.npmjs.org/@zendeskgarden/react-forms/-/react-forms-9.0.0-next.22.tgz",
+      "integrity": "sha512-LeYVGhhMP09+Z0u6JkAfw0Zbe3TgT1V/L9hJBqIFW5yA+DxVzta1J+0kT85tQUSo0fDq2h3mWZi3aoPxrmQE7w==",
+      "dev": true,
+      "dependencies": {
+        "@zendeskgarden/container-field": "^3.0.0",
+        "@zendeskgarden/container-utilities": "^2.0.0",
+        "lodash.debounce": "^4.0.8",
+        "polished": "^4.3.1",
+        "prop-types": "^15.5.7",
+        "react-merge-refs": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@zendeskgarden/react-theming": ">=9.0.0-next",
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0",
+        "styled-components": "^5.3.1"
+      }
+    },
+    "node_modules/@zendeskgarden/react-colorpickers/node_modules/@zendeskgarden/react-modals": {
+      "version": "9.0.0-next.22",
+      "resolved": "https://registry.npmjs.org/@zendeskgarden/react-modals/-/react-modals-9.0.0-next.22.tgz",
+      "integrity": "sha512-/ib7LiK8qyy7nvpMjj3kzMWj1CTUWJT0Ia1UmpgMM+k50EDnERu+MvdAxj/hnu2sFiX2LZX4SO8qJwqkYxgAGw==",
+      "dev": true,
+      "dependencies": {
+        "@floating-ui/react-dom": "^2.0.0",
+        "@zendeskgarden/container-modal": "^1.0.15",
+        "@zendeskgarden/container-utilities": "^2.0.0",
+        "@zendeskgarden/react-buttons": "^9.0.0-next.22",
+        "dom-helpers": "^5.1.0",
+        "prop-types": "^15.5.7",
+        "react-merge-refs": "^2.0.0",
+        "react-transition-group": "^4.4.2"
+      },
+      "peerDependencies": {
+        "@zendeskgarden/react-theming": ">=9.0.0-next",
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0",
+        "styled-components": "^5.3.1"
+      }
+    },
+    "node_modules/@zendeskgarden/react-colorpickers/node_modules/@zendeskgarden/react-tooltips": {
+      "version": "9.0.0-next.22",
+      "resolved": "https://registry.npmjs.org/@zendeskgarden/react-tooltips/-/react-tooltips-9.0.0-next.22.tgz",
+      "integrity": "sha512-2lTn2DxguXoGQe4usGU/Vo3EVPCWQBt6vCVTvFrGDSkc0EgEIpdU/2Ymv8pzdCZQA0kpTudlXAfns3PTqvgmqA==",
+      "dev": true,
+      "dependencies": {
+        "@floating-ui/react-dom": "^2.0.0",
+        "@zendeskgarden/container-tooltip": "^1.0.16",
+        "@zendeskgarden/container-utilities": "^2.0.0",
+        "polished": "^4.3.1",
+        "prop-types": "^15.5.7",
         "react-merge-refs": "^2.0.0"
       },
       "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "@zendeskgarden/react-breadcrumbs": "9.0.0-next.21",
     "@zendeskgarden/react-buttons": "9.0.0-next.21",
     "@zendeskgarden/react-chrome": "8.76.3",
-    "@zendeskgarden/react-colorpickers": "9.0.0-next.21",
+    "@zendeskgarden/react-colorpickers": "9.0.0-next.22",
     "@zendeskgarden/react-datepickers": "9.0.0-next.21",
     "@zendeskgarden/react-draggable": "9.0.0-next.21",
     "@zendeskgarden/react-dropdowns": "9.0.0-next.21",

--- a/src/examples/color-picker/ColorPickerDefault.tsx
+++ b/src/examples/color-picker/ColorPickerDefault.tsx
@@ -8,14 +8,14 @@
 import React from 'react';
 import { PALETTE } from '@zendeskgarden/react-theming';
 import { ColorPicker } from '@zendeskgarden/react-colorpickers';
-import { Row, Col } from '@zendeskgarden/react-grid';
+import { Grid } from '@zendeskgarden/react-grid';
 
 const Example = () => (
-  <Row justifyContent="center">
-    <Col size="auto">
+  <Grid.Row justifyContent="center">
+    <Grid.Col size="auto">
       <ColorPicker defaultColor={PALETTE.blue[700]} />
-    </Col>
-  </Row>
+    </Grid.Col>
+  </Grid.Row>
 );
 
 export default Example;

--- a/src/examples/color-picker/ColorPickerDialogCustomTrigger.tsx
+++ b/src/examples/color-picker/ColorPickerDialogCustomTrigger.tsx
@@ -9,7 +9,7 @@ import React, { useState } from 'react';
 import { rgba } from 'polished';
 import { PALETTE } from '@zendeskgarden/react-theming';
 import { ColorPickerDialog, IColor } from '@zendeskgarden/react-colorpickers';
-import { Row, Col } from '@zendeskgarden/react-grid';
+import { Grid } from '@zendeskgarden/react-grid';
 import { Tooltip } from '@zendeskgarden/react-tooltips';
 import { IconButton } from '@zendeskgarden/react-buttons';
 import { ReactComponent as PaletteIcon } from '@zendeskgarden/svg-icons/src/16/palette-fill.svg';
@@ -40,13 +40,13 @@ const Example = () => {
       : `rgba(${color.red}, ${color.green}, ${color.blue}, ${color.alpha / 100})`;
 
   return (
-    <Row>
-      <Col textAlign="center">
+    <Grid.Row>
+      <Grid.Col textAlign="center">
         <ColorPickerDialog color={color} onChange={setColor}>
           <PaletteIconButton iconColor={iconColor} />
         </ColorPickerDialog>
-      </Col>
-    </Row>
+      </Grid.Col>
+    </Grid.Row>
   );
 };
 

--- a/src/examples/color-picker/ColorPickerDialogDefault.tsx
+++ b/src/examples/color-picker/ColorPickerDialogDefault.tsx
@@ -7,20 +7,20 @@
 
 import React from 'react';
 import { ColorPickerDialog } from '@zendeskgarden/react-colorpickers';
-import { Row, Col } from '@zendeskgarden/react-grid';
+import { Grid } from '@zendeskgarden/react-grid';
 import { PALETTE } from '@zendeskgarden/react-theming';
 
 const Example = () => (
-  <Row>
-    <Col textAlign="center">
+  <Grid.Row>
+    <Grid.Col textAlign="center">
       <ColorPickerDialog
         defaultColor={PALETTE.blue[700]}
         buttonProps={{
           'aria-label': 'choose your favorite color'
         }}
       />
-    </Col>
-  </Row>
+    </Grid.Col>
+  </Grid.Row>
 );
 
 export default Example;

--- a/src/examples/color-picker/ColorPickerDialogFormInput.tsx
+++ b/src/examples/color-picker/ColorPickerDialogFormInput.tsx
@@ -9,13 +9,13 @@ import React, { useState } from 'react';
 import styled from 'styled-components';
 import { rgba, parseToRgb, toColorString } from 'polished';
 import { PALETTE } from '@zendeskgarden/react-theming';
-import { Row, Col } from '@zendeskgarden/react-grid';
+import { Grid } from '@zendeskgarden/react-grid';
 import { ColorPickerDialog, IColor } from '@zendeskgarden/react-colorpickers';
-import { Field, Label, Input, InputGroup } from '@zendeskgarden/react-forms';
+import { Field, Input, InputGroup } from '@zendeskgarden/react-forms';
 
 const validHex = /^#(?:(?:[0-9A-F]{6}(?:[0-9A-F]{2})?)|(?:[0-9A-F]{3})(?:[0-9A-F]?))$/iu;
 
-const StyledCol = styled(Col)`
+const StyledCol = styled(Grid.Col)`
   flex-grow: 0;
 `;
 
@@ -55,10 +55,10 @@ const Example = () => {
   const [color, setColor] = useState<string | IColor>(rgba(PALETTE.blue[700], 0.6));
 
   return (
-    <Row justifyContent="center">
+    <Grid.Row justifyContent="center">
       <StyledCol>
         <Field>
-          <Label>Favorite color</Label>
+          <Field.Label>Favorite color</Field.Label>
           <InputGroup style={{ zIndex: 1 }}>
             <StyledInput
               maxLength={9}
@@ -84,7 +84,7 @@ const Example = () => {
           </InputGroup>
         </Field>
       </StyledCol>
-    </Row>
+    </Grid.Row>
   );
 };
 

--- a/src/examples/color-picker/ColorPickerOpaque.tsx
+++ b/src/examples/color-picker/ColorPickerOpaque.tsx
@@ -8,14 +8,14 @@
 import React from 'react';
 import { PALETTE } from '@zendeskgarden/react-theming';
 import { ColorPicker } from '@zendeskgarden/react-colorpickers';
-import { Row, Col } from '@zendeskgarden/react-grid';
+import { Grid } from '@zendeskgarden/react-grid';
 
 const Example = () => (
-  <Row justifyContent="center">
-    <Col size="auto">
+  <Grid.Row justifyContent="center">
+    <Grid.Col size="auto">
       <ColorPicker defaultColor={PALETTE.blue[700]} isOpaque />
-    </Col>
-  </Row>
+    </Grid.Col>
+  </Grid.Row>
 );
 
 export default Example;

--- a/src/examples/color-swatch/ColorSwatchCustomTrigger.tsx
+++ b/src/examples/color-swatch/ColorSwatchCustomTrigger.tsx
@@ -7,7 +7,7 @@
 
 import React, { useState } from 'react';
 import { ColorSwatchDialog } from '@zendeskgarden/react-colorpickers';
-import { Row, Col } from '@zendeskgarden/react-grid';
+import { Grid } from '@zendeskgarden/react-grid';
 import { Tooltip } from '@zendeskgarden/react-tooltips';
 import { IconButton } from '@zendeskgarden/react-buttons';
 import { ReactComponent as PaletteIcon } from '@zendeskgarden/svg-icons/src/16/palette-fill.svg';
@@ -82,8 +82,8 @@ const Example = () => {
   };
 
   return (
-    <Row>
-      <Col textAlign="center">
+    <Grid.Row>
+      <Grid.Col textAlign="center">
         <ColorSwatchDialog
           name="color-swatch-custom-trigger"
           colors={matrix}
@@ -93,8 +93,8 @@ const Example = () => {
         >
           <PaletteIconButton iconColor={color} />
         </ColorSwatchDialog>
-      </Col>
-    </Row>
+      </Grid.Col>
+    </Grid.Row>
   );
 };
 

--- a/src/examples/color-swatch/ColorSwatchDefault.tsx
+++ b/src/examples/color-swatch/ColorSwatchDefault.tsx
@@ -7,7 +7,7 @@
 
 import React from 'react';
 import { ColorSwatch } from '@zendeskgarden/react-colorpickers';
-import { Row, Col } from '@zendeskgarden/react-grid';
+import { Grid } from '@zendeskgarden/react-grid';
 import { convertToMatrix } from '@zendeskgarden/container-utilities';
 import { PALETTE } from '@zendeskgarden/react-theming';
 
@@ -45,11 +45,11 @@ const colors = [
 const matrix = convertToMatrix(colors, 7);
 
 const Example = () => (
-  <Row justifyContent="center">
-    <Col size="auto">
+  <Grid.Row justifyContent="center">
+    <Grid.Col size="auto">
       <ColorSwatch name="color-swatch-default" colors={matrix} />
-    </Col>
-  </Row>
+    </Grid.Col>
+  </Grid.Row>
 );
 
 export default Example;

--- a/src/examples/color-swatch/ColorSwatchDialog.tsx
+++ b/src/examples/color-swatch/ColorSwatchDialog.tsx
@@ -7,7 +7,7 @@
 
 import React, { useState } from 'react';
 import { ColorSwatchDialog } from '@zendeskgarden/react-colorpickers';
-import { Row, Col } from '@zendeskgarden/react-grid';
+import { Grid } from '@zendeskgarden/react-grid';
 import { convertToMatrix } from '@zendeskgarden/container-utilities';
 import { PALETTE } from '@zendeskgarden/react-theming';
 
@@ -55,8 +55,8 @@ const Example = () => {
   };
 
   return (
-    <Row justifyContent="center">
-      <Col size="auto">
+    <Grid.Row justifyContent="center">
+      <Grid.Col size="auto">
         <ColorSwatchDialog
           name="color-swatch-dialog"
           colors={matrix}
@@ -64,8 +64,8 @@ const Example = () => {
           selectedRowIndex={selectedRowIndex}
           selectedColIndex={selectedColIndex}
         />
-      </Col>
-    </Row>
+      </Grid.Col>
+    </Grid.Row>
   );
 };
 


### PR DESCRIPTION
## Description

Updates `react-colorpickers` to v9.


## V9 Migration checklist
- [x] Bump @zendeskgarden dependency
- [x] Update imports (handled in [#601](https://github.com/zendeskgarden/website/pull/601/files#diff-f8e94fbb2af05e6a99091f1a00fd3b1fcfc9b55c4ccfc8bddd11ce05e32e8d2a))
- [x] `Grid` - Update examples to subcomponent properties
- [ ] ~~Update API breaking changes~~
- [x] MDX - Update docs to reflect migration changes (handled in [#602](https://github.com/zendeskgarden/website/pull/602/files#diff-516d3a25fb20397f56e4e8ffe49d902c65a3ba632eeddd3e0f49b1c9fdb96752R7-R8)
- [ ] ~~MDX - Update to subcomponent properties~~

![Screenshot 2024-08-16 at 1 09 12 PM](https://github.com/user-attachments/assets/c7521224-2b81-4c7a-af8d-b5f413b78a4d)
![Screenshot 2024-08-16 at 1 08 10 PM](https://github.com/user-attachments/assets/c79231f7-4fe0-4fad-947a-9be1a0c987a7)

## Checklist

- [ ] ~~:ok_hand: website updates are Garden Designer approved (add the designer as a reviewer)~~
- [ ] ~~:black_nib: copy updates are approved (add the content strategist as a reviewer)~~
- [ ] ~~:link: considered opportunities for adding cross-reference URLs (grep for keywords)~~
- [ ] ~~:wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver~~
- [ ] ~~:memo: tested in Chrome, Firefox, Safari, Edge~~
