### PR TITLE
fix(docsearch): enable SSR page rendering

### DIFF
--- a/src/layouts/Root/index.tsx
+++ b/src/layouts/Root/index.tsx
@@ -40,7 +40,7 @@ const RootLayout: React.FC<IRootLayoutProps> = ({ children, hasSkipNav = true, p
     }
   }, [isGlobalAlertVisible]);
 
-  return typeof window === 'undefined' ? null /* prevent global alert flash */ : (
+  return (
     <div
       css={css`
         display: flex;


### PR DESCRIPTION
## Description

The support thread with Algolia uncovered the fact that the website is rendering blank with JavaScript disabled. This PR removes a `typeof window === 'undefined'` check at the root to allow pages to render content. The impact is a slight, occasional page shift due to the v9 global alert. But we need to get a handle on this issue before the more significant dark mode PR lands. This PR is key for that effort.
