### PR TITLE
fix: `css-bedrock` upgrade, color variable API docs, remove feedback links

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "@types/react-window": "1.8.8",
         "@types/styled-components": "5.1.34",
         "@zendeskgarden/container-utilities": "2.0.0",
-        "@zendeskgarden/css-bedrock": "9.1.1",
+        "@zendeskgarden/css-bedrock": "10.0.0",
         "@zendeskgarden/eslint-config": "43.0.0",
         "@zendeskgarden/react-accordions": "9.0.0",
         "@zendeskgarden/react-avatars": "9.0.0",
@@ -6713,20 +6713,13 @@
       }
     },
     "node_modules/@zendeskgarden/css-bedrock": {
-      "version": "9.1.1",
-      "resolved": "https://registry.npmjs.org/@zendeskgarden/css-bedrock/-/css-bedrock-9.1.1.tgz",
-      "integrity": "sha512-dDpHPDJ2jRCVoRaImbLyX8WMSIHLoFCQKVZppfhgKWlTYx1x+3ytqFkkSWV3b0csf/dUXhw2efqF7Q+vQgtbeQ==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@zendeskgarden/css-bedrock/-/css-bedrock-10.0.0.tgz",
+      "integrity": "sha512-v/BeqgrkVFVO2orsJENmo+2hy5/GiiM440+1D5twsDHx4qBduMZztLnW/VFswJdV06heD7/DAN5epx/rqWN5PA==",
       "dev": true,
       "dependencies": {
-        "@zendeskgarden/css-variables": "^6.4.6",
         "modern-normalize": "^2.0.0"
       }
-    },
-    "node_modules/@zendeskgarden/css-variables": {
-      "version": "6.4.6",
-      "resolved": "https://registry.npmjs.org/@zendeskgarden/css-variables/-/css-variables-6.4.6.tgz",
-      "integrity": "sha512-jx5N3Vn4zHNWwZnkCFkk5VpXKB5404h/mcCR2Y7HR8XwSH5nfUugwsH/5AyPOng/atyHz3XNORuuEJ0mZ/vi5w==",
-      "dev": true
     },
     "node_modules/@zendeskgarden/eslint-config": {
       "version": "43.0.0",
@@ -33433,6 +33426,48 @@
       "integrity": "sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA==",
       "dev": true
     },
+    "node_modules/netlify-cli/node_modules/@types/body-parser": {
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.2.tgz",
+      "integrity": "sha512-ALYone6pm6QmwZoAgeyNksccT9Q4AWZQ6PvfwR37GT6r6FWUPguq6sUmNGSMV2Wr761oQoBxwGGa6DR5o1DC9g==",
+      "extraneous": true,
+      "dependencies": {
+        "@types/connect": "*",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/netlify-cli/node_modules/@types/connect": {
+      "version": "3.4.35",
+      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.35.tgz",
+      "integrity": "sha512-cdeYyv4KWoEgpBISTxWvqYsVy444DOqehiF3fM3ne10AmJ62RSyNkUnxMJXHQWRQQX2eR94m5y1IZyDwBjV9FQ==",
+      "extraneous": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/netlify-cli/node_modules/@types/express": {
+      "version": "4.17.13",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.13.tgz",
+      "integrity": "sha512-6bSZTPaTIACxn48l50SR+axgrqm6qXFIxrdAKaG6PaJk3+zuUr35hBlgT7vOmJcum+OEaIBLtHV/qloEAFITeA==",
+      "extraneous": true,
+      "dependencies": {
+        "@types/body-parser": "*",
+        "@types/express-serve-static-core": "^4.17.18",
+        "@types/qs": "*",
+        "@types/serve-static": "*"
+      }
+    },
+    "node_modules/netlify-cli/node_modules/@types/express-serve-static-core": {
+      "version": "4.17.28",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.28.tgz",
+      "integrity": "sha512-P1BJAEAW3E2DJUlkgq4tOL3RyMunoWXqbSCygWo5ZIWTjUgN1YnaXWW4VWl/oc8vs/XoYibEGBKP0uZyF4AHig==",
+      "extraneous": true,
+      "dependencies": {
+        "@types/node": "*",
+        "@types/qs": "*",
+        "@types/range-parser": "*"
+      }
+    },
     "node_modules/netlify-cli/node_modules/@types/http-cache-semantics": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.4.tgz",
@@ -33472,6 +33507,12 @@
         "@types/istanbul-lib-report": "*"
       }
     },
