### PR TITLE
chore: add AI-ready documentation files

### DIFF
--- a/.cursor/rules/00-core.mdc
+++ b/.cursor/rules/00-core.mdc
@@ -1,0 +1,9 @@
+---
+description: Core project conventions
+globs: ["**/*"]
+alwaysApply: true
+---
+
+Read and follow all instructions in the root `AGENTS.md` file.
+Read and follow all security requirements in `SECURITY.md`.
+See `ARCHITECTURE.md` for system architecture and design decisions.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,5 @@
+# Copilot Instructions
+
+Read and follow all instructions in `AGENTS.md` — the source of truth for coding conventions.
+Read and follow all instructions in `SECURITY.md` — mandatory security requirements.
+See `ARCHITECTURE.md` for system architecture and design decisions.

--- a/.windsurfrules
+++ b/.windsurfrules
@@ -1,0 +1,3 @@
+Read and follow all instructions in `AGENTS.md` — the source of truth for coding conventions.
+Read and follow all instructions in `SECURITY.md` — mandatory security requirements.
+See `ARCHITECTURE.md` for system architecture and design decisions.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,101 @@
+# Garden Website
+
+Documentation site for the [Zendesk Garden](https://garden.zendesk.com) design system, built with Gatsby, React, TypeScript, and MDX. Content is sourced from MDX pages, the `react-components` git submodule, and the Figma API.
+
+## Setup & Commands
+
+```bash
+# Install dependencies (also triggers build via prepare script)
+npm install
+
+# Local dev server with live reload
+npm start
+
+# Production build
+npm run build
+
+# Run all checks (prettier + lint + tsc) — matches CI
+npm test
+
+# Lint JS/TS (ESLint)
+npm run lint:js
+
+# Lint CSS-in-JS (StyleLint)
+npm run lint:css
+
+# Lint Markdown/MDX (markdownlint)
+npm run lint:md
+
+# Run all linters
+npm run lint
+
+# Type check
+npm exec tsc
+
+# Format files with Prettier
+npm run format
+
+# Upgrade Garden component packages and sync submodule
+npm run upgrade
+```
+
+**Required env var:** `FIGMA_TOKEN` — needed for build; see `.github/CONTRIBUTING.md` for how to generate one.
+
+## Code Conventions
+
+- All source files start with the Apache 2.0 copyright header (see any existing `.ts`/`.tsx` file)
+- TypeScript strict mode — `tsconfig.json` has `"strict": true`
+- Path aliases: `components/*` → `src/components/*`, `layouts/*` → `src/layouts/*` (configured in `tsconfig.json` and `gatsby-config.ts`)
+- styled-components for all CSS-in-JS; StyleLint enforces `@zendeskgarden/stylelint-config`
+- Prettier: `printWidth: 100`, `singleQuote: true`, `trailingComma: 'none'`, `arrowParens: 'avoid'`
+- MDX files for documentation pages; markdownlint enforces `.markdownlintrc`
+
+## Do
+
+- Add the Apache 2.0 copyright block at the top of every new `.ts`/`.tsx` file
+- Import shared components using the `components/` path alias (e.g. `import { Layout } from 'components'`)
+- Use `import … from '!!raw-loader!../../examples/…'` to pull raw code strings for code blocks in MDX
+- Keep example components in `src/examples/<package-name>/` — one component per file
+
+## Don't
+
+- Don't edit files inside `react-components/` — it's a read-only git submodule
+- Don't skip `npm run lint` before pushing; it runs as a pre-commit hook
+- Don't hardcode navigation — update the YAML files in `content/nav/` instead
+- Don't commit `.env` files or the `FIGMA_TOKEN` value
+
+## Architecture
+
+See `ARCHITECTURE.md` for system architecture, component map, and data flow.
+
+## Security
+
+See `SECURITY.md` for mandatory security requirements and prohibited patterns.
+
+## Safety & Permissions
+
+Allowed without approval:
+- Read/list files
+- Run `npm run lint`, `npm run lint:js`, `npm run lint:css`, `npm run lint:md`, `npm exec tsc`
+
+Ask before:
+- Installing or removing packages
+- Deleting files or directories
+- Running `npm run build` or `npm test` (slow)
+- Modifying CI/CD or Netlify configuration
+- Pushing to remote branches
+
+## PR & Commit Guidelines
+
+- Branch format: `username/verb-noun` (e.g. `jzempel/update-components`)
+- PR title follows [Conventional Commits](https://conventionalcommits.org/): `type: description` or `type(scope): description`
+- Common types: `feat`, `fix`, `chore`, `ci`, `docs`
+- Maintainers squash-merge using the PR title as the commit message — write titles accordingly
+- Consult `.github/PULL_REQUEST_TEMPLATE.md` when opening a PR
+
+## References
+
+- Contributing workflow: `.github/CONTRIBUTING.md`
+- PR template: `.github/PULL_REQUEST_TEMPLATE.md`
+- Architecture: `ARCHITECTURE.md`
+- Security: `SECURITY.md`

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,89 @@
+# Garden Website — Architecture
+
+## System Overview
+
+The Garden website is a Gatsby-based static site that documents the [Zendesk Garden](https://garden.zendesk.com) design system. It renders MDX documentation pages, live React component examples, auto-generated component API docs, and design/pattern guidelines. Content is sourced from MDX files, a `react-components` git submodule, and the Figma API. The site is deployed to Netlify.
+
+## Architecture Diagram
+
+```mermaid
+graph LR
+    subgraph Build["Build (gatsby build)"]
+        MDX["MDX pages\n(src/pages/)"]
+        Figma["Figma API\n(FIGMA_TOKEN)"]
+        RCSubmodule["react-components\n(git submodule)"]
+        Plugins["Custom Plugins\n(plugins/)"]
+    end
+
+    subgraph Runtime["Gatsby Site"]
+        Pages["Rendered Pages"]
+        Components["React Components\n(src/components/, src/layouts/)"]
+        Examples["Live Examples\n(src/examples/)"]
+    end
+
+    MDX --> Pages
+    Figma --> Plugins
+    RCSubmodule --> Plugins
+    Plugins --> Pages
+    Pages --> Components
+    Examples --> Pages
+
+    Pages --> Netlify["Netlify\n(static hosting)"]
+```
+
+## Component Map
+
+| Directory | Responsibility |
+|-----------|---------------|
+| `src/pages/` | MDX + TSX pages — route-mapped to URL paths (`/components/`, `/design/`, `/patterns/`, `/content/`) |
+| `src/examples/` | Live interactive React examples embedded in MDX pages |
+| `src/components/` | Shared site-wide React components (`Layout`, `Provider`, `SEO`) |
+| `src/layouts/` | Page layout shells: `Root`, `Sidebar`, `Titled`, `Home`, `MaxWidth` |
+| `src/icons/` | Site-specific SVG icons |
+| `plugins/` | Custom Gatsby plugins (see below) |
+| `content/` | Static data — `nav/` YAML files for sidebar navigation, `figma/` assets, `news/` |
+| `react-components/` | Git submodule — source of component prop types and versions (read-only) |
+| `utils/` | Build/deploy scripts (`upgrade.js`, `deploy.mjs`) |
+
+### Custom Plugins
+
+| Plugin | Purpose |
+|--------|---------|
+| `gatsby-source-garden-content` | Sources nav YAML and news content into GraphQL |
+| `gatsby-source-garden-docgen` | Parses `react-components` submodule to generate component prop API data via GraphQL |
+| `gatsby-remark-figma-assets` | Downloads and inlines Figma images during build |
+| `gatsby-transformer-garden-svg` | Transforms SVG files for use in the site |
+| `gatsby-algolia-docsearch` | Indexes pages for Algolia DocSearch |
+
+## Page Content Flow
+
+1. `gatsby-source-garden-docgen` parses TypeScript source in `react-components/` → GraphQL nodes (`gardenReactComponent`, `gardenReactPackage`)
+2. `gatsby-source-garden-content` reads `content/nav/*.yml` → GraphQL navigation nodes
+3. `gatsby-remark-figma-assets` fetches images from Figma API using `FIGMA_TOKEN` during MDX processing
+4. MDX pages in `src/pages/` define frontmatter (`title`, `description`, `package`, `components`, `subcomponents`)
+5. `gatsby-node.ts` sets up redirects and injects `pageContext` (slug, group, frontmatter) into each page
+6. `src/components/Layout.tsx` selects the appropriate layout shell (sidebar + TOC) based on `pageContext`
+7. Live examples from `src/examples/` are imported directly into MDX using standard ES imports; raw source is imported via `!!raw-loader!` for the code block display
+
+## Key Design Decisions
+
+### MDX as Documentation Format
+All component/design/pattern pages are MDX files. This allows prose, live React examples, and JSX components (like `<Usage>`) to coexist in one file without a separate CMS.
+
+### react-components as Git Submodule
+The `react-components` repo is a read-only submodule. The `gatsby-source-garden-docgen` plugin parses its TypeScript source to auto-generate component API reference tables, ensuring docs stay in sync with the component library.
+
+### FIGMA_TOKEN Required at Build Time
+Figma images are fetched during `gatsby build` via `FIGMA_TOKEN`. Local dev also requires this token. See `.github/CONTRIBUTING.md`.
+
+### Path Aliases for src/components and src/layouts
+`tsconfig.json` defines `components/*` and `layouts/*` path aliases to avoid deep relative imports throughout the codebase.
+
+## External Dependencies
+
+| Service | Purpose | Config |
+|---------|---------|--------|
+| Figma API | Design asset images | `FIGMA_TOKEN` env var |
+| Netlify | Static hosting + deploy previews | `NETLIFY_TOKEN`, `NETLIFY_SITE_ID` env vars |
+| Algolia DocSearch | Site search | `gatsby-algolia-docsearch` plugin |
+| Google Analytics | Page analytics | `UA-970836-25` (gatsby-plugin-google-gtag) |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+# Claude Code Configuration
+
+Read and follow all instructions in `AGENTS.md` — the source of truth for coding conventions.
+Read and follow all instructions in `SECURITY.md` — mandatory security requirements.
+See `ARCHITECTURE.md` for system architecture and design decisions.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,78 @@
+# AI Agent Security Standard
+
+This document defines mandatory security requirements for all AI coding assistants operating in this repository.
+
+**Authority:** Derived from [Zendesk Minimum Baseline Security Standard](https://docs.google.com/document/d/17GZ9TpjKCt6WCdw3yxL44Ra_YscbOBVnVkUVGgx5Hz0/) and internal security policies.
+
+---
+
+## Core Security Mandate
+
+Security is a first-class requirement. If a request would produce insecure code:
+1. **Stop** and flag the concern
+2. **Explain** why it's problematic
+3. **Propose** a secure alternative
+
+---
+
+## Absolute Prohibitions
+
+AI agents must **NEVER**:
+
+- Hardcode secrets, API keys, tokens, or credentials in source code
+- Commit `.env` files or any file containing real secret values
+- Log or expose `FIGMA_TOKEN`, `NETLIFY_TOKEN`, `NETLIFY_SITE_ID`, or any other secret
+- Disable or bypass security controls
+- Transmit sensitive data over unencrypted channels
+- Log PII or customer data
+
+---
+
+## Required Security Patterns
+
+### Secrets — always use environment variables
+
+```ts
+// Correct
+const figmaToken = process.env.FIGMA_TOKEN;
+
+// NEVER
+const figmaToken = 'figd_abc123XYZ';
+```
+
+### Input Validation — validate external data before use
+
+The site's build-time plugins fetch data from the Figma API and the `react-components` submodule. Validate and sanitize any externally sourced data before injecting it into GraphQL nodes or page output.
+
+---
+
+## Site-Specific Requirements
+
+- **`FIGMA_TOKEN`** must only be accessed via `process.env.FIGMA_TOKEN` — never embed in source or config files
+- **`NETLIFY_TOKEN` / `NETLIFY_SITE_ID`** are deployment secrets — access only via CI environment variables
+- SVG files sourced from `@zendeskgarden/svg-icons` or Figma must not be modified to inject scripts
+- Dependencies are managed by Dependabot and Renovate — do not manually downgrade packages to bypass security patches
+- The `react-components` submodule is read-only; do not modify it
+
+---
+
+## When to Stop and Escalate
+
+Stop and involve a human if a task requires:
+
+- Exposing or logging any secret or token
+- Bypassing authentication or authorization
+- Disabling certificate validation or TLS
+- Using deprecated cryptographic algorithms
+- Modifying Netlify or CI/CD configuration in ways that bypass security controls
+
+---
+
+## References
+
+- [Minimum Baseline Security Standard](https://docs.google.com/document/d/17GZ9TpjKCt6WCdw3yxL44Ra_YscbOBVnVkUVGgx5Hz0/)
+- [Cryptography Standards](https://techmenu.zende.sk/standards/cryptography-standards/)
+
+---
+
+**Questions?** Reach out to the Security team or file a ticket via the Security Engagement process.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,8 +2,6 @@
 
 This document defines mandatory security requirements for all AI coding assistants operating in this repository.
 
-**Authority:** Derived from [Zendesk Minimum Baseline Security Standard](https://docs.google.com/document/d/17GZ9TpjKCt6WCdw3yxL44Ra_YscbOBVnVkUVGgx5Hz0/) and internal security policies.
-
 ---
 
 ## Core Security Mandate
@@ -65,14 +63,3 @@ Stop and involve a human if a task requires:
 - Disabling certificate validation or TLS
 - Using deprecated cryptographic algorithms
 - Modifying Netlify or CI/CD configuration in ways that bypass security controls
-
----
-
-## References
-
-- [Minimum Baseline Security Standard](https://docs.google.com/document/d/17GZ9TpjKCt6WCdw3yxL44Ra_YscbOBVnVkUVGgx5Hz0/)
-- [Cryptography Standards](https://techmenu.zende.sk/standards/cryptography-standards/)
-
----
-
-**Questions?** Reach out to the Security team or file a ticket via the Security Engagement process.


### PR DESCRIPTION
## Description

Adds AI-ready documentation files to help AI coding assistants understand this codebase.

## Detail

- **`AGENTS.md`** — vendor-neutral hub with project overview, commands, conventions, do/don't lists, and PR guidelines
- **`ARCHITECTURE.md`** — system diagram, directory map, data flow (MDX pages → Gatsby build → Netlify), and key design decisions (submodule for docgen, Figma at build time, path aliases)
- **`SECURITY.md`** — security constraints for AI agents, including secret handling for `FIGMA_TOKEN`/`NETLIFY_TOKEN` and absolute prohibitions
- **`CLAUDE.md`** — thin spoke referencing AGENTS.md + SECURITY.md
- **`.github/copilot-instructions.md`** — thin spoke referencing AGENTS.md + SECURITY.md
- **`.cursor/rules/00-core.mdc`** — thin spoke with MDC frontmatter
- **`.windsurfrules`** — thin spoke referencing AGENTS.md + SECURITY.md

## Checklist

- [ ] :ok_hand: website updates are Garden Designer approved (add the designer as a reviewer)
- [ ] :black_nib: copy updates are approved (add the content strategist as a reviewer)
- [ ] :link: considered opportunities for adding cross-reference URLs (grep for keywords)
- [ ] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [ ] :memo: tested in Chrome, Firefox, Safari, Edge

---
Requested by @zendesk-rickschmoo via [zendesk/ai-repo#352](https://github.com/zendesk/ai-repo/issues/352)