### PR TITLE
fix(versions): links for legacy docs

### DIFF
--- a/src/pages/components/versions.mdx
+++ b/src/pages/components/versions.mdx
@@ -18,10 +18,10 @@ Garden website release documentation
 - [Version 8](https://zendeskgarden-v8.netlify.app/)
   - [changelog](https://github.com/zendeskgarden/react-components/blob/main/docs/changelogs/v8.md)
   - [migration guide](https://github.com/zendeskgarden/react-components/blob/main/docs/migrations/v8.md)
-- Version 7
+- [Version 7](https://zendeskgarden-v7.netlify.app/)
   - [changelog](https://github.com/zendeskgarden/react-components/blob/main/docs/changelogs/v7.md)
   - [migration guide](https://github.com/zendeskgarden/react-components/blob/main/docs/migrations/v7.md)
-- Version 6
+- [Version 6](https://zendeskgarden-v6.netlify.app/)
   - [changelog](https://github.com/zendeskgarden/react-components/blob/main/docs/changelogs/v6.md)
   - [migration guide](https://github.com/zendeskgarden/react-components/blob/main/docs/migrations/v6.md)
 


### PR DESCRIPTION
## Description

This update restores missing links to documentation websites for legacy versions of Garden.

## Checklist

- ~~[ ] :ok_hand: website updates are Garden Designer approved (add the designer as a reviewer)~~
- ~~[ ] :black_nib: copy updates are approved (add the content strategist as a reviewer)~~
- [x] :link: considered opportunities for adding cross-reference URLs (grep for keywords)
- ~~[ ] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver~~
- ~~[ ] :memo: tested in Chrome, Firefox, Safari, Edge~~