+    "node_modules/netlify-cli/node_modules/@types/mime": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.2.tgz",
+      "integrity": "sha512-YATxVxgRqNH6nHEIsvg6k2Boc1JHI9ZbH5iWFFv/MTkchz3b1ieGDa5T0a9RznNdI0KhVbdbWSN+KWWrQZRxTw==",
+      "extraneous": true
+    },
     "node_modules/netlify-cli/node_modules/@types/node": {
       "version": "20.14.2",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.2.tgz",
@@ -33487,11 +33528,33 @@
       "integrity": "sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==",
       "dev": true
     },
+    "node_modules/netlify-cli/node_modules/@types/qs": {
+      "version": "6.9.7",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.7.tgz",
+      "integrity": "sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw==",
+      "extraneous": true
+    },
+    "node_modules/netlify-cli/node_modules/@types/range-parser": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.4.tgz",
+      "integrity": "sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw==",
+      "extraneous": true
+    },
     "node_modules/netlify-cli/node_modules/@types/retry": {
       "version": "0.12.1",
       "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.1.tgz",
       "integrity": "sha512-xoDlM2S4ortawSWORYqsdU+2rxdh4LRW9ytc3zmT37RIKQh6IHyKwwtKhKis9ah8ol07DCkZxPt8BBvPjC6v4g==",
       "dev": true
+    },
+    "node_modules/netlify-cli/node_modules/@types/serve-static": {
+      "version": "1.13.10",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.13.10.tgz",
+      "integrity": "sha512-nCkHGI4w7ZgAdNkrEu0bv+4xNV/XDqW+DydknebMOQwkpDGx8G+HTlj7R7ABI8i8nKxVw0wtKPi1D+lPOkh4YQ==",
+      "extraneous": true,
+      "dependencies": {
+        "@types/mime": "^1",
+        "@types/node": "*"
+      }
     },
     "node_modules/netlify-cli/node_modules/@types/shimmer": {
       "version": "1.0.5",
@@ -33877,6 +33940,22 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/netlify-cli/node_modules/ajv": {
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "extraneous": true,
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
       }
     },
     "node_modules/netlify-cli/node_modules/ajv-formats": {
@@ -37115,6 +37194,12 @@
         "node": ">=8.6.0"
       }
     },
+    "node_modules/netlify-cli/node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "extraneous": true
+    },
     "node_modules/netlify-cli/node_modules/fast-json-stringify": {
       "version": "5.15.1",
       "resolved": "https://registry.npmjs.org/fast-json-stringify/-/fast-json-stringify-5.15.1.tgz",
@@ -38887,6 +38972,15 @@
         "ipx": "bin/ipx.mjs"
       }
     },
+    "node_modules/netlify-cli/node_modules/ipx/node_modules/@netlify/blobs": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@netlify/blobs/-/blobs-6.5.0.tgz",
+      "integrity": "sha512-wRFlNnL/Qv3WNLZd3OT/YYqF1zb6iPSo8T31sl9ccL1ahBxW1fBqKgF4b1XL7Z+6mRIkatvcsVPkWBcO+oJMNA==",
+      "extraneous": true,
+      "engines": {
+        "node": "^14.16.0 || >=16.0.0"
+      }
+    },
     "node_modules/netlify-cli/node_modules/ipx/node_modules/lru-cache": {
       "version": "10.2.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.2.0.tgz",
@@ -39462,6 +39556,12 @@
       "dependencies": {
         "fast-deep-equal": "^3.1.3"
       }
+    },
+    "node_modules/netlify-cli/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "extraneous": true
     },
     "node_modules/netlify-cli/node_modules/jsonc-parser": {
       "version": "3.2.0",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@types/react-window": "1.8.8",
     "@types/styled-components": "5.1.34",
     "@zendeskgarden/container-utilities": "2.0.0",
-    "@zendeskgarden/css-bedrock": "9.1.1",
+    "@zendeskgarden/css-bedrock": "10.0.0",
     "@zendeskgarden/eslint-config": "43.0.0",
     "@zendeskgarden/react-accordions": "9.0.0",
     "@zendeskgarden/react-avatars": "9.0.0",

--- a/src/layouts/Root/components/StyledNavigationLink.tsx
+++ b/src/layouts/Root/components/StyledNavigationLink.tsx
@@ -19,8 +19,6 @@ interface ILink {
 
 /*
  * Copy Garden `Anchor` styling
- *
- * 1. Override bedrock CSS transition
  */
 const colorStyles = ({ theme }: ThemeProps<DefaultTheme>) => {
   const options = { theme, variable: 'foreground.primary' };
@@ -30,7 +28,7 @@ const colorStyles = ({ theme }: ThemeProps<DefaultTheme>) => {
   const focusOutlineColor = getColor({ theme, variable: 'border.primaryEmphasis' });
 
   return css`
-    transition: color 0.25s ease-in-out; /* [1] */
+    text-decoration: none;
     color: ${color};
 
     ${focusStyles({ theme, condition: false, styles: { color, outlineColor: focusOutlineColor } })};

--- a/src/pages/components/theme-object.mdx
+++ b/src/pages/components/theme-object.mdx
@@ -159,7 +159,6 @@ variables and expected usage.
   - **background.recessed** background that sits below the main surface
   - **background.subtle** subtle background that sits on the same plane as the main surface
   - **background.emphasis** strong background, usually for interactive elements
-  - **background.primary** background used for primary layouts
   - **background.success** background used for success states
   - **background.warning** background used for warning states
   - **background.danger** background used for danger states

--- a/src/pages/patterns/buttons.mdx
+++ b/src/pages/patterns/buttons.mdx
@@ -268,12 +268,6 @@ Finally, a Button that opens a Dropdown menu must have `aria-haspopup` set to â€
 - [https://inclusive-components.design/toggle-button/](https://inclusive-components.design/toggle-button/)
 - [https://inclusive-components.design/menus-menu-buttons/](https://inclusive-components.design/menus-menu-buttons/)
 
----
-
-## Feedback
-
-Help improve this page. [Give us your feedback](https://forms.gle/VFD799SvNfs2yiFC7)
-
 import { graphql } from 'gatsby';
 
 export const pageQuery = graphql`

--- a/src/pages/patterns/copy.mdx
+++ b/src/pages/patterns/copy.mdx
@@ -129,12 +129,6 @@ If there are multiple copy fields on a page or view within a form, use the `aria
 
 - [https://www.w3.org/WAI/WCAG21/Understanding/headings-and-labels.html](https://www.w3.org/WAI/WCAG21/Understanding/headings-and-labels.html)
 
----
-
-## Feedback
-
-Help improve this page. [Give us your feedback](https://forms.gle/VFD799SvNfs2yiFC7)
-
 import { graphql } from 'gatsby';
 
 export const pageQuery = graphql`

--- a/src/pages/patterns/drag-and-drop.mdx
+++ b/src/pages/patterns/drag-and-drop.mdx
@@ -341,12 +341,6 @@ heavily on the workflow context. What makes sense for one flow, might not make m
 
 ![Example where each draggable item has an action button next to.](figma:patterns-dnd-accessibility-alternative-1.png)
 
----
-
-<h2>Feedback</h2>
-
-Help improve this page. [Give us your feedback](https://forms.gle/VFD799SvNfs2yiFC7)
-
 import { graphql } from 'gatsby';
 
 export const pageQuery = graphql`

--- a/src/pages/patterns/errors.mdx
+++ b/src/pages/patterns/errors.mdx
@@ -191,17 +191,11 @@ An accessible error message should exhibit these qualities.
 - Informative, helping the user resolve the issue
 - The message should refer to the failed element in code
 
-## Additional resources
+### Additional resources
 
 [https://www.w3.org/WAI/standards-guidelines/act/rules/36b590/proposed/](https://www.w3.org/WAI/standards-guidelines/act/rules/36b590/proposed/)
 [https://www.w3.org/WAI/WCAG21/Understanding/error-identification.html](https://www.w3.org/WAI/WCAG21/Understanding/error-identification.html)
 [https://www.w3.org/WAI/WCAG21/Understanding/error-suggestion.html](https://www.w3.org/WAI/WCAG21/Understanding/error-suggestion.html)
-
----
-
-## Feedback
-
-Help improve this page. [Give us your feedback](https://forms.gle/VFD799SvNfs2yiFC7)
 
 import { graphql } from 'gatsby';
 

--- a/src/pages/patterns/filters.mdx
+++ b/src/pages/patterns/filters.mdx
@@ -199,12 +199,6 @@ after the filtering actions are completed.
 - [WAI-ARIA Listbox](https://www.w3.org/WAI/ARIA/apg/patterns/listbox/)
 - [WAI-ARIA Menu](https://www.w3.org/WAI/ARIA/apg/patterns/menu-button/)
 
----
-
-<h2>Feedback</h2>
-
-Help improve this page. [Give us your feedback](https://forms.gle/VFD799SvNfs2yiFC7)
-
 import { graphql } from 'gatsby';
 
 export const pageQuery = graphql`

--- a/src/pages/patterns/loaders.mdx
+++ b/src/pages/patterns/loaders.mdx
@@ -134,12 +134,6 @@ Inline loaders have the role of `img`. The `aria-live` property, `alert` role, o
 what part of the page is loading, the speed of loading on slower connections, and other live regions on the page.
 Before, during, and after loading, browser focus should remain where the user put it.
 
----
-
-## Feedback
-
-Help improve this page. [Give us your feedback](https://forms.gle/VFD799SvNfs2yiFC7)
-
 import { graphql } from 'gatsby';
 
 export const pageQuery = graphql`

--- a/src/pages/patterns/rich-text-editor.mdx
+++ b/src/pages/patterns/rich-text-editor.mdx
@@ -211,12 +211,6 @@ If the editor has enabled indentation, the `Tab` key will be reserved for settin
 In those situations a custom text shortcut is used to move the focus from the editor to the toolbar: `Alt + F10` on PC,
 and `Option + F10` on macOS. Read more about [keyboard support](https://ckeditor.com/docs/ckeditor5/latest/features/keyboard-support.html).
 
----
-
-<h2>Feedback</h2>
-
-Help improve this page. [Give us your feedback](https://forms.gle/VFD799SvNfs2yiFC7)
-
 import { graphql } from 'gatsby';
 
 export const pageQuery = graphql`

--- a/src/pages/patterns/save.mdx
+++ b/src/pages/patterns/save.mdx
@@ -170,12 +170,6 @@ presses `esc` or clicks outside the modal.
 - [https://www.w3.org/WAI/WCAG21/Understanding/labels-or-instructions.html](https://www.w3.org/WAI/WCAG21/Understanding/labels-or-instructions.html)
 - [https://www.w3.org/WAI/WCAG21/Understanding/error-suggestion.html](https://www.w3.org/WAI/WCAG21/Understanding/error-suggestion.html)
 
----
-
-## Feedback
-
-Help improve this page. [Give us your feedback](https://forms.gle/VFD799SvNfs2yiFC7)
-
 import { graphql } from 'gatsby';
 
 export const pageQuery = graphql`

--- a/src/pages/patterns/tables/basic-formatting.mdx
+++ b/src/pages/patterns/tables/basic-formatting.mdx
@@ -462,12 +462,6 @@ readers speak one cell at a time and reference the associated header cells, so t
 
 - [https://developer.mozilla.org/en-US/docs/Learn/HTML/Tables/Advanced](https://developer.mozilla.org/en-US/docs/Learn/HTML/Tables/Advanced)
 
----
-
-## Feedback
-
-Help improve this page. [Give us your feedback](https://forms.gle/VFD799SvNfs2yiFC7)
-
 import { graphql } from 'gatsby';
 
 export const pageQuery = graphql`


### PR DESCRIPTION
## Description

- upgrades `@zendeskgarden/css-bedrock` to v10
- removes `background.primary` color variable doc from "Theme object" component page
- removes broken feedback form links from pattern pages
